### PR TITLE
feat: migrate dist token JSON to DTCG-compliant format

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,83 @@
+# UI Foundations — DESIGN.md
+
+## Source of Truth
+
+This file is an agent-facing design contract.
+It does not replace token files, Figma variables, ADRs, or component documentation.
+
+Canonical sources:
+
+- `AGENTS.md`
+- `docs/ui-foundations-rules.md`
+- `docs/foundations/`
+- `figma/exports/*.tokens.json`
+- `dist/tokens.css`
+- `dist/tokens.json`
+
+## Design Philosophy
+
+UI Foundations is a token-first, Figma-aligned design system built for reliable
+design-to-code parity. The system prioritises semantic intent over visual
+guesswork.
+
+## Token Architecture
+
+The system follows a layered model:
+
+1. Core primitives
+2. Semantic tokens
+3. Component tokens
+4. Brand / mode / theme application
+
+Agents must never invent token names.
+Use existing CSS custom properties from `codeSyntax.WEB` or exported token files.
+
+## Theming Model
+
+Themes are orthogonal:
+
+- `data-brand`
+- `data-mode`
+
+Brand and appearance must not be hardcoded into components.
+
+## Color Rules
+
+Use semantic tokens for UI decisions.
+Do not use raw hex values in components unless explicitly documented.
+
+## Typography Rules
+
+Use existing typography tokens.
+Do not infer font stacks, line heights, or weights from screenshots.
+
+## Spacing Rules
+
+Prefer semantic spacing intent where available.
+Avoid arbitrary pixel values.
+
+## Component Rules
+
+Components must:
+
+- use existing tokens
+- support theming
+- respect accessibility
+- avoid hardcoded brand-specific styling
+- match Figma/code naming where possible
+
+## Accessibility
+
+Generated UI must meet WCAG expectations.
+Colour choices must preserve contrast.
+Interactive states must be explicit.
+
+## Agent Rules
+
+Before creating UI:
+
+1. Read this file.
+2. Read `AGENTS.md`.
+3. Inspect token exports.
+4. Reuse existing tokens/components.
+5. Validate with available scripts.

