### PR TITLE
feat(radio): add Radio component with tokens, docs, playground, and C…+

### DIFF
--- a/docs/agentic/assistant-behavior-rules.md
+++ b/docs/agentic/assistant-behavior-rules.md
@@ -20,3 +20,18 @@ type: agent-guide
    - This decision is independent from token work: new tokens alone are not sufficient reason for a standalone component.
    - Apply the Snowflake check: local one-off solutions stay local; shared utility can enter the system.
    - Source of truth: `docs/foundations/foundation-009-component-boundaries-and-utility.md`.
+8. When creating a new component, always complete all integration surfaces:
+   - CSS pattern in `src/ui/patterns/<component>.css`
+   - Import in `src/ui/index.css`
+   - React wrapper in `src/react/<component>.js`
+   - Export in `src/react/index.js`
+   - Nunjucks macro in `site/_includes/macros/ui.njk` (source of truth; `dist/macros/ui.njk` is copied during build)
+   - Playground renderer in `site/assets/playground/renderers.js` — register the render function and add it to the `renderers` map
+   - Playground page in `site/components/<component>-playground.md` with `renderer: <component>` matching the key in the renderers map
+   - Docs page in `site/components/<component>.md`
+   - Code Connect file in `figma/connections/web-<component>.figma.ts`
+   Missing any of these (especially the playground renderer) will cause broken pages.
+9. Every new component must have its own Component-layer tokens. Never reuse tokens from another component (e.g. do not use `--input-checkbox-*` for a radio).
+   - Check `dist/tokens/css/components-ui.tokens.css` for existing tokens.
+   - If the component has no tokens in Figma yet, propose new ones following the naming pattern `--<component>-<part>-<property>-<state>` and add them to `components-ui.tokens.css`, referencing only Semantic or Core tokens.
+   - This keeps components independently themeable and avoids hidden coupling.

--- a/figma/connections/web-radio.figma.ts
+++ b/figma/connections/web-radio.figma.ts
@@ -1,0 +1,84 @@
+import figma, { html } from "@figma/code-connect/html";
+
+figma.connect(
+  "https://www.figma.com/design/uqMsy8fV1fPbQdAzgwlmBA/UI-Foundations?node-id=2329-241&m=dev",
+  {
+    props: {
+      className: figma.className([
+        "radio",
+        figma.enum("State", {
+          Default: undefined,
+          Hover: "is-hover",
+        }),
+        figma.enum("Disabled", {
+          False: undefined,
+          True: "is-disabled",
+          false: undefined,
+          true: "is-disabled",
+        }),
+      ]),
+      checked: figma.enum("Checked", {
+        Unchecked: "false",
+        Checked: "true",
+      }),
+      disabled: figma.boolean("Disabled"),
+      ariaLabel: figma.enum("Checked", {
+        Unchecked: "Radio",
+        Checked: "Radio",
+      }),
+    },
+    example: ({ className, checked, disabled, ariaLabel }) => html`<input
+      type="radio"
+      class="${className}"
+      checked="${checked}"
+      disabled="${disabled}"
+      aria-label="${ariaLabel}"
+    />`,
+  },
+);
+
+figma.connect(
+  "https://www.figma.com/design/uqMsy8fV1fPbQdAzgwlmBA/UI-Foundations?node-id=2329-250&m=dev",
+  {
+    props: {
+      wrapperClassName: figma.className([
+        "radio-field",
+        figma.enum("Is Disabled", {
+          False: undefined,
+          True: "is-disabled",
+          false: undefined,
+          true: "is-disabled",
+        }),
+      ]),
+      className: figma.className([
+        "radio",
+        figma.enum("Is Disabled", {
+          False: undefined,
+          True: "is-disabled",
+          false: undefined,
+          true: "is-disabled",
+        }),
+        "is-checked",
+      ]),
+      checked: figma.enum("Is Disabled", {
+        False: "true",
+        True: "true",
+        false: "true",
+        true: "true",
+      }),
+      disabled: figma.boolean("Is Disabled"),
+      text: figma.string("Text"),
+    },
+    example: ({ wrapperClassName, className, checked, disabled, text }) => html`<label
+      class="${wrapperClassName}"
+    >
+      <input
+        type="radio"
+        class="${className}"
+        checked="${checked}"
+        disabled="${disabled}"
+      />
+      <span class="radio-field__text">${text}</span>
+    </label>`,
+  },
+);

