### PR TITLE
docs: cherry-pick valuable restructure, remove stubs, fix broken refe…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,29 +6,31 @@ Before acting, agents must load context in this order:
 
 1. `DESIGN.md` → executive design contract
 2. `AGENTS.md` → this file (behavior rules)
-3. `docs/working-context.md` → current priorities
-4. `docs/ui-foundations-rules.md` → canonical operating rules
-5. `docs/foundations/` → architecture decisions
-6. `docs/agentic/assistant-behavior-rules.md` → component checklist
-7. `IMPLEMENTATION.md` → repo-specific execution guidance
+3. `docs/playbook.md` → documentation hierarchy and operating model
+4. `docs/working-context.md` → current priorities
+5. `docs/ui-foundations-rules.md` → canonical operating rules
+6. `docs/foundations/` → architecture decisions
+7. `docs/agentic/assistant-behavior-rules.md` → component checklist
+8. `IMPLEMENTATION.md` → repo-specific execution guidance
 
 Never contradict these sources.
 
 ---
 
 ## Core Principle
+
 Never assume system state. Always verify before acting.
 
-Workflow:
-Plan → Execute → Verify → Report
+Workflow: Plan → Execute → Verify → Report
 
 ---
 
 ## Repository Rules
+
 - Verify repo state before changes:
-  - pwd
-  - git status
-  - git branch
+  - `pwd`
+  - `git status`
+  - `git branch`
 - Work on feature branches only
 - Never rely on assumed state
 - Keep changes small, reviewable, non-breaking
@@ -36,7 +38,9 @@ Plan → Execute → Verify → Report
 ---
 
 ## Decision Bias
+
 When in doubt, prefer the option that:
+
 - preserves Core → Semantic → Component separation
 - uses explicit semantic naming over visual naming
 - keeps Figma naming and code naming closely aligned
@@ -49,6 +53,7 @@ When in doubt, prefer the option that:
 ---
 
 ## Token Workflow (MANDATORY)
+
 1. Ingest tokens (Figma export)
 2. Compare with code
 3. Identify drift:
@@ -60,6 +65,7 @@ When in doubt, prefer the option that:
 6. Re-validate
 
 Never:
+
 - invent tokens
 - skip comparison
 - modify tokens blindly
@@ -67,20 +73,21 @@ Never:
 ---
 
 ## Design System Rules
-- Respect token layers:
-  Core → Semantic → Component
+
+- Respect token layers: Core → Semantic → Component
 - Never mix layers
 - Never hardcode values
-- Always use CSS variables: var(--...)
+- Always use CSS variables: `var(--...)`
 - Prefer explicit semantic naming over visual or convenience naming
 - Align Figma naming and code naming as closely as possible
 - Document exceptions when a rule must be broken
 
-Do not edit generated files in `dist/`
+Do not edit generated files in `dist/`.
 
 ---
 
 ## Implementation Rules
+
 - Use existing patterns and file structure
 - Do not introduce new frameworks
 - Keep docs and implementation in sync
@@ -88,20 +95,25 @@ Do not edit generated files in `dist/`
 ---
 
 ## Validation (REQUIRED)
+
 Before completion:
-- npm run lint
-- npm run test:unit
-- npm run ci:check
+
+- `npm run lint`
+- `npm run test:unit`
+- `npm run ci:check`
 
 ---
 
 ## Behavior
+
 - Be concise and structured
 - Explain intent before actions
 - Show commands before execution
 - Verify results after execution
 
 If not verified → not true
+
+---
 
 ## Agent Modes
 
@@ -112,3 +124,11 @@ If unclear:
 - default = Implementation
 - exploratory tasks = Pattern Discovery or Token Proposal
 - review tasks = Audit
+
+---
+
+## Agent-Specific Workflows
+
+- Kiro: `docs/agentic/kiro-workflow.md`
+- Goose: `docs/agentic/goose-workflow.md`
+- Codex: `docs/agentic/codex-workflow.md`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -11,8 +11,8 @@ Canonical sources:
 - `docs/ui-foundations-rules.md`
 - `docs/foundations/`
 - `figma/exports/*.tokens.json`
