### PR TITLE
docs: add GitHub Projects workflow ADR and clean up ADR naming

### DIFF
--- a/.kiro/steering/workflows/pull-requests.md
+++ b/.kiro/steering/workflows/pull-requests.md
@@ -1,0 +1,35 @@
+---
+inclusion: manual
+---
+
+# Pull Request Conventions
+
+When creating PRs with `gh pr create`, always include:
+
+## Required properties
+
+- **Label**: Choose from repo labels based on the change type:
+  - `documentation` — docs, README, steering, copy changes
+  - `enhancement` — new features, components, capabilities
+  - `bug` — fixes for broken behavior
+- **Project**: `--project "@tbielich's ui-foundations"` (project number 5)
+- **Description**: Structured body with Summary and What Changed sections
+
+## Example
+
+```bash
+gh pr create \
+  --title "docs: update README" \
+  --body "## Summary\n\n- Fixed component list\n- Added Brand C" \
+  --label documentation \
+  --project "@tbielich's ui-foundations"
+```
+
+## Label mapping from commit prefix
+
+| Prefix | Label |
+|--------|-------|
+| `docs:` | `documentation` |
+| `chore:` | `documentation` or `enhancement` depending on scope |
+| `feat:` | `enhancement` |
+| `fix:` | `bug` |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -5,9 +5,10 @@
 This section collects architecture decision records and doc migration notes in a
 stable location for humans and agents.
 
-## Canonical rules
+## ADRs
 
-- `foundation-003-agentic-docs.md`
+- `adr-agentic-docs-restructure.md` — documentation structure and agent consumption model
+- `adr-github-projects-workflow.md` — GitHub Projects delivery workflow (proposed)
 
 ## Related docs
 

--- a/docs/adr/adr-agentic-docs-restructure.md
+++ b/docs/adr/adr-agentic-docs-restructure.md
@@ -1,10 +1,10 @@
 ---
-title: Foundation-003 – Agentic Docs Restructure
+title: ADR – Agentic Docs Restructure
 status: active
-type: foundation-decision
+type: adr
 ---
 
-# Foundation-003: Agentic Docs Restructure
+# ADR: Agentic Docs Restructure
 
 ## Purpose
 

--- a/docs/adr/adr-github-projects-workflow.md
+++ b/docs/adr/adr-github-projects-workflow.md
@@ -1,0 +1,163 @@
+# ADR: Adopt GitHub Projects as the delivery workflow for project-driven development
+
+## Status
+
+Proposed
+
+## Context
+
+The repository needs a more structured way to manage work from idea through
+implementation and validation.
+
+Current task execution can be too prompt-led or implementation-led, which creates
+several risks:
+
+- work begins before scope is clear
+- requirements are not consistently captured
+- acceptance criteria may be implicit or missing
+- implementation and review are harder to trace back to the original objective
+- architectural decisions and delivery work are not always linked
+- agent-driven work can become under-specified or difficult to verify
+
+A GitHub Projects-based workflow would provide a lightweight but explicit
+operating model for project-driven development using:
+
+- GitHub Issues for work definition
+- GitHub Projects for tracking and workflow state
+- Pull Requests for implementation
+- ADRs for durable architectural or process decisions
+
+This supports clearer delivery, better review discipline, and stronger
+traceability across human and agent work.
+
+## Decision
+
+Adopt GitHub Projects as the standard delivery workflow for project-driven
+development in this repository.
+
+Work should move through a defined chain:
+
+1. Idea or request is captured as a GitHub Issue
+2. The issue is added to the GitHub Project
+3. The issue defines:
+   - problem statement
+   - goal
+   - scope
+   - out of scope
+   - acceptance criteria
+   - dependencies or unknowns
+4. If the work introduces a lasting architectural, governance, or process
+   decision, create or update an ADR
+5. Implementation is executed on a linked branch and Pull Request
+6. The Pull Request references the issue and validates the acceptance criteria
+7. The project item is updated as work progresses
+8. The issue is closed only when implementation and validation are complete
+
+## Workflow model
+
+### Required artefacts
+
+- GitHub Project item for tracked work
+- GitHub Issue as the delivery definition
+- Pull Request for implementation
+- ADR when the work introduces a durable decision
+
+### Minimum issue structure
+
+Each feature or improvement issue should include:
+
+- Problem statement
+- Goal
+- Scope
+- Out of scope
+- Acceptance criteria
+- Dependencies or unknowns
+
+### Pull Request expectations
+
+Each Pull Request should:
+
+- reference the linked issue
+- describe the change made
+- explain how acceptance criteria were met
+- include validation evidence
+- note any remaining risks or follow-up work
+
+### ADR trigger
+
+An ADR is required when work changes:
+
+- architecture
+- token or component governance
+- design-to-code contracts
+- repository workflow or operating model
+- shared metadata or indexing patterns
+- other decisions expected to guide future work
+
+## Consequences
+
+### Positive
+
+- clearer delivery structure
+- better traceability from request to implementation
+- stronger review quality through explicit acceptance criteria
+- improved compatibility with agent-driven execution
+- easier prioritisation and status visibility
+- reduced ambiguity around what "done" means
+
+### Negative
+
+- introduces some process overhead
+- requires discipline in issue writing and project maintenance
+- can become noisy if every small task is over-formalised
+- depends on consistent use by both humans and agents
+
+## Alternatives considered
+
+### 1. Continue with ad-hoc issue and PR management
+
+Rejected because it does not provide enough structure for predictable
+project-driven delivery.
+
+### 2. Use issues only, without GitHub Projects
+
+Rejected because issues alone do not provide the same workflow visibility,
+prioritisation, and operational tracking.
+
+### 3. Use GitHub Projects without issue structure standards
+
+Rejected because tracking without clear work definition still leads to ambiguity
+and weak execution.
+
+### 4. Use an external project management tool
+
+Rejected for now because GitHub Projects keeps planning and delivery close to
+the code, issues, and PRs.
+
+## Operating rules
+
+### Required
+
+- Work starts from an issue, not from an implementation prompt alone
+- Issues must contain explicit acceptance criteria
+- PRs must link back to the issue
+- Durable decisions must be captured in ADRs
+- Project status should reflect real delivery state
+
+### Preferred
+
+- Agent prompts should be derived from issues
+- Feature branches should map to a single scoped issue where possible
+- Closure notes should summarise what was delivered and validated
+
+### Not required
+
+- ADRs for every small implementation detail
+- Project items for trivial housekeeping work, unless the team wants full
+  visibility
+
+## Notes
+
+This decision establishes GitHub Projects as the primary workflow framework for
+delivery tracking. It does not replace repository-specific engineering, token, or
+documentation governance rules.


### PR DESCRIPTION
## Summary

- Add proposed ADR for GitHub Projects delivery workflow
- Rename foundation-003-agentic-docs → adr-agentic-docs-restructure (resolves naming conflict with foundation-003-color-semantics)
- Update ADR README index with both ADRs
- Add pull-requests steering for PR conventions (label, project, description)

## What changed

| File | Change |
|------|--------|
| docs/adr/adr-github-projects-workflow.md | New ADR (proposed) |
| docs/adr/adr-agentic-docs-restructure.md | Renamed from foundation-003, updated frontmatter |
| docs/adr/README.md | Updated index |
| .kiro/steering/workflows/pull-requests.md | New steering for PR conventions |