--- a/figma/exports/Components (UI).tokens.json
+++ b/figma/exports/Components (UI).tokens.json
@@ -2379,6 +2379,284 @@
           "com.figma.isOverride": true
         }
       }
+    },
+    "Radio": {
+      "Text Color Default": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Text/Default"
+        },
+        "$extensions": {
+          "com.figma.scopes": ["ALL_SCOPES"],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-radio-text-color-default)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableName": "Color/Text/Default",
+            "targetVariableSetName": "Appearance (Modes)"
+          }
+        }
+      },
+      "Text Color Hover": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Text/Strong"
+        },
+        "$extensions": {
+          "com.figma.scopes": ["ALL_SCOPES"],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-radio-text-color-hover)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableName": "Color/Text/Strong",
+            "targetVariableSetName": "Appearance (Modes)"
+          }
+        }
+      },
+      "Text Color Active": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Text/Inverse"
+        },
+        "$extensions": {
+          "com.figma.scopes": ["ALL_SCOPES"],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-radio-text-color-active)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableName": "Color/Text/Inverse",
+            "targetVariableSetName": "Appearance (Modes)"
+          }
+        }
+      },
+      "Text Color Disabled": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Text/Disabled"
+        },
+        "$extensions": {
+          "com.figma.scopes": ["ALL_SCOPES"],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-radio-text-color-disabled)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableName": "Color/Text/Disabled",
+            "targetVariableSetName": "Appearance (Modes)"
+          }
+        }
+      },
+      "Border": {
+        "Color Default": {
+          "$type": "color",
+          "$value": {
+            "$ref": "Color/Border/Subtle"
+          },
+          "$extensions": {
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.codeSyntax": {
+              "WEB": "var(--input-radio-border-color-default)"
+            },
+            "com.figma.aliasData": {
+              "targetVariableName": "Color/Border/Subtle",
+              "targetVariableSetName": "Appearance (Modes)"
+            }
+          }
+        },
+        "Color Hover": {
+          "$type": "color",
+          "$value": {
+            "$ref": "Color/Border/Strong"
+          },
+          "$extensions": {
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.codeSyntax": {
+              "WEB": "var(--input-radio-border-color-hover)"
+            },
+            "com.figma.aliasData": {
+              "targetVariableName": "Color/Border/Strong",
+              "targetVariableSetName": "Appearance (Modes)"
+            }
+          }
+        },
+        "Color Active": {
+          "$type": "color",
+          "$value": {
+            "$ref": "Color/Border/Brand"
+          },
+          "$extensions": {
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.codeSyntax": {
+              "WEB": "var(--input-radio-border-color-active)"
+            },
+            "com.figma.aliasData": {
+              "targetVariableName": "Color/Border/Brand",
+              "targetVariableSetName": "Appearance (Modes)"
+            }
+          }
+        },
+        "Color Focus": {
+          "$type": "color",
+          "$value": {
+            "$ref": "Color/Border/Brand"
+          },
+          "$extensions": {
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.codeSyntax": {
+              "WEB": "var(--input-radio-border-color-focus)"
+            },
+            "com.figma.aliasData": {
+              "targetVariableName": "Color/Border/Brand",
+              "targetVariableSetName": "Appearance (Modes)"
+            }
+          }
+        },
+        "Color Disabled": {
+          "$type": "color",
+          "$value": {
+            "$ref": "Color/Border/Disabled"
+          },
+          "$extensions": {
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.codeSyntax": {
+              "WEB": "var(--input-radio-border-color-disabled)"
+            },
+            "com.figma.aliasData": {
+              "targetVariableName": "Color/Border/Disabled",
+              "targetVariableSetName": "Appearance (Modes)"
+            }
+          }
+        }
+      },
+      "Container": {
+        "Background Default": {
+          "$type": "color",
+          "$value": {
+            "$ref": "Color/Fill/Surface"
+          },
+          "$extensions": {
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.codeSyntax": {
+              "WEB": "var(--input-radio-container-background-default)"
+            },
+            "com.figma.aliasData": {
+              "targetVariableName": "Color/Fill/Surface",
+              "targetVariableSetName": "Appearance (Modes)"
+            }
+          }
+        },
+        "Background Hover": {
+          "$type": "color",
+          "$value": {
+            "$ref": "Color/Fill/Surface"
+          },
+          "$extensions": {
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.codeSyntax": {
+              "WEB": "var(--input-radio-container-background-hover)"
+            },
+            "com.figma.aliasData": {
+              "targetVariableName": "Color/Fill/Surface",
+              "targetVariableSetName": "Appearance (Modes)"
+            }
+          }
+        },
+        "Background Focus": {
+          "$type": "color",
+          "$value": {
+            "$ref": "Color/Fill/Surface"
+          },
+          "$extensions": {
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.codeSyntax": {
+              "WEB": "var(--input-radio-container-background-focus)"
+            },
+            "com.figma.aliasData": {
+              "targetVariableName": "Color/Fill/Surface",
+              "targetVariableSetName": "Appearance (Modes)"
+            }
+          }
+        },
+        "Background Active": {
+          "$type": "color",
+          "$value": {
+            "$ref": "Color/Fill/Brand"
+          },
+          "$extensions": {
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.codeSyntax": {
+              "WEB": "var(--input-radio-container-background-active)"
+            },
+            "com.figma.aliasData": {
+              "targetVariableName": "Color/Fill/Brand",
+              "targetVariableSetName": "Appearance (Modes)"
+            }
+          }
+        },
+        "Background Disabled": {
+          "$type": "color",
+          "$value": {
+            "$ref": "Color/Fill/Disabled"
+          },
+          "$extensions": {
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.codeSyntax": {
+              "WEB": "var(--input-radio-container-background-disabled)"
+            },
+            "com.figma.aliasData": {
+              "targetVariableName": "Color/Fill/Disabled",
+              "targetVariableSetName": "Appearance (Modes)"
+            }
+          }
+        }
+      },
+      "Border Size Default": {
+        "$type": "number",
+        "$value": {
+          "$ref": "Size/Border/100"
+        },
+        "$extensions": {
+          "com.figma.scopes": ["STROKE_FLOAT"],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--radio-border-size-default)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableName": "Size/Border/100",
+            "targetVariableSetName": "Core (Primitives)"
+          }
+        }
+      },
+      "Border Size Hover": {
+        "$type": "number",
+        "$value": {
+          "$ref": "Size/Border/200"
+        },
+        "$extensions": {
+          "com.figma.scopes": ["ALL_SCOPES"],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--radio-border-size-hover)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableName": "Size/Border/200",
+            "targetVariableSetName": "Core (Primitives)"
+          }
+        }
+      },
+      "Border Size Disabled": {
+        "$type": "number",
+        "$value": {
+          "$ref": "Size/Border/000"
+        },
+        "$extensions": {
+          "com.figma.scopes": ["ALL_SCOPES"],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--radio-border-size-disabled)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableName": "Size/Border/000",
+            "targetVariableSetName": "Core (Primitives)"
+          }
+        }
+      }
     }
   },
   "Form": {

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -48,6 +48,25 @@
 </label>
 {%- endmacro %}
 
+{% macro radio(label='Option', checked=false, disabled=false, state='default', className='', wrapperClassName='', id='', name='', value='') -%}
+{%- set radioClasses = "radio" -%}
+{%- set fieldClasses = "radio-field" -%}
+{%- if checked -%}{%- set radioClasses = radioClasses + " is-checked" -%}{%- endif -%}
+{%- if state == "hover" -%}{%- set radioClasses = radioClasses + " is-hover" -%}{%- endif -%}
+{%- if state == "active" -%}{%- set radioClasses = radioClasses + " is-active" -%}{%- endif -%}
+{%- if state == "focus" -%}{%- set radioClasses = radioClasses + " is-focus-visible" -%}{%- endif -%}
+{%- if disabled or state == "disabled" -%}
+  {%- set radioClasses = radioClasses + " is-disabled" -%}
+  {%- set fieldClasses = fieldClasses + " is-disabled" -%}
+{%- endif -%}
+{%- if className -%}{%- set radioClasses = radioClasses + " " + className -%}{%- endif -%}
+{%- if wrapperClassName -%}{%- set fieldClasses = fieldClasses + " " + wrapperClassName -%}{%- endif -%}
+<label class="{{ fieldClasses }}">
+  <input class="{{ radioClasses }}" type="radio"{% if id %} id="{{ id }}"{% endif %}{% if name %} name="{{ name }}"{% endif %}{% if value %} value="{{ value }}"{% endif %}{% if checked %} checked{% endif %}{% if disabled or state == "disabled" %} disabled{% endif %} />
+  <span class="radio-field__text">{{ label }}</span>
+</label>
+{%- endmacro %}
+
 {% macro switch(label='Notifications', checked=false, disabled=false, state='default', className='', wrapperClassName='', id='', name='', value='on') -%}
 {%- set switchClasses = "switch" -%}
 {%- set fieldClasses = "switch-field" -%}

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -473,6 +473,49 @@
     return { element, code };
   };
 
