### PR TITLE
chore: consolidate duplicated helpers and remove dead code

### DIFF
--- a/scripts/extract-tokens.js
+++ b/scripts/extract-tokens.js
@@ -49,16 +49,6 @@ function isTokenNode(node) {
   );
 }
 
-function inferBucketFromFilename(fileName) {
-  // Legacy fallback — only used if content-based detection is bypassed
-  const baseName = path.basename(fileName);
-  const stem = baseName
-    .replace(/\.(token|tokens)\.jsonc?$/i, "")
-    .replace(/\.jsonc?$/i, "")
-    .trim();
-  return { bucket: "global", id: slugifyName(stem), stem };
-}
-
 // Derive scope from mode name (e.g. "Light Mode" → mode:light, "Brand A" → brand:a)
 function inferScopeFromModeName(modeName) {
   const slug = slugifyName(modeName);
@@ -72,47 +62,11 @@ function inferScopeFromModeName(modeName) {
   return { bucket: "mode", id: slug };
 }
 
-// Derive scope from file content by inspecting token paths and types
+// Derive scope from file content — currently uses filename-based slug.
+// The heuristic inspection hooks are reserved for future refinement.
 function inferScopeFromContent(data, filePath) {
-  const topKeys = Object.keys(data).filter(k => !k.startsWith("$"));
   const slug = slugifyName(path.basename(filePath).replace(/\.(token|tokens)\.jsonc?$/i, "").replace(/\.jsonc?$/i, ""));
-
-  // Check if all top-level keys look like component names (Button, Input, etc.)
-  // by looking for codeSyntax with component-level prefixes
-  const sampleTokens = collectSampleTokens(data, 5);
-
-  // If tokens have codeSyntax starting with --color- or --font- → primitives
-  // If tokens have codeSyntax starting with --brand- → brand tokens
-  // If tokens have codeSyntax starting with --button-, --input- → components
-  const prefixes = sampleTokens
-    .map(t => t.web)
-    .filter(Boolean)
-    .map(w => w.replace(/^var\(--/, "").replace(/\)$/, "").split("-")[0]);
-
-  const uniquePrefixes = [...new Set(prefixes)];
-
-  // Heuristic: if most tokens are color/font/size primitives → global:primitives
-  // This is intentionally loose — the content tells us what it is
   return { bucket: "global", id: slug };
-}
-
-// Collect a few sample tokens from a data tree for content inspection
-function collectSampleTokens(node, max, found) {
-  if (!found) found = [];
-  if (found.length >= max || !node || typeof node !== "object") return found;
-  if (node.$type && (node.$value !== undefined || node.$value === null)) {
-    const web = node.$extensions && node.$extensions["com.figma.codeSyntax"]
-      ? node.$extensions["com.figma.codeSyntax"].WEB
-      : null;
-    found.push({ type: node.$type, web });
-    return found;
-  }
-  for (const [key, val] of Object.entries(node)) {
-    if (key.startsWith("$")) continue;
-    collectSampleTokens(val, max, found);
-    if (found.length >= max) break;
-  }
-  return found;
 }
 
 // Collect all unique mode names from modeValues in a token file

--- a/src/react/button.js
+++ b/src/react/button.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { LabelContent, hasTextContent } from "./label.js";
+import { warnDev } from "./warn-dev.js";
 
 function normalizeOrientation(value) {
   return value === "vertical" ? "vertical" : "horizontal";
@@ -7,18 +8,6 @@ function normalizeOrientation(value) {
 
 function normalizeJustify(value) {
   return value === "stretch" ? "stretch" : "start";
-}
-
-function warnDev(message) {
-  if (
-    typeof process !== "undefined" &&
-    process.env &&
-    process.env.NODE_ENV === "production"
-  ) {
-    return;
-  }
-
-  console.warn(message);
 }
 
 export function Button({

--- a/src/react/checkbox.js
+++ b/src/react/checkbox.js
@@ -1,23 +1,6 @@
 import React from "react";
-
-function hasLabelContent(value) {
-  if (value === null || value === undefined || value === false) return false;
-  if (typeof value === "string") return value.trim().length > 0;
-  if (Array.isArray(value)) return value.some(hasLabelContent);
-  return true;
-}
-
-function warnDev(message) {
-  if (
-    typeof process !== "undefined" &&
-    process.env &&
-    process.env.NODE_ENV === "production"
-  ) {
-    return;
-  }
-
-  console.warn(message);
-}
+import { hasTextContent } from "./label.js";
+import { warnDev } from "./warn-dev.js";
 
 export function Checkbox({
   className = "",
@@ -32,7 +15,7 @@ export function Checkbox({
   if (className) classes.push(className);
 
   const content = children ?? label;
-  const hasLabel = hasLabelContent(content);
+  const hasLabel = hasTextContent(content);
   const disabled = Boolean(props.disabled);
   const inputRef = React.useRef(null);
 

--- a/src/react/icon.js
+++ b/src/react/icon.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { warnDev } from "./warn-dev.js";
 
 function resolveIconUrl(name, folder, src) {
   if (src) return src;
@@ -9,18 +10,6 @@ function humanizeName(name) {
   return String(name || "")
     .replace(/[-_]+/g, " ")
     .trim();
-}
-
-function warnDev(message) {
-  if (
-    typeof process !== "undefined" &&
-    process.env &&
-    process.env.NODE_ENV === "production"
-  ) {
-    return;
-  }
-
-  console.warn(message);
 }
 
 export function Icon({

--- a/src/react/radio.js
+++ b/src/react/radio.js
@@ -1,23 +1,6 @@
 import React from "react";
-
-function hasLabelContent(value) {
-  if (value === null || value === undefined || value === false) return false;
-  if (typeof value === "string") return value.trim().length > 0;
-  if (Array.isArray(value)) return value.some(hasLabelContent);
-  return true;
-}
-
-function warnDev(message) {
-  if (
-    typeof process !== "undefined" &&
-    process.env &&
-    process.env.NODE_ENV === "production"
-  ) {
-    return;
-  }
-
-  console.warn(message);
-}
+import { hasTextContent } from "./label.js";
+import { warnDev } from "./warn-dev.js";
 
 export function Radio({
   className = "",
@@ -30,7 +13,7 @@ export function Radio({
   if (className) classes.push(className);
 
   const content = children ?? label;
-  const hasLabel = hasLabelContent(content);
+  const hasLabel = hasTextContent(content);
   const disabled = Boolean(props.disabled);
 
   const input = React.createElement("input", {

--- a/src/react/switch.js
+++ b/src/react/switch.js
@@ -1,23 +1,6 @@
 import React from "react";
-
-function hasLabelContent(value) {
-  if (value === null || value === undefined || value === false) return false;
-  if (typeof value === "string") return value.trim().length > 0;
-  if (Array.isArray(value)) return value.some(hasLabelContent);
-  return true;
-}
-
-function warnDev(message) {
-  if (
-    typeof process !== "undefined" &&
-    process.env &&
-    process.env.NODE_ENV === "production"
-  ) {
-    return;
-  }
-
-  console.warn(message);
-}
+import { hasTextContent } from "./label.js";
+import { warnDev } from "./warn-dev.js";
 
 export function Switch({
   className = "",
@@ -31,7 +14,7 @@ export function Switch({
   if (className) classes.push(className);
 
   const content = children ?? label;
-  const hasLabel = hasLabelContent(content);
+  const hasLabel = hasTextContent(content);
   const disabled = Boolean(props.disabled);
   const input = React.createElement("input", {
     type: "checkbox",

--- a/src/react/warn-dev.js
+++ b/src/react/warn-dev.js
@@ -1,0 +1,15 @@
+/**
+ * Log a warning in non-production environments.
+ * Shared across React wrappers to avoid copy-pasting the same guard.
+ */
+export function warnDev(message) {
+  if (
+    typeof process !== "undefined" &&
+    process.env &&
+    process.env.NODE_ENV === "production"
+  ) {
+    return;
+  }
+
+  console.warn(message);
+}


### PR DESCRIPTION
- Extract shared warnDev() into src/react/warn-dev.js (was copy-pasted in 5 files)
- Replace hasLabelContent() in checkbox/radio/switch with hasTextContent import from label.js
- Remove dead inferBucketFromFilename() from extract-tokens.js (never called)
- Remove dead collectSampleTokens() and unused variables in inferScopeFromContent()

No behavior changes. CI passes (lint, test, build, smoke, tokens, docs).