--- a/docs/token-pipeline.md
+++ b/docs/token-pipeline.md
@@ -1,0 +1,90 @@
+# Token Pipeline
+
+## Overview
+
+Figma is the single source of truth. Tokens flow through a generation pipeline
+that transforms Figma Variable exports into DTCG-compliant dist files consumed
+by CSS, TypeScript, and JSON tooling.
+
+```
+figma/exports/*.tokens.json
+        │
+        ▼
+  npm run tokens:generate
+  (scripts/extract-tokens.js)
+        │
+        ├─► dist/tokens/json/*.json   (DTCG 2025.10 format)
+        ├─► dist/tokens/css/*.css     (CSS custom properties)
+        ├─► dist/tokens/ts/*.ts       (TypeScript constants)
+        └─► dist/tokens/tokens.yaml   (flat index)
+```
+
+## Source Format (Figma Exports)
+
+Files in `figma/exports/` are direct Figma Variables REST API exports.
+
+- `$type` uses Figma types: `color`, `number`, `string`
+- `$value` aliases use Figma object syntax: `{"$ref": "Path/To/Token"}`
+- Color values are Figma objects: `{colorSpace, components, alpha, hex}`
+- `$extensions` contains `com.figma.*` metadata (variable IDs, scopes, code syntax, mode values)
+- Multi-mode tokens store per-mode values in `$extensions.com.figma.modeValues`
+
+These files are never edited manually. They are replaced on each Figma export.
+
+## Source Files
+
+| File | Layer | Content |
+|---|---|---|
+| `Core (Primitives).tokens.json` | Core | Raw values: spacing, radii, borders, typography, colors |
+| `Appearance (Modes).tokens.json` | Modes | Light/dark color assignments (references Core + Themes) |
+| `Semantics (Roles).tokens.json` | Semantic | Intent-based aliases: typography roles, corner radii |
+| `Themes (Brands).tokens.json` | Themes | Brand-specific overrides (references Core) |
+| `Components (UI).tokens.json` | Component | Component-specific tokens (references Semantic + Core) |
+
+## Pipeline Transforms
+
+The generation script applies these transforms in order:
+
+1. **Flatten & scope** — Tokens are extracted with path segments, CSS variable
+   names (from `com.figma.codeSyntax.WEB`), and alias metadata.
+2. **Mode expansion** — Files with `com.figma.modeValues` are split into
+   separate token sets per mode/brand (e.g., light, dark, brand-a, brand-b).
+3. **W3C type mapping** — Figma types are converted to DTCG types:
+   - `number` → `dimension` (with `{value, unit}`) for spatial values
+   - `string` → `fontFamily` for font family paths
+   - `string` → `fontWeight` with numeric mapping for weight paths
+   - `number` stays `number` for unitless values (z-index, columns)
+4. **DTCG alias conversion** — `{"$ref": "Path/To/Token"}` → `"{Path.To.Token}"`
+5. **Color normalization** — Figma color objects → hex strings (`#rrggbb` or `#rrggbbaa`)
+6. **Extension cleanup** — All `com.figma.*` keys are stripped from `$extensions`
+7. **Schema injection** — `$schema` pointing to DTCG 2025.10 is added to each file
+
+## Dist Format (DTCG 2025.10)
+
+Files in `dist/tokens/json/` follow the DTCG Design Tokens Format Module:
+
+- `$schema` declares `https://www.designtokens.org/schemas/2025.10/format.json`
+- `$type` uses DTCG types: `color`, `dimension`, `fontFamily`, `fontWeight`, `number`
+- `$value` aliases use DTCG syntax: `"{Group.Path.Token}"`
+- Color values are hex strings: `"#333333"`, `"#0000004d"`
+- No Figma-specific metadata
+
+## Dist Files
+
+| File | Scope |
+|---|---|
+| `core-primitives.tokens.json` | All primitives |
+| `semantics-roles.tokens.json` | Semantic aliases |
+| `appearance-modes.tokens.mode-light.json` | Light mode colors |
+| `appearance-modes.tokens.mode-dark.json` | Dark mode colors |
+| `components-ui.tokens.json` | Component tokens |
+| `themes-brands.tokens.brand-a.json` | Brand A overrides |
+| `themes-brands.tokens.brand-b.json` | Brand B overrides |
+
+## Validation
+
+| Command | What it checks |
+|---|---|
+| `npm run tokens:validate` | Token file structure, alias resolution, CSS variable consistency |
+| `npm run dtcg:validate` | DTCG compliance: alias syntax, color format, type vocabulary, schema |
+| `npm run ci:check` | Full pipeline including both validators |

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "rules:validate": "node scripts/validate-rule-pipeline.mjs",
     "tokens:generate": "node scripts/extract-tokens.js",
     "tokens:validate": "node scripts/validate-tokens.mjs",
+    "dtcg:validate": "node scripts/validate-dtcg.mjs",
     "tokens:build": "npm run tokens:generate",
     "build:css": "node scripts/build-css.mjs",
     "build:all": "npm run icons:generate-list && npm run tokens:generate && npm run build:css",
@@ -65,7 +66,7 @@
     "release:publish": "npm publish",
     "docs:build": "eleventy",
     "docs:site": "npm run build:all && npm run docs:build",
