### PR TITLE
docs: clarify agentic skill selection and add architect skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ root.dataset.mode = "light"; // "light" | "dark"
 - Workflow + pipeline details: `docs/foundations/foundation-010-implementation-and-pipeline-workflow.md`
 - Branching + release governance: `docs/foundations/foundation-011-branching-and-release-governance.md`
 - AI playbook: `docs/agentic/team-ai-playbook.md`
-- Shareable skill: `docs/agentic/skills/design-ops-specialist/SKILL.md`
+- Agentic skills overview: `docs/agentic/skills/README.md`
+- Shareable skills:
+  - `docs/agentic/skills/design-ops-specialist/SKILL.md`
+  - `docs/agentic/skills/design-system-architect/SKILL.md`
 - Docs site content: `site/`
 - Vanilla starter guide: `site/examples/vanilla-starter.md`
 

--- a/docs/agentic/skills/README.md
+++ b/docs/agentic/skills/README.md
@@ -1,0 +1,51 @@
+# Agentic Skills
+
+This directory contains repo-specific skills for AI-assisted design-system work.
+
+## Available skills
+
+### design-ops-specialist
+
+Use for tactical, proposal-first work:
+
+- minimal component drafts
+- token naming proposals
+- CSS pattern structure suggestions
+- optional React wrapper API sketches
+- docs/playground integration plans
+
+Best when the question is close to implementation and should stay incremental and non-breaking.
+
+Path:
+- `docs/agentic/skills/design-ops-specialist/SKILL.md`
+
+### design-system-architect
+
+Use for strategic, system-level work:
+
+- foundation reviews
+- token governance decisions
+- component boundary decisions
+- Figma/code reconciliation
+- architecture-level handoff and system recommendations
+
+Best when the question is about whether something belongs in the system at all, how foundations should evolve, or how to restore consistency across Figma, tokens, code, and docs.
+
+Path:
+- `docs/agentic/skills/design-system-architect/SKILL.md`
+
+## Quick selection guide
+
+Use `design-ops-specialist` when the question sounds like:
+
+- "Propose a draft for this component"
+- "How should the token names look?"
+- "What files would change?"
+- "How would the CSS and docs be structured?"
+
+Use `design-system-architect` when the question sounds like:
+
+- "Should this be a standalone component or composition?"
+- "Do we need new semantic tokens?"
+- "Are the foundations still coherent?"
+- "How do we reconcile Figma and code drift?"

--- a/docs/agentic/skills/design-ops-specialist/SKILL.md
+++ b/docs/agentic/skills/design-ops-specialist/SKILL.md
@@ -1,46 +1,60 @@
 ---
 name: design-ops-specialist
-description: "Design Ops Specialist guidance for token-first component proposals in this repo and package consumers. Use when a request asks for token naming (variants/parts/states), CSS pattern structure under src/ui/patterns, optional React wrapper API, and docs/playground integration while keeping scope minimal and non-breaking."
+description: "Tactical proposal-first guidance for token-first component work in this repo and package consumers. Use when a request asks for a minimal component draft, token naming proposal, CSS pattern structure under src/ui/patterns, optional React wrapper API, docs/playground integration, or a concrete implementation plan that should stay incremental and non-breaking. Prefer design-system-architect instead when the request is about foundations, token governance, component-boundary decisions, Figma/code drift, or system-wide architecture."
 ---
 
 # Design Ops Specialist
 
 ## Intent
 
-Use this skill for proposal-first work before implementation.
+Use this skill for tactical, proposal-first work before or just ahead of implementation.
+
+This skill is narrower than `design-system-architect`.
+
+- Use `design-ops-specialist` for concrete component drafts and repo-shaped implementation proposals.
+- Use `design-system-architect` for system-wide reviews, governance, and architecture decisions.
 
 ## Workflow
 
 1. Confirm scope and constraints:
    - component name
-   - parts/variants/states
+   - parts / variants / states
    - platform or framework constraints
+   - whether the ask is proposal-only or implementation-adjacent
 2. Align with source rules:
    - `docs/foundations/`
    - `docs/agentic/assistant-behavior-rules.md`
    - `docs/agentic/team-ai-playbook.md`
-3. Produce a concise proposal (no code changes unless explicitly requested).
-4. Keep proposals minimal, incremental, and non-breaking by default.
+3. If the request implies a new system component, call out that boundary validation is required and defer the strategic decision to `design-system-architect` when needed.
+4. Produce a concise proposal by default, with no code changes unless explicitly requested.
+5. Keep proposals minimal, incremental, and non-breaking.
 
-## Output Format
+## Output format
 
 Provide these sections:
 
-1. Token naming proposal
+1. Boundary assumption
+   - whether this is assumed to be composition or a valid standalone candidate
+   - if unclear, say so briefly
+2. Token naming proposal
    - prefix, variants, parts, states
    - alignment to foundations naming rules
-2. CSS pattern structure
-   - target files under `src/ui/patterns`
+3. CSS pattern structure
+   - target files under `src/ui/patterns` or existing family integration
    - expected class names and token hookups
-3. Optional React wrapper API
-   - only when requested or needed
+4. Optional React wrapper API
+   - only when requested or clearly needed
    - props mapped to token variants/states
-4. Docs + playground integration
+5. Docs + playground integration
    - required docs pages/sections
    - playground additions or updates
+6. Implementation surface
+   - exact repo paths likely to change
 
 ## Guardrails
 
 - Prefer extending existing patterns over introducing new frameworks.