+  const renderVanillaRadio = ({ props, meta }) => {
+    const previewState = String(meta.state || "default");
+    const labelText = String(props.label || "Option A");
+    const checked = asBoolean(props.checked);
+    const disabled =
+      previewState === "disabled" ||
+      asBoolean(props.disabled);
+
+    const wrapper = document.createElement("label");
+    const wrapperClasses = ["radio-field"];
+    if (disabled) wrapperClasses.push("is-disabled");
+    wrapper.className = wrapperClasses.join(" ");
+
+    const input = document.createElement("input");
+    const inputClasses = ["radio"];
+    if (checked) inputClasses.push("is-checked");
+    if (previewState === "hover") inputClasses.push("is-hover");
+    if (previewState === "active") inputClasses.push("is-active");
+    if (previewState === "focus") inputClasses.push("is-focus-visible");
+    if (disabled) inputClasses.push("is-disabled");
+
+    input.className = inputClasses.join(" ");
+    input.type = "radio";
+    input.checked = checked;
+    input.disabled = disabled;
+
+    const text = document.createElement("span");
+    text.className = "radio-field__text";
+    text.textContent = labelText;
+
+    wrapper.append(input, text);
+
+    const attrs = [
+      `class="${quoteAttr(input.className)}"`,
+      'type="radio"',
+    ];
+    if (checked) attrs.push("checked");
+    if (disabled) attrs.push("disabled");
+
+    const code = `<label class="${quoteAttr(wrapper.className)}"><input ${attrs.join(" ")} /><span class="radio-field__text">${quoteAttr(labelText)}</span></label>`;
+    return { element: wrapper, code };
+  };
+
   global.UIPlaygroundRenderers = {
     renderers: {
       button: renderVanillaButton,
@@ -481,6 +524,7 @@
       icon: renderVanillaIcon,
       input: renderVanillaInput,
       label: renderVanillaLabel,
+      radio: renderVanillaRadio,
       switch: renderVanillaSwitch,
     },
   };

