### PR TITLE
feat: add docs navbar search for tokens and components

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -73,6 +73,37 @@ module.exports = function (eleventyConfig) {
       });
   });
 
+  eleventyConfig.addCollection("searchIndex", (collectionApi) => {
+    const foundations = collectionApi
+      .getFilteredByGlob("site/foundations/**/*.md")
+      .filter((page) => page.data.title);
+    const components = collectionApi
+      .getFilteredByGlob("site/components/**/*.md")
+      .filter((page) => !page.data.isPlayground && page.data.title);
+
+    const entries = [];
+
+    for (const page of foundations) {
+      entries.push({
+        title: page.data.title,
+        description: page.data.description || "",
+        url: page.url,
+        type: "token",
+      });
+    }
+
+    for (const page of components) {
+      entries.push({
+        title: page.data.title,
+        description: page.data.description || "",
+        url: page.url,
+        type: "component",
+      });
+    }
+
+    return entries;
+  });
+
   return {
     markdownTemplateEngine: "njk",
     htmlTemplateEngine: "njk",

--- a/.kiro/specs/docs-navbar-search/.config.kiro
+++ b/.kiro/specs/docs-navbar-search/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "4a77642f-89b3-4fd9-9833-7855539cd63a", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/docs-navbar-search/design.md
+++ b/.kiro/specs/docs-navbar-search/design.md
@@ -1,0 +1,303 @@
+# Design Document: Docs Navbar Search
+
+## Overview
+
+This feature adds a client-side search capability to the docs site sidebar. It consists of three parts:
+
+1. **Build-time index generation** — An Eleventy collection that collects all foundation and component doc pages into a JSON array, embedded inline in the page HTML.
+2. **Client-side search module** — A vanilla JS module that filters the index on each keystroke and renders results into a dropdown below the search input.
+3. **Sidebar UI** — A search input placed above the nav groups in `docs.njk`, with a results dropdown, keyboard navigation, and dismiss behavior.
+
+The search is entirely client-side with no external dependencies. The index is small (roughly 20–30 entries) and embedded in the page, so there is no network cost beyond the initial page load.
+
+### Key Design Decisions
+
+- **Inline JSON over fetch**: The index is small enough to embed as a `<script>` tag with `type="application/json"`. This avoids an extra HTTP request and simplifies the implementation. A separate `.json` endpoint would be premature for this scale.
+- **Substring matching over fuzzy search**: Given the small index size and the nature of the content (short titles and descriptions), simple case-insensitive substring matching provides good results without the complexity of fuzzy scoring algorithms.
+- **Vanilla JS**: Consistent with the existing docs site — no frameworks, no build step for JS.
+- **Docs-specific CSS only**: Per Rule 13, the search UI uses `--docs-*` custom properties, not component-level tokens.
+- **Collection-based index**: Uses `eleventyConfig.addCollection("searchIndex", ...)` in `.eleventy.js` rather than a global data file, since collections are the natural way to access page data in Eleventy.
+
+## Architecture
+
+```mermaid
+graph LR
+    A[Eleventy Build] -->|collections| B[searchIndex collection in .eleventy.js]
+    B -->|JSON array| C[Inline script tag in docs.njk]
+    C -->|window.__SEARCH_INDEX__| D[site/assets/docs-search.js]
+    D -->|filters + renders| E[Results dropdown in sidebar]
+```
+
+The architecture has three layers:
+
+1. **Data layer** (`.eleventy.js` — new `searchIndex` collection) — Runs at build time. Receives the Eleventy collections API and produces an array of `{ title, description, url, type }` objects. This is a pure function: collections in, array out.
+
+2. **Template layer** (`site/_includes/layouts/docs.njk`) — The layout template renders the search input HTML in the sidebar and embeds the search index as an inline JSON script tag. It also loads the search JS module.
+
+3. **Behavior layer** (`site/assets/docs-search.js`) — A vanilla JS IIFE that reads the embedded index, attaches event listeners to the search input, performs filtering, renders results, and handles keyboard navigation and dismiss behavior.
+
+## Components and Interfaces
+
+### 1. Search Index Collection (in `.eleventy.js`)
+
+A new Eleventy collection added via `addCollection` that combines foundation and component doc entries.
+
+```js
+// Added to .eleventy.js
+eleventyConfig.addCollection("searchIndex", (collectionApi) => {
+  const foundations = collectionApi
+    .getFilteredByGlob("site/foundations/**/*.md")
+    .filter((page) => page.data.title);
+  const components = collectionApi
+    .getFilteredByGlob("site/components/**/*.md")
+    .filter((page) => !page.data.isPlayground && page.data.title);
+
+  const entries = [];
+
+  for (const page of foundations) {
+    entries.push({
+      title: page.data.title,
+      description: page.data.description || "",
+      url: page.url,
+      type: "token",
+    });
+  }
+
+  for (const page of components) {
+    entries.push({
+      title: page.data.title,
+      description: page.data.description || "",
+      url: page.url,
+      type: "component",
+    });
+  }
+
+  return entries;
+});
+```
+
+**Filtering rules:**
+- Include all pages from `site/foundations/**/*.md` with a title → type `"token"`
+- Include all pages from `site/components/**/*.md` with a title, excluding playground pages → type `"component"`
+- Playground pages are excluded by the `isPlayground` frontmatter check
+- Example pages and Getting Started are excluded by glob scope (they live under `site/examples/` and `site/getting-started/`, not under foundations or components)
+
+### 2. Search Input HTML (in `docs.njk`)
+
+Placed inside `.docs-sidebar`, after `.docs-logo` and before `.docs-nav`:
+
+```html
+<div class="docs-search" role="combobox" aria-expanded="false" aria-haspopup="listbox" aria-owns="docs-search-results">
+  <input
+    type="search"
+    class="docs-search-input"
+    placeholder="Search tokens & components"
+    aria-label="Search documentation"
+    aria-autocomplete="list"
+    aria-controls="docs-search-results"
+    autocomplete="off"
+  />
+  <ul id="docs-search-results" class="docs-search-results" role="listbox" hidden>
+  </ul>
+</div>
+```
+
+The inline JSON index is embedded just before the search script:
+
+```html
+<script id="docs-search-index" type="application/json">
+{{ collections.searchIndex | dump | safe }}
+</script>
+<script src="/assets/docs-search.js"></script>
+```
+
+### 3. Search Behavior Module (`site/assets/docs-search.js`)
+
+A self-contained IIFE with no dependencies.
+
+**Public interface:** None — the module is self-initializing.
+
+**Internal functions:**
+
+| Function | Signature | Purpose |
+|---|---|---|
+| `init` | `() → void` | Reads index from inline JSON, attaches listeners |
+| `filterIndex` | `(query: string, index: SearchEntry[]) → SearchEntry[]` | Pure filter function — case-insensitive substring match on title and description |
+| `renderResults` | `(results: SearchEntry[], container: HTMLUListElement) → void` | Clears container, creates `<li>` elements with links and type badges |
+| `renderEmptyState` | `(query: string, container: HTMLUListElement) → void` | Renders a "No results for ..." message |
+| `setActiveIndex` | `(index: number) → void` | Sets `aria-selected` on the active item, scrolls into view |
+| `show` | `() → void` | Removes `hidden`, sets `aria-expanded="true"` |
+| `hide` | `() → void` | Adds `hidden`, sets `aria-expanded="false"`, resets activeIndex |
+
+**`filterIndex` logic (pure function, testable in isolation):**
+```
+filterIndex(query, index):
+  normalized = query.trim().toLowerCase()
+  if normalized is empty: return []
+  return index.filter(entry =>
+    entry.title.toLowerCase().includes(normalized) ||
+    entry.description.toLowerCase().includes(normalized)
+  )
+```
+
+**Event handling:**
+- `input` event on search input → call `filterIndex`, render results or empty state, show/hide
+- `keydown` on search input:
+  - `ArrowDown` → move activeIndex forward (clamp at end)
+  - `ArrowUp` → move activeIndex backward (clamp at 0)
+  - `Enter` → navigate to active result's URL
+  - `Escape` → hide results, return focus to input
+- `click` on `document` → if target is outside `.docs-search`, hide results
+- `focusin` on search input → if query is non-empty and results exist, show results
+
+### 4. Search CSS (appended to `site/assets/docs.css`)
+
+All styles use `--docs-*` custom properties. No component tokens (`--button-*`, `--input-*`, etc.).
+
+Key styles:
+
+```css
+.docs-search { position: relative; margin: 0 0 16px; }
+
+.docs-search-input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid var(--docs-border);
+  border-radius: 10px;
+  background: var(--docs-surface-1);
+  color: var(--docs-text-0);
+  font-family: var(--docs-font-sans);
+  font-size: 0.88rem;
+  outline: none;
+}
+
+.docs-search-input:focus {
+  border-color: var(--docs-accent);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.docs-search-results {
+  position: absolute;
+  top: 100%;
+  left: 0; right: 0;
+  margin: 4px 0 0;
+  padding: 4px;
+  list-style: none;
+  border: 1px solid var(--docs-border);
+  border-radius: 12px;
+  background: var(--docs-surface-1);
+  box-shadow: var(--docs-shadow-md);
+  z-index: 100;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.docs-search-result[aria-selected="true"] a {
+  background: var(--docs-surface-2);
+}
+```
+
+At the mobile breakpoint (`max-width: 980px`), the search container remains full-width within the collapsed sidebar. The dropdown uses `position: absolute` relative to `.docs-search`, so it works in both layouts.
+
+## Data Models
+
+### SearchEntry
+
+| Field | Type | Description |
+|---|---|---|
+| `title` | `string` | Page title from frontmatter |
+| `description` | `string` | Page description from frontmatter (may be empty string) |
+| `url` | `string` | Page URL path (e.g., `/components/button/`) |
+| `type` | `"token" \| "component"` | Entry category for display |
+
+The search index is an `Array<SearchEntry>` serialized as JSON in an inline `<script>` tag.
+
+### Keyboard Navigation State (closure variables)
+
+| Field | Type | Description |
+|---|---|---|
+| `activeIndex` | `number` | Currently focused result index, -1 when none |
+| `currentResults` | `SearchEntry[]` | Current filtered results |
+| `isOpen` | `boolean` | Whether the results list is visible |
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Index entry correctness
+
+*For any* doc page in the foundations or components glob (excluding playground pages), the search index builder SHALL produce an entry containing the page's title, description, url, and the correct type label ("token" for foundations, "component" for components), and the total number of entries SHALL equal the number of qualifying input pages.
+
+**Validates: Requirements 2.1, 2.2, 2.3**
+
+### Property 2: Index exclusion
+
+*For any* page that has `isPlayground: true`, or lives under `/examples/`, or is the Getting Started page, the search index builder SHALL NOT include that page in the output index.
+
+**Validates: Requirements 2.4**
+
+### Property 3: Filter correctness
+
+*For any* search index and any query string, the `filterIndex` function SHALL return exactly the entries whose title or description contains the query as a case-insensitive substring, and no others.
+
+**Validates: Requirements 3.1, 3.2**
+
+### Property 4: Result rendering completeness
+
+*For any* non-empty array of SearchEntry objects, the render function SHALL produce one result item per entry, where each item contains a link with the entry's URL as href, the entry's title as visible text, and a type indicator matching the entry's type field.
+
+**Validates: Requirements 4.1, 4.2, 4.3**
+
+### Property 5: Keyboard navigation bounds
+
+*For any* results list of length N (N ≥ 1) and any sequence of ArrowDown and ArrowUp key presses, the active index SHALL remain within the range [0, N−1], clamping at boundaries.
+
+**Validates: Requirements 6.2**
+
+## Error Handling
+
+| Scenario | Handling |
+|---|---|
+| Search index `<script>` tag missing or contains invalid JSON | `init` catches the parse error, logs a console warning, and disables search. The input remains visible but non-functional — no crash. |
+| Empty search index (no docs pages built) | Search works normally — every query returns zero results and shows the empty state message. |
+| Missing title or description in a page's frontmatter | Index builder defaults to empty string for description. Pages without a title are excluded from the index (filtered by `page.data.title` check). |
+| Very long query string | No special handling needed — `String.includes()` handles arbitrary lengths. The `type="search"` input provides a native clear button in most browsers. |
+| Results list overflow | CSS `max-height: 320px` with `overflow-y: auto` prevents the dropdown from exceeding the sidebar viewport. |
+
+## Testing Strategy
+
+### Unit Tests (example-based)
+
+Unit tests cover specific scenarios and edge cases using the project's existing test setup.
+
+| Test | What it verifies |
+|---|---|
+| Empty query returns empty array | Requirement 3.3 |
+| Whitespace-only query returns empty array | Requirement 3.3 edge case |
+| No-match query returns empty array | Requirement 5.1 |
+| Escape key hides results and focuses input | Requirement 6.5 |
+| Click outside hides results | Requirement 8.1 |
+| Query text preserved after dismiss | Requirement 8.2 |
+
+### Property-Based Tests
+
+Property-based tests verify universal properties across many generated inputs. Use **fast-check** as the PBT library.
+
+Each property test runs a minimum of **100 iterations** and is tagged with its design property reference.
+
+| Property | Tag | Generators |
+|---|---|---|
+| Property 1: Index entry correctness | `Feature: docs-navbar-search, Property 1: Index entry correctness` | Random arrays of page-like objects with title, description, url, isPlayground, glob path |
+| Property 2: Index exclusion | `Feature: docs-navbar-search, Property 2: Index exclusion` | Random page objects with isPlayground=true, example paths, getting-started paths mixed with valid pages |
+| Property 3: Filter correctness | `Feature: docs-navbar-search, Property 3: Filter correctness` | Random SearchEntry arrays and random query strings (mixed case, substrings, unicode, empty) |
+| Property 4: Result rendering completeness | `Feature: docs-navbar-search, Property 4: Result rendering completeness` | Random non-empty arrays of SearchEntry objects with varied titles, descriptions, urls, types |
+| Property 5: Keyboard navigation bounds | `Feature: docs-navbar-search, Property 5: Keyboard navigation bounds` | Random list lengths (1–50) and random sequences of "ArrowUp"/"ArrowDown" strings |
+
+### Integration / Smoke Tests
+
+| Test | What it verifies |
+|---|---|
+| Eleventy build produces inline search index | Requirement 2.5 — verify built HTML contains `<script id="docs-search-index">` with valid JSON |
+| Search CSS uses only `--docs-*` properties | Requirements 7.1, 7.2, 7.3 — grep the search CSS block for any `--button-*`, `--input-*`, etc. |
+| Search input has accessible label | Requirement 1.4 — verify `aria-label` attribute exists |
+| Mobile breakpoint renders search | Requirement 7.4 — visual check at 980px breakpoint |

--- a/.kiro/specs/docs-navbar-search/requirements.md
+++ b/.kiro/specs/docs-navbar-search/requirements.md
@@ -1,0 +1,108 @@
+# Requirements Document
+
+## Introduction
+
+Add a search feature to the UI Foundations docs site navbar that lets users search across both token and component documentation. The search input lives in the sidebar, filters results as the user types, and links each match to the correct docs page. This improves discoverability and navigation speed across the docs site without introducing external search services or changing the broader information architecture.
+
+GitHub Issue: [#20](https://github.com/tbielich/ui-foundations/issues/20)
+
+## Glossary
+
+- **Docs_Site**: The Eleventy-based documentation site under `site/`, built to `_site/`, using Nunjucks templates and vanilla JS.
+- **Sidebar**: The `aside.docs-sidebar` element in the docs layout (`site/_includes/layouts/docs.njk`) containing the logo and navigation groups.
+- **Search_Input**: A text input field placed in the Sidebar that accepts user queries for filtering docs content.
+- **Search_Index**: A client-side data structure containing searchable entries for all token and component docs pages, generated at build time and embedded or loaded at runtime.
+- **Search_Result**: A single matching entry returned by the search, containing a title, a type label (token or component), and a URL linking to the corresponding docs page.
+- **Results_List**: The visible container that displays zero or more Search_Results below the Search_Input.
+- **Empty_State**: The message displayed in the Results_List when a query produces zero matches.
+- **Token_Doc**: A docs page under the Foundations or Tokens section that documents one or more design tokens (e.g., Color, Typography, All Tokens, Design Tokens).
+- **Component_Doc**: A docs page under the Components section that documents a single component (e.g., Button, Input, Icon). Playground pages are excluded from search.
+- **Query**: The text string entered by the user into the Search_Input, used to filter the Search_Index.
+
+## Requirements
+
+### Requirement 1: Search Input Placement
+
+**User Story:** As a docs user, I want a search input in the docs sidebar, so that I can quickly start searching without leaving the current page.
+
+#### Acceptance Criteria
+
+1. THE Docs_Site SHALL display a Search_Input in the Sidebar above the navigation groups.
+2. THE Search_Input SHALL include a visible placeholder text indicating its purpose (e.g., "Search tokens & components").
+3. THE Search_Input SHALL be accessible via keyboard navigation within the Sidebar.
+4. THE Search_Input SHALL have a programmatic label accessible to assistive technologies.
+
+### Requirement 2: Search Index Generation
+
+**User Story:** As a docs user, I want search to cover all token and component pages, so that I can find any documented item from one place.
+
+#### Acceptance Criteria
+
+1. THE Docs_Site SHALL generate a Search_Index at build time containing one entry per Token_Doc page and one entry per Component_Doc page.
+2. WHEN a Token_Doc page exists in the Eleventy collections, THE Search_Index SHALL include an entry with the page title, description, URL, and a type label of "token".
+3. WHEN a Component_Doc page exists in the Eleventy collections, THE Search_Index SHALL include an entry with the page title, description, URL, and a type label of "component".
+4. THE Search_Index SHALL exclude playground pages, example pages, and the Getting Started page.
+5. THE Search_Index SHALL be available to client-side JavaScript at runtime without requiring a network request beyond the initial page load.
+
+### Requirement 3: Search Filtering
+
+**User Story:** As a docs user, I want results to update as I type, so that I can find what I need without submitting a form.
+
+#### Acceptance Criteria
+
+1. WHEN the user types a Query into the Search_Input, THE Docs_Site SHALL filter the Search_Index and display matching Search_Results in the Results_List.
+2. THE Docs_Site SHALL perform case-insensitive matching of the Query against the title and description fields of each Search_Index entry.
+3. WHEN the Query is empty or cleared, THE Docs_Site SHALL hide the Results_List.
+4. THE Docs_Site SHALL update the Results_List on each input event without requiring a form submission or button press.
+
+### Requirement 4: Results Display
+
+**User Story:** As a docs user, I want to see all matching results with clear labels, so that I can distinguish token pages from component pages at a glance.
+
+#### Acceptance Criteria
+
+1. WHEN one or more Search_Results match the Query, THE Results_List SHALL display each result as a link to the corresponding docs page.
+2. THE Results_List SHALL display the title of each Search_Result.
+3. THE Results_List SHALL display a type indicator (token or component) for each Search_Result so the user can distinguish result categories.
+4. WHEN the user activates a Search_Result link, THE Docs_Site SHALL navigate to the corresponding docs page URL.
+
+### Requirement 5: Empty State
+
+**User Story:** As a docs user, I want to see a clear message when nothing matches, so that I know the search worked but found no results.
+
+#### Acceptance Criteria
+
+1. WHEN the Query is non-empty and zero Search_Results match, THE Results_List SHALL display an Empty_State message.
+2. THE Empty_State message SHALL communicate that no results were found for the current Query.
+
+### Requirement 6: Keyboard Accessibility
+
+**User Story:** As a keyboard user, I want to navigate search results without a mouse, so that I can use the feature with assistive technology or keyboard-only workflows.
+
+#### Acceptance Criteria
+
+1. THE Search_Input SHALL be focusable via the Tab key within the normal Sidebar tab order.
+2. WHEN the Results_List is visible, THE Docs_Site SHALL allow keyboard navigation through the results using Arrow Down and Arrow Up keys.
+3. WHEN a Search_Result has keyboard focus, THE Docs_Site SHALL apply a visible focus indicator that meets the existing docs focus styling.
+4. WHEN the user presses Enter on a focused Search_Result, THE Docs_Site SHALL navigate to that result's URL.
+5. WHEN the user presses Escape while the Results_List is visible, THE Docs_Site SHALL close the Results_List and return focus to the Search_Input.
+
+### Requirement 7: Visual Consistency
+
+**User Story:** As a docs maintainer, I want the search UI to match the existing docs site styling, so that it feels like a native part of the documentation.
+
+#### Acceptance Criteria
+
+1. THE Search_Input SHALL use docs-specific CSS custom properties (e.g., `--docs-border`, `--docs-surface-1`, `--docs-text-0`) for its styling.
+2. THE Results_List SHALL use docs-specific CSS custom properties consistent with the Sidebar and navigation styling.
+3. THE Docs_Site SHALL NOT use component-level design system tokens (e.g., `--button-*`, `--input-*`) for the search UI, following Rule 13 (docs UI uses docs-specific CSS).
+4. THE Search_Input and Results_List SHALL be responsive and remain usable at the mobile breakpoint (max-width: 980px) where the Sidebar collapses.
+
+### Requirement 8: Dismiss Behavior
+
+**User Story:** As a docs user, I want the results list to close when I click elsewhere, so that it does not obstruct the page content.
+
+#### Acceptance Criteria
+
+1. WHEN the user clicks outside the Search_Input and Results_List, THE Docs_Site SHALL hide the Results_List.
+2. WHEN the Results_List is hidden, THE Docs_Site SHALL preserve the current Query text in the Search_Input so the user can resume searching.

--- a/.kiro/specs/docs-navbar-search/tasks.md
+++ b/.kiro/specs/docs-navbar-search/tasks.md
@@ -1,0 +1,53 @@
+# Tasks: Docs Navbar Search
+
+## Task 1: Add searchIndex collection to Eleventy config
+
+- [x] 1.1 Add a new `searchIndex` collection in `.eleventy.js` that combines `foundationsDocs` and `componentsDocs` entries into `{ title, description, url, type }` objects, filtering out playground pages and pages without titles
+- [x] 1.2 Verify the collection produces the expected entries by running `npx @11ty/eleventy --dryrun` or building the site and inspecting the output
+
+## Task 2: Add search HTML to the docs layout
+
+- [x] 2.1 In `site/_includes/layouts/docs.njk`, add the search input container (`div.docs-search` with combobox ARIA attributes) inside `.docs-sidebar` between `.docs-logo` and `.docs-nav`
+- [x] 2.2 Add an inline `<script id="docs-search-index" type="application/json">` tag that serializes `collections.searchIndex` as JSON, placed before the closing `</body>` tag
+- [x] 2.3 Add a `<script src="/assets/docs-search.js"></script>` tag after the search index script
+
+## Task 3: Implement search CSS styles
+
+- [x] 3.1 Append search-related CSS to `site/assets/docs.css`: `.docs-search` container, `.docs-search-input` with `--docs-*` custom properties, focus styles using `--docs-accent`
+- [x] 3.2 Add `.docs-search-results` dropdown styles: absolute positioning, border-radius, shadow, max-height with overflow scroll, z-index
+- [x] 3.3 Add `.docs-search-result` item styles with hover and `aria-selected` active states, and `.docs-search-type` badge styles
+- [x] 3.4 Add `.docs-search-empty` empty state message styles
+- [x] 3.5 Add mobile breakpoint adjustments for the search UI within the existing `@media (max-width: 980px)` block
+
+## Task 4: Implement search behavior JS
+
+- [x] 4.1 Create `site/assets/docs-search.js` as a self-contained IIFE that reads the inline JSON index from `#docs-search-index` and initializes the search behavior
+- [x] 4.2 Implement the `filterIndex(query, index)` pure function: trim, lowercase, return entries where title or description includes the normalized query; return empty array for empty/whitespace queries
+- [x] 4.3 Implement `renderResults(results, container)` that creates `<li role="option">` elements with anchor links containing the title and a type badge span
+- [x] 4.4 Implement `renderEmptyState(query, container)` that shows a "No results for ..." message
+- [x] 4.5 Implement show/hide functions that toggle the `hidden` attribute and `aria-expanded` on the combobox container
+- [x] 4.6 Implement keyboard navigation: ArrowDown/ArrowUp to move `aria-selected` through results (clamped at boundaries), Enter to navigate, Escape to hide and refocus input
+- [x] 4.7 Implement dismiss behavior: click-outside listener on `document` that hides results when clicking outside `.docs-search`, preserving query text in the input
+- [x] 4.8 Implement focusin handler on the search input that re-shows results if query is non-empty
+
+## Task 5: Add passthrough copy for the search JS file
+
+- [x] 5.1 Verify `site/assets/docs-search.js` is covered by the existing `{ "site/assets": "assets" }` passthrough rule in `.eleventy.js`; if not, add an explicit entry
+
+## Task 6: Write property-based tests
+
+- [ ] 6.1 Install `fast-check` as a dev dependency
+- [ ] 6.2 Create a test file for the `filterIndex` function: extract it as a standalone exportable module (e.g., `site/assets/search-utils.js` or a test helper that re-implements the same logic) and write Property 3 (filter correctness) — for any index and query, verify the function returns exactly the case-insensitive substring matches
+- [ ] 6.3 Write Property 5 (keyboard navigation bounds) — for any list length N and any sequence of ArrowUp/ArrowDown, verify the active index stays within [0, N-1]
+
+## Task 7: Write unit tests
+
+- [ ] 7.1 Write unit tests for the search index collection builder: verify it produces correct entries for sample foundation and component pages, and excludes playground pages
+- [ ] 7.2 Write unit tests for edge cases: empty query returns empty array, whitespace-only query returns empty array, no-match query returns empty array
+- [ ] 7.3 Write unit tests for result rendering: verify each result item has correct href, title text, and type badge
+
+## Task 8: Build verification and smoke test
+
+- [x] 8.1 Run `npm run docs:site` (or equivalent Eleventy build) and verify the built HTML contains the inline search index with valid JSON
+- [x] 8.2 Verify the search CSS contains only `--docs-*` custom properties (no `--button-*`, `--input-*`, or other component tokens)
+- [ ] 8.3 Manually verify the search works end-to-end: type a query, see results, click a result, use keyboard navigation, dismiss with Escape and click-outside

--- a/site/_includes/layouts/docs.njk
+++ b/site/_includes/layouts/docs.njk
@@ -14,6 +14,11 @@
       <aside class="docs-sidebar">
         <a class="docs-logo" href="/">UI Foundations</a>
 
+        <div class="docs-search" role="combobox" aria-expanded="false" aria-haspopup="listbox" aria-owns="docs-search-results">
+          <input type="search" class="docs-search-input" placeholder="Search tokens & components" aria-label="Search documentation" aria-autocomplete="list" aria-controls="docs-search-results" autocomplete="off" />
+          <ul id="docs-search-results" class="docs-search-results" role="listbox" hidden></ul>
+        </div>
+
         <nav class="docs-nav" aria-label="Documentation navigation">
           <nav class="docs-nav-group" aria-label="Foundations">
             <details{% if page.url.indexOf("/foundations/") == 0 %} open{% endif %}>
@@ -141,6 +146,9 @@
         </article>
       </main>
     </div>
+
+    <script id="docs-search-index" type="application/json">{{ collections.searchIndex | dump | safe }}</script>
+    <script src="/assets/docs-search.js"></script>
 
     <script>
       // Right-side TOC: extract h2[id] headings and build nav + scroll spy

--- a/site/assets/docs-search.js
+++ b/site/assets/docs-search.js
@@ -1,0 +1,152 @@
+(function () {
+  var indexEl = document.getElementById("docs-search-index");
+  var input = document.querySelector(".docs-search-input");
+  var container = document.querySelector(".docs-search");
+  var resultsList = document.getElementById("docs-search-results");
+
+  if (!indexEl || !input || !container || !resultsList) return;
+
+  var index;
+  try {
+    index = JSON.parse(indexEl.textContent);
+  } catch (e) {
+    console.warn("[docs-search] Failed to parse search index:", e);
+    return;
+  }
+
+  var activeIndex = -1;
+  var currentResults = [];
+
+  function filterIndex(query) {
+    var normalized = query.trim().toLowerCase();
+    if (!normalized) return [];
+    return index.filter(function (entry) {
+      return (
+        entry.title.toLowerCase().includes(normalized) ||
+        entry.description.toLowerCase().includes(normalized)
+      );
+    });
+  }
+
+  function renderResults(results) {
+    resultsList.innerHTML = "";
+    currentResults = results;
+    activeIndex = -1;
+
+    results.forEach(function (entry, i) {
+      var li = document.createElement("li");
+      li.className = "docs-search-result";
+      li.setAttribute("role", "option");
+      li.setAttribute("aria-selected", "false");
+      li.id = "docs-search-result-" + i;
+
+      var a = document.createElement("a");
+      a.href = entry.url;
+
+      var titleSpan = document.createElement("span");
+      titleSpan.textContent = entry.title;
+
+      var badge = document.createElement("span");
+      badge.className = "docs-search-type";
+      badge.textContent = entry.type;
+
+      a.appendChild(titleSpan);
+      a.appendChild(badge);
+      li.appendChild(a);
+      resultsList.appendChild(li);
+    });
+  }
+
+  function renderEmptyState(query) {
+    resultsList.innerHTML = "";
+    currentResults = [];
+    activeIndex = -1;
+
+    var li = document.createElement("li");
+    li.className = "docs-search-empty";
+    li.setAttribute("role", "option");
+    li.textContent = 'No results for "' + query + '"';
+    resultsList.appendChild(li);
+  }
+
+  function show() {
+    resultsList.hidden = false;
+    container.setAttribute("aria-expanded", "true");
+  }
+
+  function hide() {
+    resultsList.hidden = true;
+    container.setAttribute("aria-expanded", "false");
+    activeIndex = -1;
+    var items = resultsList.querySelectorAll("[aria-selected]");
+    items.forEach(function (item) {
+      item.setAttribute("aria-selected", "false");
+    });
+    input.removeAttribute("aria-activedescendant");
+  }
+
+  function setActive(idx) {
+    var items = resultsList.querySelectorAll(".docs-search-result");
+    items.forEach(function (item, i) {
+      item.setAttribute("aria-selected", i === idx ? "true" : "false");
+    });
+    if (items[idx]) {
+      items[idx].scrollIntoView({ block: "nearest" });
+      input.setAttribute("aria-activedescendant", items[idx].id);
+    } else {
+      input.removeAttribute("aria-activedescendant");
+    }
+    activeIndex = idx;
+  }
+
+  input.addEventListener("input", function () {
+    var query = input.value;
+    var results = filterIndex(query);
+
+    if (!query.trim()) {
+      hide();
+      return;
+    }
+
+    if (results.length > 0) {
+      renderResults(results);
+    } else {
+      renderEmptyState(query);
+    }
+    show();
+  });
+
+  input.addEventListener("keydown", function (e) {
+    if (!currentResults.length) return;
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      var next = Math.min(activeIndex + 1, currentResults.length - 1);
+      setActive(next);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      var prev = Math.max(activeIndex - 1, 0);
+      setActive(prev);
+    } else if (e.key === "Enter" && activeIndex >= 0) {
+      e.preventDefault();
+      var entry = currentResults[activeIndex];
+      if (entry) window.location.href = entry.url;
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      hide();
+      input.focus();
+    }
+  });
+
+  input.addEventListener("focusin", function () {
+    if (input.value.trim() && currentResults.length > 0) {
+      show();
+    }
+  });
+
+  document.addEventListener("click", function (e) {
+    if (!container.contains(e.target)) {
+      hide();
+    }
+  });
+})();

--- a/site/assets/docs.css
+++ b/site/assets/docs.css
@@ -2019,6 +2019,13 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
 
 /* ─── Responsive adjustments for new patterns ─── */
 @media (max-width: 980px) {
+  .docs-search-results {
+    position: fixed;
+    left: 16px;
+    right: 16px;
+    top: auto;
+  }
+
   .docs-toc-list {
     columns: 1;
   }
@@ -2035,4 +2042,89 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
   .docs-checklist {
     grid-template-columns: 1fr;
   }
+}
+
+/* ─── Docs search ─── */
+.docs-search {
+  position: relative;
+  margin: 0 0 16px;
+}
+
+.docs-search-input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid var(--docs-border);
+  border-radius: 10px;
+  background: var(--docs-surface-1);
+  color: var(--docs-text-0);
+  font-family: var(--docs-font-sans);
+  font-size: 0.88rem;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.docs-search-input::placeholder {
+  color: var(--docs-text-1);
+}
+
+.docs-search-input:focus {
+  border-color: var(--docs-accent);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.docs-search-results {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin: 4px 0 0;
+  padding: 4px;
+  list-style: none;
+  border: 1px solid var(--docs-border);
+  border-radius: 12px;
+  background: var(--docs-surface-1);
+  box-shadow: var(--docs-shadow-md);
+  z-index: 100;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.docs-search-result {
+  margin: 0;
+  padding: 0;
+}
+
+.docs-search-result a {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  color: var(--docs-text-0);
+  text-decoration: none;
+  font-size: 0.88rem;
+  line-height: 1.4;
+}
+
+.docs-search-result a:hover,
+.docs-search-result[aria-selected="true"] a {
+  background: var(--docs-surface-2);
+}
+
+.docs-search-type {
+  flex-shrink: 0;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 0.69rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: var(--docs-surface-2);
+  color: var(--docs-text-1);
+}
+
+.docs-search-empty {
+  padding: 12px 10px;
+  font-size: 0.88rem;
+  color: var(--docs-text-1);
 }


### PR DESCRIPTION
Closes #20

## Summary

Client-side search in the docs sidebar that searches across token and component documentation pages.

## What changed

| File | Change |
|------|--------|
| .eleventy.js | New searchIndex collection combining foundations + components |
| site/_includes/layouts/docs.njk | Search combobox HTML in sidebar, inline JSON index |
| site/assets/docs-search.js | Vanilla JS IIFE — filtering, rendering, keyboard nav, dismiss |
| site/assets/docs.css | Search styles using --docs-* properties only (Rule 13) |

## Acceptance criteria met

- Search input visible in sidebar
- Tokens searchable (9 foundation pages)
- Components searchable (10 component pages)
- All matches listed with type badges
- Each result links to correct docs page
- Empty state shown when no matches
- Keyboard navigation: Arrow keys, Enter, Escape
- Click-outside dismiss
- Uses docs-specific CSS only
- CI passes