-- If requirements are underspecified, ask targeted clarifying questions.
-- Preserve compatibility with token-first and Figma-aligned architecture.
+- Keep recommendations compatible with token-first and Figma-aligned architecture.
+- Do not broaden into foundations governance unless explicitly asked.
+- If requirements are underspecified, ask targeted clarifying questions or state minimal assumptions.
+- If the task is really about whether something belongs in the system at all, hand off conceptually to `design-system-architect`.

--- a/docs/agentic/skills/design-system-architect/SKILL.md
+++ b/docs/agentic/skills/design-system-architect/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: design-system-architect
+description: "Strategic design-system architecture for this repo. Use when reviewing or evolving foundations, deciding token governance, evaluating component boundaries, reconciling Figma/code drift, auditing semantic coverage, or making architecture-level decisions that span beyond a single component proposal. Prefer this skill over design-ops-specialist when the request is system-wide, governance-heavy, or about whether something should enter the system at all."
+---
+
+# Design System Architect
+
+## Intent
+
+Use this skill for system-level decisions, reviews, and governance.
+
+This skill is broader than `design-ops-specialist`.
+
+- Use `design-ops-specialist` for tactical, proposal-first component drafts.
+- Use `design-system-architect` for architecture, boundaries, token governance, and Figma/code alignment decisions.
+
+## Required source alignment
+
+Before responding, align to these repo sources:
+
+- `docs/foundations/`
+- `docs/agentic/assistant-behavior-rules.md`
+- `docs/agentic/team-ai-playbook.md`
+
+At minimum, check these when relevant:
+
+- `docs/foundations/foundation-001-token-layering.md`
+- `docs/foundations/foundation-002-naming-and-grouping.md`
+- `docs/foundations/foundation-003-color-semantics-and-status.md`
+- `docs/foundations/foundation-009-component-boundaries-and-utility.md`
+- `docs/foundations/foundation-010-implementation-and-pipeline-workflow.md`
+- `docs/foundations/foundation-011-branching-and-release-governance.md`
+
+## Task types
+
+### 1. Foundation review
+
+Use when reviewing the health of the system.
+
+Check for:
+
+- layering integrity
+- semantic gaps
+- naming drift
+- duplicate concepts
+- hard-coded or leaky component decisions
+- weak state coverage
+- Figma/code mismatch
+
+### 2. Token governance
+
+Use when deciding whether to create, alias, rename, or reject token changes.
+
+Report:
+
+- correct layer
+- rationale
+- consumer scope
+- theme/mode impact
+- migration implications
+
+### 3. Boundary decision
+
+Use before proposing or implementing a new component.
+
+Decide:
+
+- composition inside an existing family, or
+- standalone system component
+
+Apply the Snowflake check from `foundation-009`.
+
+### 4. Figma/code reconciliation
+
+Use when system contracts drift between Figma and implementation.
+
+Review:
+
+- token exports in `figma/exports/`
+- Code Connect mappings in `figma/connections/`
+- implementation in `src/ui/` and `src/react/`
+- docs/playground representation in `site/components/`
+
+### 5. System handoff
+
+Use when another designer or engineer needs a structured architectural recommendation.
+
+## Output format
+
+Provide these sections when relevant:
+
+1. Task type
+2. Current system reading
+3. Decision
+4. Rationale
+5. Repo surfaces affected
+6. Risks / mismatches
+7. Recommended next step
+
+## Guardrails
+
+- Do not invent raw values inside components.
+- Keep the 4-layer architecture intact.
+- Treat token work and component boundary decisions as separate questions.
+- Prefer small, reviewable changes and feature-branch delivery.
+- Say explicitly when something should remain local instead of entering the system.

--- a/docs/agentic/team-ai-playbook.md
+++ b/docs/agentic/team-ai-playbook.md
@@ -56,6 +56,16 @@ Run this decision gate before implementing a "new component":
    - `npm run ci:check`
 8. Iterate naming/states/a11y until stable.
 
+## Skill selection
+
+Use the repo skills intentionally:
+
+- `design-ops-specialist` for tactical, proposal-first component work
+- `design-system-architect` for strategic, system-level reviews and decisions
+
+See also:
+- `docs/agentic/skills/README.md`
+
 ## Proposal Mode: Design Ops Specialist
 
 Use this mode when the request is explicitly a proposal (no implementation yet).


### PR DESCRIPTION
## Summary

This improvement PR clarifies how the repo's agentic skills should be selected and adds a dedicated `design-system-architect` skill for system-level design-system decisions.

## What changed

- add `docs/agentic/skills/README.md` as an overview and quick selection guide
- add `docs/agentic/skills/design-system-architect/SKILL.md`
- refine `design-ops-specialist` so it stays tactical and proposal-first
- add a skill-selection section to `docs/agentic/team-ai-playbook.md`
- link the new skill docs from `README.md`
- remove a stray duplicated tail fragment from `team-ai-playbook.md`

## Why

The current docs benefit from a clearer split between:

- tactical component proposal work
- strategic design-system architecture and governance work

This makes AI-assisted contributions more predictable and reduces the chance that implementation-oriented guidance gets mixed with system-boundary or token-governance decisions.

## Scope / risk

- documentation only
- no runtime or package behavior changes
- no release process changes

## Notes

This PR is intended as an improvement proposal for review rather than a direct policy bypass. The aim is to make the repo's agentic guidance easier to apply consistently.