--- a/site/components/radio-playground.md
+++ b/site/components/radio-playground.md
@@ -1,0 +1,54 @@
+---
+layout: layouts/docs.njk
+title: Radio Playground
+description: Interactive vanilla preview for radio states and form behavior.
+navTitle: Radio Playground
+order: 56
+permalink: /components/radio-playground/
+templateEngineOverride: njk
+isPlayground: true
+breadcrumb:
+  - label: Components
+    url: /components/
+  - label: Radio
+    url: /components/radio/
+  - label: Playground
+playground:
+  id: radio-playground
+  queryPrefix: radio
+  runtime: vanilla
+  renderer: radio
+  controls:
+    - kind: text
+      name: label
+      label: Label
+      query: true
+      default: Option A
+    - kind: boolean
+      name: checked
+      label: Checked
+      valueType: boolean
+      query: true
+      default: false
+    - kind: boolean
+      name: disabled
+      label: Disabled
+      valueType: boolean
+      query: true
+      default: false
+    - kind: select
+      name: state
+      label: State
+      source: meta
+      default: default
+      options:
+        - default
+        - hover
+        - active
+        - focus
+        - disabled
+---
+
+{% from "macros/playground.njk" import playground as uiPlayground with context %}
+
+{{ uiPlayground(playground) }}