-    "ci:check": "npm run lint && npm run test:unit && npm run build:all && npm run smoke:check && npm run tokens:validate && npm run assets:check && npm run rules:validate && npm run docs:build",
+    "ci:check": "npm run lint && npm run test:unit && npm run build:all && npm run smoke:check && npm run tokens:validate && npm run dtcg:validate && npm run assets:check && npm run rules:validate && npm run docs:build",
     "docs:dev": "npm run build:all && eleventy --serve"
   },
   "devDependencies": {

--- a/scripts/extract-tokens.js
+++ b/scripts/extract-tokens.js
@@ -474,6 +474,110 @@ function stripFigmaExtensions(node) {
   return out;
 }
 
+/**
+ * Convert Figma-style alias references to DTCG alias syntax.
+ * Figma: { "$ref": "Path/To/Token" }
+ * DTCG:  "{Path.To.Token}"
+ */
+function convertAliasesToDTCG(node) {
+  if (!node || typeof node !== "object") return node;
+  if (Array.isArray(node)) return node.map(convertAliasesToDTCG);
+
+  // If this is a token node, convert its $value (and leave $type/$extensions alone)
+  if (isTokenNode(node)) {
+    const out = {};
+    for (const [key, value] of Object.entries(node)) {
+      if (key === "$value") {
+        out[key] = convertValueAliases(value);
+      } else if (key === "$extensions") {
+        out[key] = convertAliasesToDTCG(value);
+      } else {
+        out[key] = value;
+      }
+    }
+    return out;
+  }
+
+  // Recurse into groups
+  const out = {};
+  for (const [key, value] of Object.entries(node)) {
+    out[key] = convertAliasesToDTCG(value);
+  }
+  return out;
+}
+
+/**
+ * Convert a $value that may be a Figma alias object to a DTCG alias string.
+ * { "$ref": "Color/Neutral/800" } → "{Color.Neutral.800}"
+ */
+function convertValueAliases(value) {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    if (typeof value.$ref === "string") {
+      const dtcgPath = value.$ref.replace(/\//g, ".");
+      return `{${dtcgPath}}`;
+    }
+  }
+  return value;
+}
+
+/**
+ * Convert Figma color value objects to DTCG hex strings.
+ * Figma: { colorSpace: "srgb", components: [r, g, b], alpha: 1, hex: "#333333" }
+ * DTCG:  "#333333" or "#333333cc" (with alpha)
+ */
+function convertColorValuesToDTCG(node) {
+  if (!node || typeof node !== "object") return node;
+  if (Array.isArray(node)) return node.map(convertColorValuesToDTCG);
+
+  if (isTokenNode(node)) {
+    const type = String(node.$type || "").toLowerCase();
+    if (type === "color" && isFigmaColorObject(node.$value)) {
+      const out = { ...node };
+      out.$value = figmaColorToHex(node.$value);
+      return convertColorValuesToDTCG(out);
+    }
+    // Recurse into $extensions in case there are nested structures
+    const out = {};
+    for (const [key, value] of Object.entries(node)) {
+      out[key] = key === "$extensions" ? convertColorValuesToDTCG(value) : value;
+    }
+    return out;
+  }
+
+  const out = {};
+  for (const [key, value] of Object.entries(node)) {
+    out[key] = convertColorValuesToDTCG(value);
+  }
+  return out;
+}
+
+function isFigmaColorObject(value) {
+  return (
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof value.colorSpace === "string" &&
+    Array.isArray(value.components)
+  );
+}
+
+function figmaColorToHex(colorObj) {
+  const { components, alpha } = colorObj;
+  const toHex = (n) => {
+    const clamped = Math.round(Math.min(1, Math.max(0, n)) * 255);
+    return clamped.toString(16).padStart(2, "0");
+  };
+  const r = toHex(components[0] || 0);
+  const g = toHex(components[1] || 0);
+  const b = toHex(components[2] || 0);
+
+  if (typeof alpha === "number" && alpha < 1) {
+    const a = toHex(alpha);
+    return `#${r}${g}${b}${a}`;
+  }
+  return `#${r}${g}${b}`;
+}
+
 function withSchema(node) {
   if (!node || typeof node !== "object" || Array.isArray(node)) return node;
   return {
@@ -650,7 +754,9 @@ async function extractTokens() {
       const perTokens = buildTokensFromList(tokenList, report, globalLookup);
       const transformReport = { unmappedFontWeights: [] };
       const w3cTokens = transformNodeToW3C(sourceData, [], transformReport);
-      const cleanTokens = withSchema(stripFigmaExtensions(w3cTokens));
+      const dtcgAliases = convertAliasesToDTCG(w3cTokens);
+      const dtcgColors = convertColorValuesToDTCG(dtcgAliases);
+      const cleanTokens = withSchema(stripFigmaExtensions(dtcgColors));
       const jsonOut = JSON.stringify(cleanTokens, null, 2);
       const cssOut = generateCSS(perTokens, scope);
       const tsOut = generateTypeScript(perTokens);

--- a/scripts/validate-dtcg.mjs
+++ b/scripts/validate-dtcg.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+/**
+ * Validate dist token JSON files against DTCG Design Tokens Format Module conventions.
+ *
+ * Checks:
+ * 1. Every leaf token has $type + $value
+ * 2. $type values are from the DTCG type set (or known extensions)
+ * 3. Alias values use {Group.Path} syntax (not $ref objects)
+ * 4. Color values are hex strings (not Figma objects)
+ * 5. $extensions keys use reverse-domain namespacing
+ */
+
+import { readFileSync, readdirSync } from "fs";
+import { join, relative, resolve } from "path";
+
+const DIST_JSON_DIR = resolve(import.meta.dirname, "..", "dist", "tokens", "json");
+
+const DTCG_TYPES = new Set([
+  "color",
+  "dimension",
+  "fontFamily",
+  "fontWeight",
+  "duration",
+  "cubicBezier",
+  "number",
+  "strokeStyle",
+  "border",
+  "transition",
+  "shadow",
+  "gradient",
+  "typography",
+  "string",
+]);
+
+const errors = [];
+const warnings = [];
+let filesChecked = 0;
+let tokensChecked = 0;
+
+function isTokenNode(node) {
+  return node && typeof node === "object" && "$type" in node && "$value" in node;
+}
+
+function validateToken(node, path, file) {
+  tokensChecked++;
+  const type = node.$type;
+  const value = node.$value;
+
+  // Check $type is a known DTCG type
+  if (!DTCG_TYPES.has(type)) {
+    warnings.push(`${file} → ${path}: unknown $type "${type}"`);
+  }
+
+  // Check alias syntax: must be "{Path.To.Token}" string, not {"$ref": "..."}
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    if ("$ref" in value) {
+      errors.push(`${file} → ${path}: alias uses {"$ref"} object instead of DTCG "{Path.To.Token}" string`);
+    }
+    // Check for Figma color objects
+    if ("colorSpace" in value && "components" in value) {
+      errors.push(`${file} → ${path}: color value is a Figma object instead of a hex string`);
+    }
+  }
+
+  // Check color values are hex strings when not aliases
+  if (type === "color" && typeof value === "string" && !value.startsWith("{")) {
+    if (!/^#[0-9a-fA-F]{6,8}$/.test(value)) {
+      warnings.push(`${file} → ${path}: color value "${value}" is not a standard hex format`);
+    }
+  }
+}
+
+function validateExtensions(node, path, file) {
+  if (!node.$extensions || typeof node.$extensions !== "object") return;
+  for (const key of Object.keys(node.$extensions)) {
+    // DTCG recommends reverse-domain namespacing for extensions
+    if (!key.includes(".")) {
+      warnings.push(`${file} → ${path}: $extensions key "${key}" lacks reverse-domain namespace`);
+    }
+  }
+}
+
+function walk(node, pathParts, file) {
+  if (!node || typeof node !== "object" || Array.isArray(node)) return;
+
+  if (isTokenNode(node)) {
+    const path = pathParts.join(".");
+    validateToken(node, path, file);
+    validateExtensions(node, path, file);
+    return;
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key.startsWith("$")) continue;
+    walk(value, [...pathParts, key], file);
+  }
+}
+
+// Run validation
+const jsonFiles = readdirSync(DIST_JSON_DIR).filter((f) => f.endsWith(".json") && f.includes(".tokens."));
+
+for (const file of jsonFiles) {
+  filesChecked++;
+  const filePath = join(DIST_JSON_DIR, file);
+  const data = JSON.parse(readFileSync(filePath, "utf-8"));
+
+  // Check $schema declaration
+  if (!data.$schema) {
+    warnings.push(`${file}: missing $schema declaration`);
+  }
+
+  walk(data, [], file);
+}
+
+// Report
+if (errors.length === 0 && warnings.length === 0) {
+  console.log(`✅ DTCG validation passed (${filesChecked} files, ${tokensChecked} tokens)`);
+  process.exit(0);
+}
+
+if (warnings.length > 0) {
+  console.warn(`⚠️  DTCG warnings (${warnings.length}):`);
+  for (const w of warnings) console.warn(`   ${w}`);
+}
+
+if (errors.length > 0) {
+  console.error(`❌ DTCG errors (${errors.length}):`);
+  for (const e of errors) console.error(`   ${e}`);
+  process.exit(1);
+}
+
+console.log(`✅ DTCG validation passed with warnings (${filesChecked} files, ${tokensChecked} tokens)`);


### PR DESCRIPTION
- Convert alias syntax from {"$ref": "Path/To/Token"} to "{Path.To.Token}"
- Convert Figma color objects to hex strings (#rrggbb / #rrggbbaa)
- Add DTCG validation script (scripts/validate-dtcg.mjs)
- Wire dtcg:validate into ci:check pipeline
- Add token pipeline documentation (docs/token-pipeline.md)
- Add DESIGN.md as agent-facing design system contract

Source files in figma/exports/ are unchanged. Transforms apply only to dist/tokens/json/ output during generation.