### PR TITLE
docs: add agent modes, context manifest, and simplify agentic docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,10 @@ _site
 .vscode
 .goose
 .goosehints
+
+# Obsidian local state
+.obsidian/workspace.json
+.obsidian/workspace-mobile.json
+.obsidian/cache/
+.obsidian/plugins/
+.obsidian/hotkeys.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,16 @@
 # UI Foundations — Agent Rules
 
-## Source of Truth
-This repository is token-first and Figma-aligned.
+## Context Loading Order
 
-Use sources in this order when working on UI Foundations decisions:
-1. `docs/ui-foundations-rules.md` → canonical operating rules for structure, naming, theming, governance, and review
-2. `docs/foundations/` → architecture decisions and foundation-specific rules
-3. `docs/agentic/assistant-behavior-rules.md` → agent behavior rules and component checklist
-4. `IMPLEMENTATION.md` → implementation details and repo-specific execution guidance
+Before acting, agents must load context in this order:
+
+1. `DESIGN.md` → executive design contract
+2. `AGENTS.md` → this file (behavior rules)
+3. `docs/working-context.md` → current priorities
+4. `docs/ui-foundations-rules.md` → canonical operating rules
+5. `docs/foundations/` → architecture decisions
+6. `docs/agentic/assistant-behavior-rules.md` → component checklist
+7. `IMPLEMENTATION.md` → repo-specific execution guidance
 
 Never contradict these sources.
 
@@ -99,3 +102,13 @@ Before completion:
 - Verify results after execution
 
 If not verified → not true
+
+## Agent Modes
+
+Depending on the task, load a mode from: `docs/agentic/modes/`
+
+If unclear:
+
+- default = Implementation
+- exploratory tasks = Pattern Discovery or Token Proposal
+- review tasks = Audit

--- a/docs/agentic/assistant-behavior-rules.md
+++ b/docs/agentic/assistant-behavior-rules.md
@@ -51,3 +51,14 @@ type: agent-guide
 13. Docs-only UI (code-tabs, mode toggles) must use docs-specific CSS, not component tokens.
     - The `.code-tabs-bar` and `.docs-header` button groups are styled in `site/assets/docs.css` with hardcoded docs colors.
     - They must not inherit brand theming from `data-brand`.
+
+## Modes
+
+The agent operates in different modes depending on the task:
+
+- **Implementation** → modify system
+- **Audit** → inspect only
+- **Pattern Discovery** → design patterns
+- **Token Proposal** → suggest tokens
+
+Mode-specific rules are defined in: `docs/agentic/modes/`

--- a/docs/agentic/modes/mode-audit.md
+++ b/docs/agentic/modes/mode-audit.md
@@ -1,0 +1,19 @@
+# Mode — Audit
+
+## Purpose
+
+Inspect the system for drift, inconsistency, or rule violations without making
+changes.
+
+## Rules
+
+- Read-only — do not modify files
+- Compare Figma exports against dist output
+- Flag naming mismatches, missing tokens, value drift
+- Report findings structured by severity
+
+## Output
+
+- List of issues with file paths and token names
+- Severity: critical / warning / info
+- Suggested remediation (do not apply)

--- a/docs/agentic/modes/mode-implementation.md
+++ b/docs/agentic/modes/mode-implementation.md
@@ -1,0 +1,21 @@
+# Mode — Implementation
+
+## Purpose
+
+Modify or create components, tokens, or styles within the system.
+
+## Inherits
+
+All rules from `docs/agentic/assistant-behavior-rules.md`.
+
+## Delta
+
+- Make the smallest possible change
+- Complete all required integration surfaces before finishing
+
+## Validation
+
+- No hardcoded values
+- Tokens exist and are valid
+- Component supports theming
+- `npm run ci:check` passes

--- a/docs/agentic/modes/mode-pattern-discovery.md
+++ b/docs/agentic/modes/mode-pattern-discovery.md
@@ -1,0 +1,19 @@
+# Mode — Pattern Discovery
+
+## Purpose
+
+Identify reusable patterns from existing components, Figma designs, or usage
+across the codebase.
+
+## Rules
+
+- Read-only — do not create new files
+- Analyse existing components for shared structure
+- Compare against current pattern rules in `.kiro/steering/pattern-rules/`
+- Identify candidates for new pattern rules or pattern consolidation
+
+## Output
+
+- List of discovered patterns with evidence
+- Mapping to existing principles and heuristics
+- Recommendation: new pattern rule, extend existing, or no action