--- a/site/components/radio.md
+++ b/site/components/radio.md
@@ -1,0 +1,81 @@
+---
+layout: layouts/docs.njk
+title: Radio
+description: Selection control for mutually exclusive choices within a group.
+navTitle: Radio
+order: 55
+permalink: /components/radio/
+playgroundUrl: /components/radio-playground/
+playgroundLabel: Open Radio Playground
+---
+
+{% import "macros/ui.njk" as ui %}
+
+## Preview
+
+<div class="docs-stack">
+  {{ ui.radio("Option A", false, false, "default", "", "", "", "demo-group", "a") }}
+  {{ ui.radio("Option B", true, false, "default", "", "", "", "demo-group", "b") }}
+  {{ ui.radio("Option C", false, false, "default", "", "", "", "demo-group", "c") }}
+  {{ ui.radio("Disabled option", false, true, "default", "", "", "", "demo-disabled", "d") }}
+</div>
+
+## Usage
+
+<div class="code-tabs">
+{% call ui.buttonGroup(true, "horizontal", "start", "Code format", "code-tabs-bar") %}
+  {{ ui.toggleButton("HTML", "lang", "html", "outline") }}
+  {{ ui.toggleButton("Nunjucks", "lang", "njk", "outline") }}
+  {{ ui.toggleButton("React", "lang", "react", "outline") }}
+{% endcall %}
+<div class="code-tabs-panel" data-lang="html">
+
+```html
+<label class="radio-field">
+  <input class="radio" type="radio" name="group" value="a" />
+  <span class="radio-field__text">Option A</span>
+</label>
+
+<label class="radio-field">
+  <input class="radio" type="radio" name="group" value="b" checked />
+  <span class="radio-field__text">Option B</span>
+</label>
+
+<label class="radio-field is-disabled">
+  <input class="radio is-disabled" type="radio" name="group" value="c" disabled />
+  <span class="radio-field__text">Disabled option</span>
+</label>
+```
+
+</div>
+<div class="code-tabs-panel" data-lang="njk">
+
+{% raw %}
+```njk
+{% import "macros/ui.njk" as ui %}
+
+{{ ui.radio("Option A", false, false, "default", "", "", "", "group", "a") }}
+{{ ui.radio("Option B", true, false, "default", "", "", "", "group", "b") }}
+{{ ui.radio("Disabled option", false, true, "default", "", "", "", "group", "c") }}
+```
+{% endraw %}
+
+</div>
+<div class="code-tabs-panel" data-lang="react">
+
+{% raw %}
+```jsx
+import { Radio } from "ui-foundations/react";
+
+<Radio name="group" value="a" label="Option A" />
+<Radio name="group" value="b" defaultChecked label="Option B" />
+<Radio name="group" value="c" disabled label="Disabled option" />
+```
+{% endraw %}
+
+</div>
+</div>
+
+## Used tokens
+
+{% componentTokenTable "src/ui/patterns/radio.css" %}

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -3,4 +3,5 @@ export { Checkbox } from "./checkbox.js";
 export { Icon } from "./icon.js";
 export { Input } from "./input.js";
 export { LabelContent, FieldLabel } from "./label.js";
+export { Radio } from "./radio.js";
 export { Switch } from "./switch.js";

--- a/src/react/radio.js
+++ b/src/react/radio.js
@@ -1,0 +1,62 @@
+import React from "react";
+
+function hasLabelContent(value) {
+  if (value === null || value === undefined || value === false) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) return value.some(hasLabelContent);
+  return true;
+}
+
+function warnDev(message) {
+  if (
+    typeof process !== "undefined" &&
+    process.env &&
+    process.env.NODE_ENV === "production"
+  ) {
+    return;
+  }
+
+  console.warn(message);
+}
+
+export function Radio({
+  className = "",
+  wrapperClassName = "",
+  label,
+  children,
+  ...props
+}) {
+  const classes = ["radio"];
+  if (className) classes.push(className);
+
+  const content = children ?? label;
+  const hasLabel = hasLabelContent(content);
+  const disabled = Boolean(props.disabled);
+
+  const input = React.createElement("input", {
+    type: "radio",
+    className: classes.join(" "),
+    ...props,
+  });
+
+  if (!hasLabel && !props["aria-label"] && !props["aria-labelledby"]) {
+    warnDev(
+      "[ui-foundations] Radio should include visible label content or `aria-label`/`aria-labelledby`.",
+    );
+  }
+
+  if (!hasLabel) return input;
+
+  const wrapperClasses = ["radio-field"];
+  if (disabled) wrapperClasses.push("is-disabled");
+  if (wrapperClassName) wrapperClasses.push(wrapperClassName);
+
+  return React.createElement(
+    "label",
+    {
+      className: wrapperClasses.join(" "),
+    },
+    input,
+    React.createElement("span", { className: "radio-field__text" }, content),
+  );
+}