-- `dist/tokens.css`
-- `dist/tokens.json`
+- `dist/tokens/css/*.css`
+- `dist/tokens/json/*.json`
 
 ## Design Philosophy
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ This repo is structured for agent consumption:
 | File | Purpose |
 |---|---|
 | `AGENTS.md` | Entry point — behavior rules and context loading order |
+| `docs/playbook.md` | Documentation hierarchy and operating model |
 | `DESIGN.md` | Executive design contract |
 | `docs/working-context.md` | Current priorities |
 | `docs/context-manifest.json` | Machine-readable file index |
@@ -159,9 +160,12 @@ Agents operate in modes:
 
 | Directory | Content |
 |---|---|
-| `docs/foundations/` | Architecture decisions (token layering, naming, color, typography, components) |
-| `docs/agentic/` | Agent behavior rules, modes, rule pipeline |
-| `docs/validation/` | Rule pipeline manifest |
+| `docs/foundations/` | Token layering, naming, theming, parity, and 12 foundation ADRs |
+| `docs/principles/` | Perception laws, heuristics, and accessibility intent |
+| `docs/patterns/` | Pattern-level composition guidance |
+| `docs/components/` | Component entry docs |
+| `docs/agentic/` | Agent behavior rules, modes, workflows, rule pipeline |
+| `docs/validation/` | CI pipeline, token parity, rule pipeline manifest |
 | `docs/token-pipeline.md` | Token generation pipeline and format reference |
 | `site/` | Docs site source (Eleventy) |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,38 @@
+# Documentation Map
+
+## Purpose
+
+This directory is the human- and agent-readable map of UI Foundations.
+Use it to find the right level of documentation before diving into implementation
+details or local agent configuration.
+
+## Canonical sections
+
+| Section | What belongs here | Start with |
+|---|---|---|
+| `playbook.md` | Reading order, operating model, and agent roles | `docs/playbook.md` |
+| `foundations/` | Token architecture, naming, theming, parity, and format guidance | `docs/foundations/README.md` |
+| `principles/` | Perception, heuristics, and accessibility intent | `docs/principles/README.md` |
+| `patterns/` | Pattern-level composition guidance | `docs/patterns/README.md` |
+| `components/` | Component-facing entry docs and TODO gaps | `docs/components/README.md` |
+| `agentic/` | Agent behavior, workflows, prompts, and migration context | `docs/agentic/README.md` |
+| `adr/` | Architecture decision records and documentation migration notes | `docs/adr/README.md` |
+| `validation/` | Validation checklists, CI, token parity, and accessibility checks | `docs/validation/README.md` |
+
+## Legacy docs kept in place
+
+- `docs/ui-foundations-rules.md`
+- `docs/token-pipeline.md`
+- `docs/working-context.md`
+- `docs/context-manifest.json`
+- `docs/foundations/foundation-*.md`
+
+These remain valid source material. New docs should point to them rather than
+rewriting them unless a targeted migration is clearly safe.
+
+## Related docs
+
+- `AGENTS.md`
+- `README.md`
+- `IMPLEMENTATION.md`
+- `DESIGN.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,20 @@
+# ADR Index
+
+## Purpose
+
+This section collects architecture decision records and doc migration notes in a
+stable location for humans and agents.
+
+## Canonical rules
+
+- `foundation-003-agentic-docs.md`
+
+## Related docs
+
+- `docs/foundations/README.md`
+- `docs/playbook.md`
+
+## TODO
+
+Most historic foundation decisions still live in `docs/foundations/`. Keep them
+there until a dedicated ADR migration is worth the churn.

--- a/docs/adr/foundation-003-agentic-docs.md
+++ b/docs/adr/foundation-003-agentic-docs.md
@@ -1,0 +1,43 @@
+---
+title: Foundation-003 – Agentic Docs Restructure
+status: active
+type: foundation-decision
+---
+
+# Foundation-003: Agentic Docs Restructure
+
+## Purpose
+
+Clarify how humans and agents should navigate the repository documentation
+without changing the technical behaviour of the project.
+
+## What changed
+
+- Added a clearer `docs/` section architecture with readme files for major
+  sections.
+- Added `docs/playbook.md` as the documentation entry point under `AGENTS.md`.
+- Added section-level docs for foundations, principles, patterns, components,
+  agent workflows, ADRs, and validation.
+- Preserved existing detailed docs in place and added cross-links rather than
+  deleting knowledge.
+
+## What did not change
+
+- No token values changed.
+- No runtime or build behaviour changed.
+- Existing detailed docs such as `docs/ui-foundations-rules.md`,
+  `docs/token-pipeline.md`, and `docs/foundations/foundation-*.md` remain valid.
+
+## Agent consumption model
+
+Agents should read:
+
+1. `AGENTS.md`
+2. `docs/playbook.md`
+3. the relevant section README
+4. the detailed canonical docs referenced there
+
+## Scope
+
+This is a documentation-only restructuring unless a file explicitly says
+otherwise.

--- a/docs/agentic/MIGRATION.md
+++ b/docs/agentic/MIGRATION.md
@@ -8,7 +8,7 @@ type: changelog
 
 This file documents why files were removed from `docs/agentic/` and where their responsibilities moved.
 
-## Current structure (after cleanup)
+## Current structure (historical snapshot)
 
 ```
 docs/agentic/