--- a/docs/agentic/modes/mode-token-proposal.md
+++ b/docs/agentic/modes/mode-token-proposal.md
@@ -1,0 +1,22 @@
+# Mode — Token Proposal
+
+## Purpose
+
+Propose new or modified tokens based on Figma changes, component needs, or
+identified gaps.
+
+## Inherits
+
+Token rules from `AGENTS.md` (Token Workflow, Design System Rules).
+
+## Delta
+
+- Propose only — do not create tokens directly
+- Follow naming convention: `--component-variant-part-property-state`
+- If a needed semantic token does not exist, flag it for Figma creation
+
+## Output
+
+- Token name, type, layer, and proposed value or alias
+- Justification referencing Figma source or component need
+- Impact assessment: which components or patterns are affected

--- a/docs/context-manifest.json
+++ b/docs/context-manifest.json
@@ -1,0 +1,64 @@
+{
+  "version": 1,
+  "description": "Agent context loading manifest for UI Foundations",
+  "readFirst": [
+    "AGENTS.md",
+    "docs/working-context.md",
+    "docs/ui-foundations-rules.md"
+  ],
+  "contextFiles": {
+    "design": {
+      "path": "DESIGN.md",
+      "purpose": "Executive design contract",
+      "priority": 1
+    },
+    "agentRules": {
+      "path": "AGENTS.md",
+      "purpose": "Agent behavior rules and workflow",
+      "priority": 2
+    },
+    "workingContext": {
+      "path": "docs/working-context.md",
+      "purpose": "Current priorities and non-negotiables",
+      "priority": 3
+    },
+    "operatingRules": {
+      "path": "docs/ui-foundations-rules.md",
+      "purpose": "Canonical operating rules for structure, naming, theming, governance",
+      "priority": 4
+    },
+    "implementation": {
+      "path": "IMPLEMENTATION.md",
+      "purpose": "Repo-specific execution guidance",
+      "priority": 5
+    },
+    "tokenPipeline": {
+      "path": "docs/token-pipeline.md",
+      "purpose": "Token generation pipeline and format reference",
+      "priority": 6
+    }
+  },
+  "contextDirectories": {
+    "foundations": {
+      "path": "docs/foundations/",
+      "purpose": "Architecture decisions and foundation-specific rules"
+    },
+    "agentic": {
+      "path": "docs/agentic/",
+      "purpose": "Agent behavior rules and component checklist"
+    },
+    "validation": {
+      "path": "docs/validation/",
+      "purpose": "Rule pipeline manifest and validation metadata"
+    },
+    "steering": {
+      "path": ".kiro/steering/",
+      "purpose": "Design principles, heuristics, pattern and component rules"
+    }
+  },
+  "tokenSources": {
+    "figmaExports": "figma/exports/*.tokens.json",
+    "distJson": "dist/tokens/json/*.json",
+    "distCss": "dist/tokens/css/*.css"
+  }
+}

--- a/docs/working-context.md
+++ b/docs/working-context.md
@@ -1,0 +1,20 @@
+# Working Context — UI Foundations
+
+## Purpose
+
+Provide a compact operating context for humans and agents.
+
+## Current focus
+
+- Close Figma ↔ Code gap
+- Ensure token parity
+- Improve agent-readiness
+
+## Theming
+
+- `data-brand`
+- `data-mode` (light/dark)
+
+## Agent expectations
+
+Before acting, read the context loading order in `AGENTS.md`.


### PR DESCRIPTION
- Add agent modes: implementation, audit, pattern-discovery, token-proposal
- Add docs/context-manifest.json with readFirst ordering
- Add docs/working-context.md as living status doc
- Add Obsidian entries to .gitignore
- Add context loading order and agent modes to AGENTS.md
- Add modes section to assistant-behavior-rules.md
- Remove duplicated rules from mode files and working-context
- Merge overlapping source-of-truth sections in AGENTS.md