--- a/src/ui/index.css
+++ b/src/ui/index.css
@@ -3,4 +3,5 @@
 @import url("./patterns/input.css") layer(components);
 @import url("./patterns/icon.css") layer(components);
 @import url("./patterns/checkbox.css") layer(components);
+@import url("./patterns/radio.css") layer(components);
 @import url("./patterns/switch.css") layer(components);

--- a/src/ui/patterns/radio.css
+++ b/src/ui/patterns/radio.css
@@ -1,0 +1,109 @@
+@layer components {
+  .radio-field {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--typography-label-gap);
+    font-family: var(--typography-label-font-family);
+    font-weight: var(--typography-label-font-weight);
+    font-size: var(--typography-label-font-size);
+    line-height: var(--typography-label-line-height);
+    color: var(--input-radio-text-color-default);
+    cursor: pointer;
+  }
+
+  .radio-field.is-disabled {
+    color: var(--input-radio-text-color-disabled);
+    cursor: not-allowed;
+  }
+
+  .radio {
+    inline-size: var(--size-spacing-600);
+    block-size: var(--size-spacing-600);
+    margin: 0;
+    appearance: none;
+    display: inline-grid;
+    place-content: center;
+    border-style: solid;
+    border-width: var(--radio-border-size-default);
+    border-color: var(--input-radio-border-color-default);
+    border-radius: var(--size-radius-full);
+    background: var(--input-radio-container-background-default);
+    cursor: pointer;
+  }
+
+  .radio::after {
+    content: "";
+    display: block;
+    inline-size: 0;
+    block-size: 0;
+    border-radius: var(--size-radius-full);
+    background: currentColor;
+    transition: all 120ms ease;
+  }
+
+  .radio:checked,
+  .radio.is-checked {
+    border-color: var(--input-radio-border-color-active);
+    background: var(--input-radio-container-background-default);
+    color: var(--input-radio-text-color-active);
+  }
+
+  .radio:checked::after,
+  .radio.is-checked::after {
+    inline-size: 0.5rem;
+    block-size: 0.5rem;
+    background: var(--input-radio-border-color-active);
+  }
+
+  .radio:hover,
+  .radio.is-hover {
+    background:
+      linear-gradient(0deg, var(--color-overlay-hover), var(--color-overlay-hover)),
+      var(--input-radio-container-background-hover);
+    color: var(--input-radio-text-color-hover);
+    border-color: var(--input-radio-border-color-hover);
+    border-width: var(--radio-border-size-hover);
+  }
+
+  .radio:checked:hover,
+  .radio.is-checked.is-hover {
+    background:
+      linear-gradient(0deg, var(--color-overlay-hover), var(--color-overlay-hover)),
+      var(--input-radio-container-background-default);
+    border-color: var(--input-radio-border-color-hover);
+    border-width: var(--radio-border-size-hover);
+  }
+
+  .radio:active,
+  .radio.is-active {
+    background:
+      linear-gradient(0deg, var(--color-overlay-active), var(--color-overlay-active)),
+      var(--input-radio-container-background-default);
+    border-color: var(--input-radio-border-color-active);
+    border-width: var(--size-border-200);
+  }
+
+  .radio:checked:active,
+  .radio.is-checked.is-active {
+    background:
+      linear-gradient(0deg, var(--color-overlay-active), var(--color-overlay-active)),
+      var(--input-radio-container-background-default);
+    border-color: var(--input-radio-border-color-active);
+  }
+
+  .radio:focus-visible,
+  .radio.is-focus-visible {
+    border-color: var(--input-radio-border-color-focus);
+    outline: none;
+    box-shadow: 0 0 0 var(--shadow-focus, 0) var(--color-focus, transparent);
+  }
+
+  .radio:disabled,
+  .radio.is-disabled {
+    border-width: var(--radio-border-size-disabled);
+    border-color: var(--input-radio-border-color-disabled);
+    background: var(--input-radio-container-background-disabled);
+    color: var(--input-radio-text-color-disabled);
+    cursor: not-allowed;
+  }
+}


### PR DESCRIPTION
- CSS pattern with dedicated input-radio-* component tokens
- React wrapper with label composition and a11y warnings
- Nunjucks macro and playground renderer
- Docs page with HTML/Nunjucks/React examples
- Figma Code Connect mapping (nodes 2329:241, 2329:250)
- Radio tokens added to Figma export JSON
- Agent behavior rules updated (rules 8 + 9)