@@ -16,13 +16,25 @@ docs/agentic/
   MIGRATION.md                  ← this file
 ```
 
-All other agent guidance lives in:
+At the time of that cleanup, all other agent guidance lived in:
 - `AGENTS.md` — operational rules, decision bias, validation
 - `IMPLEMENTATION.md` — file locations, build pipeline, component workflow
 - `docs/ui-foundations-rules.md` — governance (naming, layering, theming, review)
 - `docs/foundations/` — architecture decisions
 
-Agent-specific configs (Kiro Steering, Goose Recipes) live locally, not in the repo.
+Agent-specific configs (Kiro Steering, Goose Recipes) lived locally, not in the repo.
+
+## Current structure after the docs architecture pass
+
+The repo now also includes:
+
+- `docs/playbook.md`
+- `docs/agentic/README.md`
+- `docs/agentic/agent-behavior-rules.md`
+- `docs/agentic/{kiro,goose,codex}-workflow.md`
+- `docs/agentic/prompts/`
+
+The detailed checklist remains in `assistant-behavior-rules.md`.
 
 ---
 

--- a/docs/agentic/README.md
+++ b/docs/agentic/README.md
@@ -1,8 +1,30 @@
-# Agentic Docs Index
+# Agentic Docs
+
+## Purpose
+
+This section explains how different agents should read, plan, validate, and act
+in the repository.
+
+## Canonical files
 
 | File | Topic |
 |---|---|
-| `assistant-behavior-rules.md` | Agent rules for components, tokens, integration surfaces, and validation |
-| `rule-pipeline.md` | Principles -> Heuristics -> Pattern rules -> Component rules -> Validation -> CI |
-| `rule-pipeline-audit.md` | Audit findings, target architecture, and current gap table |
-| `MIGRATION.md` | Consolidated migration notes from older agentic docs |
+| `assistant-behavior-rules.md` | Detailed component and token checklist |
+| `kiro-workflow.md` | Kiro steering, specs, and workflow guidance |
+| `goose-workflow.md` | Goose audit and validation workflow guidance |
+| `codex-workflow.md` | Codex execution workflow guidance |
+| `rule-pipeline.md` | Principles -> Patterns -> Components -> Validation -> CI |
+
+## Supporting files
+
+| File | Topic |
+|---|---|
+| `rule-pipeline-audit.md` | Audit findings, target architecture, and gap table |
+| `MIGRATION.md` | Historical migration context |
+| `prompts/` | Prompt templates and placeholders |
+| `modes/` | Task-specific agent modes |
+
+## Who should read this
+
+- Agents planning or executing repo work
+- Engineers maintaining local agent workflows

--- a/docs/agentic/codex-workflow.md
+++ b/docs/agentic/codex-workflow.md
@@ -1,0 +1,17 @@
+# Codex Workflow
+
+## Purpose
+
+Summarise the expected Codex execution style for this repository.
+
+## Canonical rules
+
+- `AGENTS.md`
+- `IMPLEMENTATION.md`
+- `docs/validation/checklist.md`
+
+## Related docs
+
+- `docs/playbook.md`
+- `docs/agentic/agent-behavior-rules.md`
+- `docs/foundations/README.md`

--- a/docs/agentic/goose-workflow.md
+++ b/docs/agentic/goose-workflow.md
@@ -1,0 +1,18 @@
+# Goose Workflow
+
+## Purpose
+
+Summarise how Goose is used in this repo for audit, cleanup, and validation
+support.
+
+## Canonical rules
+
+- `.goose/recipes/`
+- `.goosehints`
+- `AGENTS.md`
+
+## Related docs
+
+- `docs/validation/checklist.md`
+- `docs/agentic/codex-workflow.md`
+- `docs/playbook.md`

--- a/docs/agentic/kiro-workflow.md
+++ b/docs/agentic/kiro-workflow.md
@@ -1,0 +1,19 @@
+# Kiro Workflow
+
+## Purpose
+
+Explain how Kiro-related repo artifacts are expected to be used without moving
+the Kiro configuration itself into `docs/`.
+
+## Canonical rules
+
+- `.kiro/steering/`
+- `.kiro/specs/`
+- `.kiro/hooks/`
+- `docs/agentic/rule-pipeline.md`
+
+## Related docs
+
+- `docs/playbook.md`
+- `docs/agentic/agent-behavior-rules.md`
+- `IMPLEMENTATION.md`

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -1,0 +1,26 @@
+# Components
+
+## Purpose
+
+This section is the documentation bridge between pattern rules and concrete UI
+surfaces such as CSS patterns, React wrappers, Nunjucks macros, playgrounds,
+docs pages, and Code Connect mappings.
+
+## Canonical rules
+
+- `docs/agentic/agent-behavior-rules.md`
+- `docs/foundations/foundation-009-component-boundaries-and-utility.md`
+- `docs/foundations/foundation-010-implementation-and-pipeline-workflow.md`
+- `site/components/*.md`
+
+## Who should read this
+
+- Engineers implementing or extending components
+- Designers checking which surfaces a component must ship with
+- Agents scaffolding or validating component work
+
+## Related docs
+
+- `docs/patterns/README.md`
+- `docs/principles/accessibility.md`
+- `docs/validation/checklist.md`

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -1,0 +1,18 @@
+# Button
+
+## Purpose
+
+Point to the existing button implementation and documentation surfaces.
+
+## Canonical rules
+
+- `site/components/button.md`
+- `src/ui/patterns/button.css`
+- `src/react/button.js`
+- `schemas/web-button.figma.ts`
+
+## Related docs
+
+- `docs/patterns/forms.md`
+- `docs/patterns/navigation.md`
+- `docs/agentic/agent-behavior-rules.md`

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -1,0 +1,18 @@
+# Input
+
+## Purpose
+
+Point to the existing input implementation and documentation surfaces.
+
+## Canonical rules
+
+- `site/components/input.md`
+- `src/ui/patterns/input.css`
+- `src/react/input.js`
+- `schemas/web-input.figma.ts`
+
+## Related docs
+
+- `docs/patterns/forms.md`
+- `docs/principles/accessibility.md`
+- `docs/validation/token-parity.md`

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -1,0 +1,20 @@
+# Modal
+
+## Purpose
+
+Track modal-related component guidance separately from the modal pattern.
+
+## Canonical rules
+
+- `.kiro/steering/pattern-rules/modals.md`
+- `docs/foundations/foundation-009-component-boundaries-and-utility.md`
+
+## Related docs
+
+- `docs/principles/accessibility.md`
+- `docs/validation/accessibility.md`
+
+## TODO
+
+No modal component implementation doc exists in the current repo. Use the modal
+pattern guidance first, then decide whether a component surface is necessary.

--- a/docs/components/notification.md
+++ b/docs/components/notification.md
@@ -1,0 +1,19 @@
+# Notification
+
+## Purpose
+
+Reserve a stable location for future notification-component documentation.
+
+## Canonical rules
+
+- `docs/components/README.md`
+- `docs/patterns/feedback.md`
+
+## Related docs
+
+- `docs/principles/usability-heuristics.md`
+- `docs/validation/accessibility.md`
+
+## TODO
+
+No notification component documentation exists in the current repo yet.

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -1,0 +1,20 @@
+# Select
+
+## Purpose
+
+Track where select-component documentation should live once the component exists.
+
+## Canonical rules
+
+- `docs/components/README.md`
+- `docs/patterns/forms.md`
+
+## Related docs
+
+- `docs/agentic/agent-behavior-rules.md`
+- `docs/foundations/foundation-009-component-boundaries-and-utility.md`
+
+## TODO
+
+No standalone select component documentation exists in the current repo.
+Validate whether this should be a new component or composition before adding it.

--- a/docs/context-manifest.json
+++ b/docs/context-manifest.json
@@ -1,10 +1,10 @@
 {
-  "version": 1,
+  "version": 2,
   "description": "Agent context loading manifest for UI Foundations",
   "readFirst": [
     "AGENTS.md",
-    "docs/working-context.md",
-    "docs/ui-foundations-rules.md"
+    "docs/playbook.md",
+    "docs/working-context.md"
   ],
   "contextFiles": {
     "design": {
@@ -17,25 +17,35 @@
       "purpose": "Agent behavior rules and workflow",
       "priority": 2
     },
+    "playbook": {
+      "path": "docs/playbook.md",
+      "purpose": "Documentation hierarchy and operating model",
+      "priority": 3
+    },
     "workingContext": {
       "path": "docs/working-context.md",
-      "purpose": "Current priorities and non-negotiables",
-      "priority": 3
+      "purpose": "Current priorities",
+      "priority": 4
     },
     "operatingRules": {
       "path": "docs/ui-foundations-rules.md",
       "purpose": "Canonical operating rules for structure, naming, theming, governance",
-      "priority": 4
+      "priority": 5
+    },
+    "agentBehavior": {
+      "path": "docs/agentic/assistant-behavior-rules.md",
+      "purpose": "Component checklist and token usage rules",
+      "priority": 6
     },
     "implementation": {
       "path": "IMPLEMENTATION.md",
       "purpose": "Repo-specific execution guidance",
-      "priority": 5
+      "priority": 7
     },
     "tokenPipeline": {
       "path": "docs/token-pipeline.md",
       "purpose": "Token generation pipeline and format reference",
-      "priority": 6
+      "priority": 8
     }
   },
   "contextDirectories": {
@@ -43,13 +53,25 @@
       "path": "docs/foundations/",
       "purpose": "Architecture decisions and foundation-specific rules"
     },
+    "principles": {
+      "path": "docs/principles/",
+      "purpose": "Perception, heuristics, and accessibility intent"
+    },
+    "patterns": {
+      "path": "docs/patterns/",
+      "purpose": "Pattern-level guidance"
+    },
+    "components": {
+      "path": "docs/components/",
+      "purpose": "Component entry docs"
+    },
     "agentic": {
       "path": "docs/agentic/",
-      "purpose": "Agent behavior rules and component checklist"
+      "purpose": "Agent workflows, behavior rules, and modes"
     },
     "validation": {
       "path": "docs/validation/",
-      "purpose": "Rule pipeline manifest and validation metadata"
+      "purpose": "Rule pipeline manifest, CI, and validation metadata"
     },
     "steering": {
       "path": ".kiro/steering/",

--- a/docs/foundations/README.md
+++ b/docs/foundations/README.md
@@ -1,4 +1,13 @@
-# Foundations Index
+# Foundations
+
+## Purpose
+
+Foundations docs describe the canonical token, naming, theming, parity, and
+format rules that other layers build on.
+
+## Canonical files
+
+The detailed foundation ADRs are the source of truth:
 
 | File | Topic |
 |---|---|
@@ -14,3 +23,9 @@
 | `foundation-010-implementation-and-pipeline-workflow.md` | Token-first implementation workflow and validation commands |
 | `foundation-011-branching-and-release-governance.md` | Feature-branch, PR, and release governance |
 | `foundation-012-minimal-markup-and-composition.md` | Minimal markup, composition, and wrapper discipline |
+
+## Who should read this
+
+- Designers defining token and naming decisions
+- Engineers implementing or validating token-driven UI
+- Agents doing token, component, or parity work

--- a/docs/patterns/README.md
+++ b/docs/patterns/README.md
@@ -1,0 +1,23 @@
+# Patterns
+
+## Purpose
+
+Pattern docs sit between principles and components. They describe reusable UI
+composition logic without dropping directly into component implementation detail.
+
+## Canonical rules
+
+- `.kiro/steering/pattern-rules/*.md`
+- `docs/agentic/rule-pipeline.md`
+
+## Who should read this
+
+- Designers defining reusable structures
+- Engineers deciding whether logic belongs at pattern or component level
+- Agents proposing new pattern rules
+
+## Related docs
+
+- `docs/principles/README.md`
+- `docs/components/README.md`
+- `docs/validation/checklist.md`

--- a/docs/patterns/cards.md
+++ b/docs/patterns/cards.md
@@ -1,0 +1,16 @@
+# Cards
+
+## Purpose
+
+Document the card-pattern guidance for single-object grouping, subject clarity,
+and scoped actions.
+
+## Canonical rules
+
+- `.kiro/steering/pattern-rules/cards.md`
+- `docs/foundations/foundation-012-minimal-markup-and-composition.md`
+
+## Related docs
+
+- `docs/principles/perception-laws.md`
+- `docs/components/button.md`

--- a/docs/patterns/feedback.md
+++ b/docs/patterns/feedback.md
@@ -1,0 +1,23 @@
+# Feedback
+
+## Purpose
+
+Capture the existing repo guidance around interactive feedback, visible state,
+error recovery, and assistive feedback.
+
+## Canonical rules
+
+- `docs/principles/usability-heuristics.md`
+- `docs/agentic/assistant-behavior-rules.md`
+- `.kiro/specs/accessibility-test-suite/requirements.md`
+
+## Related docs
+
+- `docs/patterns/forms.md`
+- `docs/validation/accessibility.md`
+
+## TODO
+
+There is no standalone feedback pattern rule in the repo yet. If one becomes
+necessary, derive it from the existing heuristics and component state guidance
+instead of inventing a new interaction model ad hoc.

--- a/docs/patterns/forms.md
+++ b/docs/patterns/forms.md
@@ -1,0 +1,18 @@
+# Forms
+
+## Purpose
+
+Explain the current form-pattern guidance that connects field grouping, labels,
+help text, errors, and action ordering.
+
+## Canonical rules
+
+- `.kiro/steering/pattern-rules/forms.md`
+- `docs/foundations/foundation-009-component-boundaries-and-utility.md`
+- `docs/agentic/assistant-behavior-rules.md`
+
+## Related docs
+
+- `docs/components/input.md`
+- `docs/components/button.md`
+- `docs/principles/accessibility.md`

--- a/docs/patterns/layout.md
+++ b/docs/patterns/layout.md
@@ -1,0 +1,23 @@
+# Layout
+
+## Purpose
+
+Describe the current layout-related guidance that already exists in foundations
+and component rules.
+
+## Canonical rules
+
+- `docs/foundations/foundation-005-responsive-breakpoints-and-containers.md`
+- `docs/foundations/foundation-012-minimal-markup-and-composition.md`
+- `docs/foundations/foundation-006-z-index-layering.md`
+
+## Related docs
+
+- `docs/patterns/cards.md`
+- `docs/foundations/theming.md`
+
+## TODO
+
+There is no standalone layout pattern doc in the current repo. Keep using the
+foundations docs as canonical until repeated layout rules justify a dedicated
+pattern rule.

--- a/docs/patterns/navigation.md
+++ b/docs/patterns/navigation.md
@@ -1,0 +1,17 @@
+# Navigation
+
+## Purpose
+
+Document the navigation-pattern expectations for landmarks, active state,
+hierarchy, and recognisable destination structure.
+
+## Canonical rules
+
+- `.kiro/steering/pattern-rules/navigation.md`
+- `docs/foundations/foundation-012-minimal-markup-and-composition.md`
+
+## Related docs
+
+- `docs/components/button.md`
+- `docs/principles/perception-laws.md`
+- `docs/validation/checklist.md`

--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -1,0 +1,70 @@
+# Documentation Playbook
+
+## Purpose
+
+This playbook explains how to consume UI Foundations documentation without
+guessing which file owns which rule.
+
+## Reading order
+
+`AGENTS.md`  
+↓  
+`docs/playbook.md`  
+↓  
+`docs/foundations/*`  
+↓  
+`docs/principles/*`  
+↓  
+`docs/patterns/*`  
+↓  
+`docs/components/*`  
+↓  
+`docs/validation/*`
+
+Supplemental context:
+
+- `DESIGN.md` for the executive design contract
+- `IMPLEMENTATION.md` for repo-specific execution guidance
+- `docs/ui-foundations-rules.md` for governance
+- `docs/token-pipeline.md` for token generation and DTCG format details
+
+## Operating model
+
+Principles  
+→ Patterns  
+→ Components  
+→ Tokens  
+→ Validation  
+→ CI
+
+How that applies in this repo:
+
+- **Principles** define the cross-cutting design intent.
+- **Patterns** translate that intent into reusable composition rules.
+- **Components** apply those rules locally in markup, tokens, wrappers, and docs.
+- **Tokens** carry the design decisions through Figma exports and generated outputs.
+- **Validation** checks the rule chain and technical integrity.
+- **CI** runs those checks consistently.
+
+## Agent roles
+
+- **ChatGPT**: strategy, structure, prompts, storytelling
+- **Kiro**: specs, implementation planning, Figma-to-code workflows
+- **Goose**: repo audit, cleanup, validation support
+- **Codex**: code changes, refactoring, scripts, tests
+
+## Canonical docs by task
+
+- Token architecture: `docs/foundations/foundation-001-token-layering.md`
+- Naming: `docs/foundations/foundation-002-naming-and-grouping.md`
+- Theming: `docs/foundations/foundation-008-mode-activation-and-consumer-control.md`
+- Figma/code parity: `docs/ui-foundations-rules.md`, `IMPLEMENTATION.md`
+- Token format / DTCG: `docs/token-pipeline.md`
+- Agent behavior: `docs/agentic/assistant-behavior-rules.md`
+- Validation and CI: `docs/validation/ci.md`
+
+## Related docs
+
+- `docs/README.md`
+- `docs/agentic/README.md`
+- `docs/validation/README.md`

--- a/docs/principles/README.md
+++ b/docs/principles/README.md
@@ -1,0 +1,26 @@
+# Principles
+
+## Purpose
+
+This section explains the upstream design intent that should shape patterns,
+components, tokens, validation, and CI.
+
+## Canonical rules
+
+- `usability-heuristics.md`
+
+These docs summarise and point to the more detailed source material in
+`DESIGN.md`, `docs/ui-foundations-rules.md`, `.kiro/steering/`, and the
+component and validation docs.
+
+## Who should read this
+
+- Designers defining reusable intent
+- Engineers translating intent into tokens and components
+- Agents generating pattern or validation guidance
+
+## Related docs
+
+- `docs/foundations/README.md`
+- `docs/patterns/README.md`
+- `docs/validation/accessibility.md`

--- a/docs/principles/usability-heuristics.md
+++ b/docs/principles/usability-heuristics.md
@@ -1,0 +1,26 @@
+# Usability Heuristics
+
+## Purpose
+
+Document the usability expectations that pattern and component rules should be
+able to implement and validation should eventually check.
+
+## Canonical rules
+
+- `.kiro/steering/usability-heuristics.md`
+- `docs/agentic/rule-pipeline.md`
+
+Current heuristic set:
+
+- feedback
+- consistency
+- error prevention
+- recognition
+- user control
+- accessibility
+
+## Related docs
+
+- `docs/principles/perception-laws.md`
+- `docs/patterns/forms.md`
+- `docs/validation/checklist.md`

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -1,0 +1,24 @@
+# Validation
+
+## Purpose
+
+This section explains what the repo currently validates, what is planned, and
+which docs are canonical for CI-facing quality checks.
+
+## Canonical rules
+
+- `ci.md`
+- `token-parity.md`
+- `rule-pipeline.manifest.json`
+
+## Who should read this
+
+- Engineers running or extending checks
+- Agents validating work before handoff
+- Reviewers checking what CI actually enforces
+
+## Related docs
+
+- `docs/playbook.md`
+- `docs/agentic/rule-pipeline.md`
+- `IMPLEMENTATION.md`

--- a/docs/validation/ci.md
+++ b/docs/validation/ci.md
@@ -1,0 +1,27 @@
+# CI
+
+## Purpose
+
+Explain what the current CI path actually runs and where the configuration lives.
+
+## Canonical rules
+
+- `package.json`
+- `.github/workflows/ci.yml`
+
+Current pipeline:
+
+- `npm run lint`
+- `npm run test:unit`
+- `npm run build:all`
+- `npm run smoke:check`
+- `npm run tokens:validate`
+- `npm run dtcg:validate`
+- `npm run assets:check`
+- `npm run rules:validate`
+- `npm run docs:build`
+
+## Related docs
+
+- `docs/validation/checklist.md`
+- `docs/agentic/rule-pipeline-audit.md`

--- a/docs/validation/token-parity.md
+++ b/docs/validation/token-parity.md
@@ -1,0 +1,24 @@
+# Token Parity
+
+## Purpose
+
+Describe how the repo currently checks token integrity and where future parity
+work is planned.
+
+## Canonical rules
+
+- `docs/token-pipeline.md`
+- `.kiro/specs/token-drift-detection/requirements.md`
+- `.kiro/specs/dark-mode-validation/requirements.md`
+
+Current enforced checks:
+
+- `npm run tokens:validate`
+- `npm run dtcg:validate`
+- `npm run rules:validate`
+
+## Related docs
+
+- `docs/foundations/figma-code-parity.md`
+- `docs/foundations/design-token-format.md`
+- `docs/validation/ci.md`

--- a/docs/working-context.md
+++ b/docs/working-context.md
@@ -17,4 +17,4 @@ Provide a compact operating context for humans and agents.
 
 ## Agent expectations
 
-Before acting, read the context loading order in `AGENTS.md`.
+Before acting, read the Context Loading Order in `AGENTS.md`.


### PR DESCRIPTION
…rences

Keep (adds real value):
- docs/playbook.md, docs/README.md, section READMEs, ci.md, token-parity.md
- Agent workflow files (kiro, goose, codex)
- ADR foundation-003 (restructure decision record)
- docs/principles/, docs/patterns/, docs/components/

Remove (empty pointer stubs):
- 5 foundation stubs, 2 agentic stubs, 2 principle stubs
- 2 validation stubs, 2 ADR duplicates, 3 prompt stubs

Fix broken references:
- DESIGN.md, AGENTS.md, context-manifest.json, working-context.md
- README.md, playbook.md, all section READMEs