### PR TITLE
fix: align Badge Figma variables with CSS token convention

### DIFF
--- a/figma/exports/Components (UI).tokens.json
+++ b/figma/exports/Components (UI).tokens.json
@@ -1309,228 +1309,26 @@
           "com.figma.isOverride": true
         }
       },
-      "Border": {
-        "Color Default": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Border/Default"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2028:295",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-text-border-color-default)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:342",
-              "targetVariableName": "Color/Border/Default",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
+      "Text Color Disabled": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Text/Disabled"
         },
-        "Color Hover": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Border/Brand"
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2028:330",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-text-text-color-disabled)"
           },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2028:297",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-text-border-color-hover)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:345",
-              "targetVariableName": "Color/Border/Brand",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
-        },
-        "Color Active": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Border/Brand"
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:328",
+            "targetVariableName": "Color/Text/Disabled",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
           },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2028:298",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-text-border-color-active)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:345",
-              "targetVariableName": "Color/Border/Brand",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
-        },
-        "Color Focus": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Border/Brand"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2028:299",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-text-border-color-focus)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:345",
-              "targetVariableName": "Color/Border/Brand",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
-        },
-        "Color Invalid": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Border/Danger"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2070:607",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-text-border-color-invalid)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:356",
-              "targetVariableName": "Color/Border/Danger",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
-        },
-        "Color Valid": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Border/Strong"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2070:608",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-text-border-color-valid)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:344",
-              "targetVariableName": "Color/Border/Strong",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
-        }
-      },
-      "Container": {
-        "Background Default": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Fill/Surface"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2028:318",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-text-container-background-default)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:329",
-              "targetVariableName": "Color/Fill/Surface",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
-        },
-        "Background Hover": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Fill/Surface"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2028:319",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-text-container-background-hover)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:329",
-              "targetVariableName": "Color/Fill/Surface",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
-        },
-        "Background Focus": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Fill/Surface"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2028:320",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-text-container-background-focus)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:329",
-              "targetVariableName": "Color/Fill/Surface",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
-        },
-        "Background Active": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Fill/Surface"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2028:321",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-text-container-background-active)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:329",
-              "targetVariableName": "Color/Fill/Surface",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
+          "com.figma.isOverride": true
         }
       },
       "Text Color Placeholder": {
@@ -1554,18 +1352,249 @@
           },
           "com.figma.isOverride": true
         }
-      },
-      "Height Min": {
-        "$type": "number",
-        "$value": 40,
+      }
+    },
+    "Border": {
+      "Border Color Default": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Border/Default"
+        },
         "$extensions": {
-          "com.figma.variableId": "VariableID:2228:321",
+          "com.figma.variableId": "VariableID:2028:295",
           "com.figma.scopes": [
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-text-height-min)"
-          }
+            "WEB": "var(--input-border-border-color-default)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:342",
+            "targetVariableName": "Color/Border/Default",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Border Color Hover": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Border/Brand"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2028:297",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-border-border-color-hover)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:345",
+            "targetVariableName": "Color/Border/Brand",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Border Color Active": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Border/Brand"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2028:298",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-border-border-color-active)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:345",
+            "targetVariableName": "Color/Border/Brand",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Border Color Focus": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Border/Brand"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2028:299",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-border-border-color-focus)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:345",
+            "targetVariableName": "Color/Border/Brand",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Border Size Default": {
+        "$type": "number",
+        "$value": {
+          "$ref": "Size/Border/100"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2028:306",
+          "com.figma.scopes": [
+            "STROKE_FLOAT"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-border-border-size-default)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:1:201",
+            "targetVariableName": "Size/Border/100",
+            "targetVariableSetId": "VariableCollectionId:1:200",
+            "targetVariableSetName": "Core (Primitives)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Border Size Hover": {
+        "$type": "number",
+        "$value": {
+          "$ref": "Size/Border/100"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2028:307",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-border-border-size-hover)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:1:201",
+            "targetVariableName": "Size/Border/100",
+            "targetVariableSetId": "VariableCollectionId:1:200",
+            "targetVariableSetName": "Core (Primitives)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Border Size Active": {
+        "$type": "number",
+        "$value": {
+          "$ref": "Size/Border/200"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2028:309",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-border-border-size-active)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:1:202",
+            "targetVariableName": "Size/Border/200",
+            "targetVariableSetId": "VariableCollectionId:1:200",
+            "targetVariableSetName": "Core (Primitives)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Border Radius": {
+        "$type": "number",
+        "$value": {
+          "$ref": "Brand/Corner/Input"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2028:310",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-border-border-radius)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2028:335",
+            "targetVariableName": "Brand/Corner/Input",
+            "targetVariableSetId": "VariableCollectionId:1:177",
+            "targetVariableSetName": "Themes (Brands)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Border Color Disabled": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Border/Disabled"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2028:331",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-border-border-color-disabled)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:346",
+            "targetVariableName": "Color/Border/Disabled",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Border Color Invalid": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Border/Danger"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2070:607",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-border-border-color-invalid)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:356",
+            "targetVariableName": "Color/Border/Danger",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Border Color Valid": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Border/Strong"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2070:608",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-border-border-color-valid)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:344",
+            "targetVariableName": "Color/Border/Strong",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
         }
       }
     },
@@ -1657,92 +1686,116 @@
         "com.figma.isOverride": true
       }
     },
-    "Border Size Default": {
-      "$type": "number",
-      "$value": {
-        "$ref": "Size/Border/100"
+    "Container": {
+      "Background Default": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Fill/Surface"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2028:318",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-container-background-default)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:329",
+            "targetVariableName": "Color/Fill/Surface",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
       },
-      "$extensions": {
-        "com.figma.variableId": "VariableID:2028:306",
-        "com.figma.scopes": [
-          "STROKE_FLOAT"
-        ],
-        "com.figma.codeSyntax": {
-          "WEB": "var(--input-border-size-default)"
+      "Background Hover": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Fill/Surface"
         },
-        "com.figma.aliasData": {
-          "targetVariableId": "VariableID:1:201",
-          "targetVariableName": "Size/Border/100",
-          "targetVariableSetId": "VariableCollectionId:1:200",
-          "targetVariableSetName": "Core (Primitives)"
-        },
-        "com.figma.isOverride": true
-      }
-    },
-    "Border Size Hover": {
-      "$type": "number",
-      "$value": {
-        "$ref": "Size/Border/100"
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2028:319",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-container-background-hover)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:329",
+            "targetVariableName": "Color/Fill/Surface",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
       },
-      "$extensions": {
-        "com.figma.variableId": "VariableID:2028:307",
-        "com.figma.scopes": [
-          "ALL_SCOPES"
-        ],
-        "com.figma.codeSyntax": {
-          "WEB": "var(--input-border-size-hover)"
+      "Background Focus": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Fill/Surface"
         },
-        "com.figma.aliasData": {
-          "targetVariableId": "VariableID:1:201",
-          "targetVariableName": "Size/Border/100",
-          "targetVariableSetId": "VariableCollectionId:1:200",
-          "targetVariableSetName": "Core (Primitives)"
-        },
-        "com.figma.isOverride": true
-      }
-    },
-    "Border Size Active": {
-      "$type": "number",
-      "$value": {
-        "$ref": "Size/Border/200"
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2028:320",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-container-background-focus)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:329",
+            "targetVariableName": "Color/Fill/Surface",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
       },
-      "$extensions": {
-        "com.figma.variableId": "VariableID:2028:309",
-        "com.figma.scopes": [
-          "ALL_SCOPES"
-        ],
-        "com.figma.codeSyntax": {
-          "WEB": "var(--input-border-size-active)"
+      "Background Active": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Fill/Surface"
         },
-        "com.figma.aliasData": {
-          "targetVariableId": "VariableID:1:202",
-          "targetVariableName": "Size/Border/200",
-          "targetVariableSetId": "VariableCollectionId:1:200",
-          "targetVariableSetName": "Core (Primitives)"
-        },
-        "com.figma.isOverride": true
-      }
-    },
-    "Border Radius": {
-      "$type": "number",
-      "$value": {
-        "$ref": "Brand/Corner/Input"
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2028:321",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-container-background-active)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:329",
+            "targetVariableName": "Color/Fill/Surface",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
       },
-      "$extensions": {
-        "com.figma.variableId": "VariableID:2028:310",
-        "com.figma.scopes": [
-          "ALL_SCOPES"
-        ],
-        "com.figma.codeSyntax": {
-          "WEB": "var(--input-border-radius)"
+      "Background Disabled": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Fill/Disabled"
         },
-        "com.figma.aliasData": {
-          "targetVariableId": "VariableID:2028:335",
-          "targetVariableName": "Brand/Corner/Input",
-          "targetVariableSetId": "VariableCollectionId:1:177",
-          "targetVariableSetName": "Themes (Brands)"
-        },
-        "com.figma.isOverride": true
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2028:332",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-container-background-disabled)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:330",
+            "targetVariableName": "Color/Fill/Disabled",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
       }
     },
     "Padding Inline": {
@@ -1833,72 +1886,6 @@
         "com.figma.isOverride": true
       }
     },
-    "Text Color Disabled": {
-      "$type": "color",
-      "$value": {
-        "$ref": "Color/Text/Disabled"
-      },
-      "$extensions": {
-        "com.figma.variableId": "VariableID:2028:330",
-        "com.figma.scopes": [
-          "ALL_SCOPES"
-        ],
-        "com.figma.codeSyntax": {
-          "WEB": "var(--input-text-color-disabled)"
-        },
-        "com.figma.aliasData": {
-          "targetVariableId": "VariableID:2007:328",
-          "targetVariableName": "Color/Text/Disabled",
-          "targetVariableSetId": "VariableCollectionId:2007:325",
-          "targetVariableSetName": "Appearance (Modes)"
-        },
-        "com.figma.isOverride": true
-      }
-    },
-    "Border Color Disabled": {
-      "$type": "color",
-      "$value": {
-        "$ref": "Color/Border/Disabled"
-      },
-      "$extensions": {
-        "com.figma.variableId": "VariableID:2028:331",
-        "com.figma.scopes": [
-          "ALL_SCOPES"
-        ],
-        "com.figma.codeSyntax": {
-          "WEB": "var(--input-border-color-disabled)"
-        },
-        "com.figma.aliasData": {
-          "targetVariableId": "VariableID:2007:346",
-          "targetVariableName": "Color/Border/Disabled",
-          "targetVariableSetId": "VariableCollectionId:2007:325",
-          "targetVariableSetName": "Appearance (Modes)"
-        },
-        "com.figma.isOverride": true
-      }
-    },
-    "Container Background Disabled": {
-      "$type": "color",
-      "$value": {
-        "$ref": "Color/Fill/Disabled"
-      },
-      "$extensions": {
-        "com.figma.variableId": "VariableID:2028:332",
-        "com.figma.scopes": [
-          "ALL_SCOPES"
-        ],
-        "com.figma.codeSyntax": {
-          "WEB": "var(--input-container-background-disabled)"
-        },
-        "com.figma.aliasData": {
-          "targetVariableId": "VariableID:2007:330",
-          "targetVariableName": "Color/Fill/Disabled",
-          "targetVariableSetId": "VariableCollectionId:2007:325",
-          "targetVariableSetName": "Appearance (Modes)"
-        },
-        "com.figma.isOverride": true
-      }
-    },
     "Overlay Hover": {
       "$type": "color",
       "$value": {
@@ -1956,705 +1943,16 @@
         }
       }
     },
-    "Checkbox": {
-      "Text Color Default": {
-        "$type": "color",
-        "$value": {
-          "$ref": "Color/Text/Default"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:2142:553",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--input-checkbox-text-color-default)"
-          },
-          "com.figma.aliasData": {
-            "targetVariableId": "VariableID:2007:326",
-            "targetVariableName": "Color/Text/Default",
-            "targetVariableSetId": "VariableCollectionId:2007:325",
-            "targetVariableSetName": "Appearance (Modes)"
-          },
-          "com.figma.isOverride": true
-        }
-      },
-      "Text Color Hover": {
-        "$type": "color",
-        "$value": {
-          "$ref": "Color/Text/Strong"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:2142:554",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--input-checkbox-text-color-hover)"
-          },
-          "com.figma.aliasData": {
-            "targetVariableId": "VariableID:2007:355",
-            "targetVariableName": "Color/Text/Strong",
-            "targetVariableSetId": "VariableCollectionId:2007:325",
-            "targetVariableSetName": "Appearance (Modes)"
-          },
-          "com.figma.isOverride": true
-        }
-      },
-      "Text Color Active": {
-        "$type": "color",
-        "$value": {
-          "$ref": "Color/Text/Inverse"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:2142:555",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--input-checkbox-text-color-active)"
-          },
-          "com.figma.aliasData": {
-            "targetVariableId": "VariableID:2007:327",
-            "targetVariableName": "Color/Text/Inverse",
-            "targetVariableSetId": "VariableCollectionId:2007:325",
-            "targetVariableSetName": "Appearance (Modes)"
-          },
-          "com.figma.isOverride": true
-        }
-      },
-      "Border": {
-        "Color Default": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Border/Subtle"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2142:556",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-checkbox-border-color-default)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:343",
-              "targetVariableName": "Color/Border/Subtle",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
-        },
-        "Color Hover": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Border/Strong"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2142:557",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-checkbox-border-color-hover)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:344",
-              "targetVariableName": "Color/Border/Strong",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
-        },
-        "Color Active": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Border/Brand"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2142:558",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-checkbox-border-color-active)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:345",
-              "targetVariableName": "Color/Border/Brand",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
-        },
-        "Color Focus": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Border/Brand"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2142:559",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-checkbox-border-color-focus)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:345",
-              "targetVariableName": "Color/Border/Brand",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
-        },
-        "Color Invalid": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Border/Danger"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2142:560",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-checkbox-border-color-invalid)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:356",
-              "targetVariableName": "Color/Border/Danger",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
-        },
-        "Color Valid": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Border/Strong"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2142:561",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-checkbox-border-color-valid)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:344",
-              "targetVariableName": "Color/Border/Strong",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
-        },
-        "Color Disabled": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Border/Disabled"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2281:720",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-checkbox-border-color-disabled)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:346",
-              "targetVariableName": "Color/Border/Disabled",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
-        }
-      },
-      "Container": {
-        "Background Default": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Fill/Surface"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2142:562",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-checkbox-container-background-default)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:329",
-              "targetVariableName": "Color/Fill/Surface",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
-        },
-        "Background Hover": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Fill/Surface"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2142:563",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-checkbox-container-background-hover)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:329",
-              "targetVariableName": "Color/Fill/Surface",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
-        },
-        "Background Focus": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Fill/Surface"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2142:564",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-checkbox-container-background-focus)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:329",
-              "targetVariableName": "Color/Fill/Surface",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
-        },
-        "Background Active": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Fill/Brand"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2142:565",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-checkbox-container-background-active)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:337",
-              "targetVariableName": "Color/Fill/Brand",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
-        },
-        "Background Disabled": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Fill/Disabled"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2281:719",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-checkbox-container-background-disabled)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2007:330",
-              "targetVariableName": "Color/Fill/Disabled",
-              "targetVariableSetId": "VariableCollectionId:2007:325",
-              "targetVariableSetName": "Appearance (Modes)"
-            },
-            "com.figma.isOverride": true
-          }
-        }
-      },
-      "Text Color Disabled": {
-        "$type": "color",
-        "$value": {
-          "$ref": "Color/Text/Disabled"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:2281:721",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--input-checkbox-text-color-disabled)"
-          },
-          "com.figma.aliasData": {
-            "targetVariableId": "VariableID:2007:328",
-            "targetVariableName": "Color/Text/Disabled",
-            "targetVariableSetId": "VariableCollectionId:2007:325",
-            "targetVariableSetName": "Appearance (Modes)"
-          },
-          "com.figma.isOverride": true
-        }
-      },
-      "Border Size Hover": {
-        "$type": "number",
-        "$value": {
-          "$ref": "Size/Border/200"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:2287:831",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-border-size-hover)"
-          },
-          "com.figma.aliasData": {
-            "targetVariableId": "VariableID:1:202",
-            "targetVariableName": "Size/Border/200",
-            "targetVariableSetId": "VariableCollectionId:1:200",
-            "targetVariableSetName": "Core (Primitives)"
-          },
-          "com.figma.isOverride": true
-        }
-      },
-      "Border Size Disabled": {
-        "$type": "number",
-        "$value": {
-          "$ref": "Size/Border/000"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:2287:832",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-border-size-disabled)"
-          },
-          "com.figma.aliasData": {
-            "targetVariableId": "VariableID:1:212",
-            "targetVariableName": "Size/Border/000",
-            "targetVariableSetId": "VariableCollectionId:1:200",
-            "targetVariableSetName": "Core (Primitives)"
-          },
-          "com.figma.isOverride": true
-        }
-      },
-      "Border Size Default": {
-        "$type": "number",
-        "$value": {
-          "$ref": "Size/Border/100"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:2287:833",
-          "com.figma.scopes": [
-            "STROKE_FLOAT"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-border-size-default)"
-          },
-          "com.figma.aliasData": {
-            "targetVariableId": "VariableID:1:201",
-            "targetVariableName": "Size/Border/100",
-            "targetVariableSetId": "VariableCollectionId:1:200",
-            "targetVariableSetName": "Core (Primitives)"
-          },
-          "com.figma.isOverride": true
-        }
-      }
-    },
-    "Radio": {
-      "Text Color Default": {
-        "$type": "color",
-        "$value": {
-          "$ref": "Color/Text/Default"
-        },
-        "$extensions": {
-          "com.figma.scopes": ["ALL_SCOPES"],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--input-radio-text-color-default)"
-          },
-          "com.figma.aliasData": {
-            "targetVariableName": "Color/Text/Default",
-            "targetVariableSetName": "Appearance (Modes)"
-          }
-        }
-      },
-      "Text Color Hover": {
-        "$type": "color",
-        "$value": {
-          "$ref": "Color/Text/Strong"
-        },
-        "$extensions": {
-          "com.figma.scopes": ["ALL_SCOPES"],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--input-radio-text-color-hover)"
-          },
-          "com.figma.aliasData": {
-            "targetVariableName": "Color/Text/Strong",
-            "targetVariableSetName": "Appearance (Modes)"
-          }
-        }
-      },
-      "Text Color Active": {
-        "$type": "color",
-        "$value": {
-          "$ref": "Color/Text/Inverse"
-        },
-        "$extensions": {
-          "com.figma.scopes": ["ALL_SCOPES"],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--input-radio-text-color-active)"
-          },
-          "com.figma.aliasData": {
-            "targetVariableName": "Color/Text/Inverse",
-            "targetVariableSetName": "Appearance (Modes)"
-          }
-        }
-      },
-      "Text Color Disabled": {
-        "$type": "color",
-        "$value": {
-          "$ref": "Color/Text/Disabled"
-        },
-        "$extensions": {
-          "com.figma.scopes": ["ALL_SCOPES"],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--input-radio-text-color-disabled)"
-          },
-          "com.figma.aliasData": {
-            "targetVariableName": "Color/Text/Disabled",
-            "targetVariableSetName": "Appearance (Modes)"
-          }
-        }
-      },
-      "Border": {
-        "Color Default": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Border/Subtle"
-          },
-          "$extensions": {
-            "com.figma.scopes": ["ALL_SCOPES"],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-radio-border-color-default)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableName": "Color/Border/Subtle",
-              "targetVariableSetName": "Appearance (Modes)"
-            }
-          }
-        },
-        "Color Hover": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Border/Strong"
-          },
-          "$extensions": {
-            "com.figma.scopes": ["ALL_SCOPES"],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-radio-border-color-hover)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableName": "Color/Border/Strong",
-              "targetVariableSetName": "Appearance (Modes)"
-            }
-          }
-        },
-        "Color Active": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Border/Brand"
-          },
-          "$extensions": {
-            "com.figma.scopes": ["ALL_SCOPES"],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-radio-border-color-active)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableName": "Color/Border/Brand",
-              "targetVariableSetName": "Appearance (Modes)"
-            }
-          }
-        },
-        "Color Focus": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Border/Brand"
-          },
-          "$extensions": {
-            "com.figma.scopes": ["ALL_SCOPES"],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-radio-border-color-focus)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableName": "Color/Border/Brand",
-              "targetVariableSetName": "Appearance (Modes)"
-            }
-          }
-        },
-        "Color Disabled": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Border/Disabled"
-          },
-          "$extensions": {
-            "com.figma.scopes": ["ALL_SCOPES"],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-radio-border-color-disabled)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableName": "Color/Border/Disabled",
-              "targetVariableSetName": "Appearance (Modes)"
-            }
-          }
-        }
-      },
-      "Container": {
-        "Background Default": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Fill/Surface"
-          },
-          "$extensions": {
-            "com.figma.scopes": ["ALL_SCOPES"],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-radio-container-background-default)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableName": "Color/Fill/Surface",
-              "targetVariableSetName": "Appearance (Modes)"
-            }
-          }
-        },
-        "Background Hover": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Fill/Surface"
-          },
-          "$extensions": {
-            "com.figma.scopes": ["ALL_SCOPES"],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-radio-container-background-hover)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableName": "Color/Fill/Surface",
-              "targetVariableSetName": "Appearance (Modes)"
-            }
-          }
-        },
-        "Background Focus": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Fill/Surface"
-          },
-          "$extensions": {
-            "com.figma.scopes": ["ALL_SCOPES"],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-radio-container-background-focus)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableName": "Color/Fill/Surface",
-              "targetVariableSetName": "Appearance (Modes)"
-            }
-          }
-        },
-        "Background Active": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Fill/Brand"
-          },
-          "$extensions": {
-            "com.figma.scopes": ["ALL_SCOPES"],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-radio-container-background-active)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableName": "Color/Fill/Brand",
-              "targetVariableSetName": "Appearance (Modes)"
-            }
-          }
-        },
-        "Background Disabled": {
-          "$type": "color",
-          "$value": {
-            "$ref": "Color/Fill/Disabled"
-          },
-          "$extensions": {
-            "com.figma.scopes": ["ALL_SCOPES"],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--input-radio-container-background-disabled)"
-            },
-            "com.figma.aliasData": {
-              "targetVariableName": "Color/Fill/Disabled",
-              "targetVariableSetName": "Appearance (Modes)"
-            }
-          }
-        }
-      },
-      "Border Size Default": {
-        "$type": "number",
-        "$value": {
-          "$ref": "Size/Border/100"
-        },
-        "$extensions": {
-          "com.figma.scopes": ["STROKE_FLOAT"],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--radio-border-size-default)"
-          },
-          "com.figma.aliasData": {
-            "targetVariableName": "Size/Border/100",
-            "targetVariableSetName": "Core (Primitives)"
-          }
-        }
-      },
-      "Border Size Hover": {
-        "$type": "number",
-        "$value": {
-          "$ref": "Size/Border/200"
-        },
-        "$extensions": {
-          "com.figma.scopes": ["ALL_SCOPES"],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--radio-border-size-hover)"
-          },
-          "com.figma.aliasData": {
-            "targetVariableName": "Size/Border/200",
-            "targetVariableSetName": "Core (Primitives)"
-          }
-        }
-      },
-      "Border Size Disabled": {
-        "$type": "number",
-        "$value": {
-          "$ref": "Size/Border/000"
-        },
-        "$extensions": {
-          "com.figma.scopes": ["ALL_SCOPES"],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--radio-border-size-disabled)"
-          },
-          "com.figma.aliasData": {
-            "targetVariableName": "Size/Border/000",
-            "targetVariableSetName": "Core (Primitives)"
-          }
+    "Height Min": {
+      "$type": "number",
+      "$value": 40,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2228:321",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--input-height-min)"
         }
       }
     }
@@ -2929,76 +2227,1132 @@
       }
     }
   },
+  "Checkbox": {
+    "Text Color Default": {
+      "$type": "color",
+      "$value": {
+        "$ref": "Color/Text/Default"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2142:553",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--checkbox-text-color-default)"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:2007:326",
+          "targetVariableName": "Color/Text/Default",
+          "targetVariableSetId": "VariableCollectionId:2007:325",
+          "targetVariableSetName": "Appearance (Modes)"
+        },
+        "com.figma.isOverride": true
+      }
+    },
+    "Text Color Hover": {
+      "$type": "color",
+      "$value": {
+        "$ref": "Color/Text/Strong"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2142:554",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--checkbox-text-color-hover)"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:2007:355",
+          "targetVariableName": "Color/Text/Strong",
+          "targetVariableSetId": "VariableCollectionId:2007:325",
+          "targetVariableSetName": "Appearance (Modes)"
+        },
+        "com.figma.isOverride": true
+      }
+    },
+    "Text Color Active": {
+      "$type": "color",
+      "$value": {
+        "$ref": "Color/Text/Inverse"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2142:555",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--checkbox-text-color-active)"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:2007:327",
+          "targetVariableName": "Color/Text/Inverse",
+          "targetVariableSetId": "VariableCollectionId:2007:325",
+          "targetVariableSetName": "Appearance (Modes)"
+        },
+        "com.figma.isOverride": true
+      }
+    },
+    "Border": {
+      "Color Default": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Border/Subtle"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2142:556",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--checkbox-border-color-default)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:343",
+            "targetVariableName": "Color/Border/Subtle",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Color Hover": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Border/Strong"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2142:557",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--checkbox-border-color-hover)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:344",
+            "targetVariableName": "Color/Border/Strong",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Color Active": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Border/Brand"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2142:558",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--checkbox-border-color-active)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:345",
+            "targetVariableName": "Color/Border/Brand",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Color Focus": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Border/Brand"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2142:559",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--checkbox-border-color-focus)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:345",
+            "targetVariableName": "Color/Border/Brand",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Color Invalid": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Border/Danger"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2142:560",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--checkbox-border-color-invalid)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:356",
+            "targetVariableName": "Color/Border/Danger",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Color Valid": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Border/Strong"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2142:561",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--checkbox-border-color-valid)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:344",
+            "targetVariableName": "Color/Border/Strong",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Color Disabled": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Border/Disabled"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2281:720",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--checkbox-border-color-disabled)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:346",
+            "targetVariableName": "Color/Border/Disabled",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Size Hover": {
+        "$type": "number",
+        "$value": {
+          "$ref": "Size/Border/200"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2287:831",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--checkbox-border-size-hover)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:1:202",
+            "targetVariableName": "Size/Border/200",
+            "targetVariableSetId": "VariableCollectionId:1:200",
+            "targetVariableSetName": "Core (Primitives)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Size Disabled": {
+        "$type": "number",
+        "$value": {
+          "$ref": "Size/Border/000"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2287:832",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--checkbox-border-size-disabled)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:1:212",
+            "targetVariableName": "Size/Border/000",
+            "targetVariableSetId": "VariableCollectionId:1:200",
+            "targetVariableSetName": "Core (Primitives)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Size Default": {
+        "$type": "number",
+        "$value": {
+          "$ref": "Size/Border/100"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2287:833",
+          "com.figma.scopes": [
+            "STROKE_FLOAT"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--checkbox-border-size-default)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:1:201",
+            "targetVariableName": "Size/Border/100",
+            "targetVariableSetId": "VariableCollectionId:1:200",
+            "targetVariableSetName": "Core (Primitives)"
+          },
+          "com.figma.isOverride": true
+        }
+      }
+    },
+    "Container": {
+      "Background Default": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Fill/Surface"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2142:562",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--checkbox-container-background-default)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:329",
+            "targetVariableName": "Color/Fill/Surface",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Background Hover": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Fill/Surface"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2142:563",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--checkbox-container-background-hover)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:329",
+            "targetVariableName": "Color/Fill/Surface",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Background Focus": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Fill/Surface"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2142:564",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--checkbox-container-background-focus)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:329",
+            "targetVariableName": "Color/Fill/Surface",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Background Active": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Fill/Brand"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2142:565",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--checkbox-container-background-active)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:337",
+            "targetVariableName": "Color/Fill/Brand",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Background Disabled": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Fill/Disabled"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2281:719",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--checkbox-container-background-disabled)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:330",
+            "targetVariableName": "Color/Fill/Disabled",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      }
+    },
+    "Text Color Disabled": {
+      "$type": "color",
+      "$value": {
+        "$ref": "Color/Text/Disabled"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2281:721",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--checkbox-text-color-disabled)"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:2007:328",
+          "targetVariableName": "Color/Text/Disabled",
+          "targetVariableSetId": "VariableCollectionId:2007:325",
+          "targetVariableSetName": "Appearance (Modes)"
+        },
+        "com.figma.isOverride": true
+      }
+    }
+  },
+  "Radio": {
+    "Text Color Default": {
+      "$type": "color",
+      "$value": {
+        "$ref": "Color/Text/Default"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2327:2",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--input-radio-text-color-default)"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:2007:326",
+          "targetVariableName": "Color/Text/Default",
+          "targetVariableSetId": "VariableCollectionId:2007:325",
+          "targetVariableSetName": "Appearance (Modes)"
+        },
+        "com.figma.isOverride": true
+      }
+    },
+    "Text Color Disabled": {
+      "$type": "color",
+      "$value": {
+        "$ref": "Color/Text/Disabled"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2327:3",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--input-radio-text-color-disabled)"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:2007:328",
+          "targetVariableName": "Color/Text/Disabled",
+          "targetVariableSetId": "VariableCollectionId:2007:325",
+          "targetVariableSetName": "Appearance (Modes)"
+        },
+        "com.figma.isOverride": true
+      }
+    },
+    "Border": {
+      "Color Default": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Border/Subtle"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2327:4",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-radio-border-color-default)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:343",
+            "targetVariableName": "Color/Border/Subtle",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Color Hover": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Border/Strong"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2327:5",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-radio-border-color-hover)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:344",
+            "targetVariableName": "Color/Border/Strong",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Color Active": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Border/Brand"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2327:6",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-radio-border-color-active)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:345",
+            "targetVariableName": "Color/Border/Brand",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Color Disabled": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Border/Disabled"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2327:7",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-radio-border-color-disabled)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:346",
+            "targetVariableName": "Color/Border/Disabled",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      }
+    },
+    "Container": {
+      "Background Default": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Fill/Surface"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2327:8",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-radio-container-background-default)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:329",
+            "targetVariableName": "Color/Fill/Surface",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Background Disabled": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Fill/Disabled"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2327:9",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--input-radio-container-background-disabled)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:330",
+            "targetVariableName": "Color/Fill/Disabled",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      }
+    },
+    "Border Size Default": {
+      "$type": "number",
+      "$value": {
+        "$ref": "Size/Border/100"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2327:10",
+        "com.figma.scopes": [
+          "STROKE_FLOAT"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--radio-border-size-default)"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:1:201",
+          "targetVariableName": "Size/Border/100",
+          "targetVariableSetId": "VariableCollectionId:1:200",
+          "targetVariableSetName": "Core (Primitives)"
+        },
+        "com.figma.isOverride": true
+      }
+    },
+    "Border Size Hover": {
+      "$type": "number",
+      "$value": {
+        "$ref": "Size/Border/200"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2327:11",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--radio-border-size-hover)"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:1:202",
+          "targetVariableName": "Size/Border/200",
+          "targetVariableSetId": "VariableCollectionId:1:200",
+          "targetVariableSetName": "Core (Primitives)"
+        },
+        "com.figma.isOverride": true
+      }
+    },
+    "Border Size Disabled": {
+      "$type": "number",
+      "$value": {
+        "$ref": "Size/Border/000"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2327:12",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--radio-border-size-disabled)"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:1:212",
+          "targetVariableName": "Size/Border/000",
+          "targetVariableSetId": "VariableCollectionId:1:200",
+          "targetVariableSetName": "Core (Primitives)"
+        },
+        "com.figma.isOverride": true
+      }
+    }
+  },
   "Badge": {
     "Default": {
+      "Text Color": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Text/Default"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2385:1160",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--badge-default-text-color)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:326",
+            "targetVariableName": "Color/Text/Default",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Border Color": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Transparent"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2385:1163",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--badge-default-border-color)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2006:195",
+            "targetVariableName": "Color/Transparent",
+            "targetVariableSetId": "VariableCollectionId:1:200",
+            "targetVariableSetName": "Core (Primitives)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
       "Container": {
         "Background": {
           "$type": "color",
-          "$value": { "$ref": "Color/Fill/Subtle" },
+          "$value": {
+            "$ref": "Color/Fill/Subtle"
+          },
           "$extensions": {
-            "com.figma.variableId": "VariableID:badge:1",
-            "com.figma.scopes": ["ALL_SCOPES"],
-            "com.figma.codeSyntax": { "WEB": "var(--badge-default-container-background)" },
+            "com.figma.variableId": "VariableID:2385:1189",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "var(--badge-default-container-background)"
+            },
+            "com.figma.aliasData": {
+              "targetVariableId": "VariableID:2007:338",
+              "targetVariableName": "Color/Fill/Subtle",
+              "targetVariableSetId": "VariableCollectionId:2007:325",
+              "targetVariableSetName": "Appearance (Modes)"
+            },
             "com.figma.isOverride": true
           }
-        }
-      },
-      "Text Color": {
-        "$type": "color",
-        "$value": { "$ref": "Color/Text/Default" },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:badge:2",
-          "com.figma.scopes": ["ALL_SCOPES"],
-          "com.figma.codeSyntax": { "WEB": "var(--badge-default-text-color)" },
-          "com.figma.isOverride": true
         }
       }
     },
     "Brand": {
+      "Text Color": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Text/Inverse"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2385:1164",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--badge-brand-text-color)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:327",
+            "targetVariableName": "Color/Text/Inverse",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Border Color": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Transparent"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2385:1170",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--badge-brand-border-color)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2006:195",
+            "targetVariableName": "Color/Transparent",
+            "targetVariableSetId": "VariableCollectionId:1:200",
+            "targetVariableSetName": "Core (Primitives)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
       "Container": {
         "Background": {
           "$type": "color",
-          "$value": { "$ref": "Color/Fill/Brand" },
+          "$value": {
+            "$ref": "Color/Fill/Brand"
+          },
           "$extensions": {
-            "com.figma.variableId": "VariableID:badge:3",
-            "com.figma.scopes": ["ALL_SCOPES"],
-            "com.figma.codeSyntax": { "WEB": "var(--badge-brand-container-background)" },
+            "com.figma.variableId": "VariableID:2385:1193",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "var(--badge-brand-container-background)"
+            },
+            "com.figma.aliasData": {
+              "targetVariableId": "VariableID:2007:337",
+              "targetVariableName": "Color/Fill/Brand",
+              "targetVariableSetId": "VariableCollectionId:2007:325",
+              "targetVariableSetName": "Appearance (Modes)"
+            },
             "com.figma.isOverride": true
           }
-        }
-      },
-      "Text Color": {
-        "$type": "color",
-        "$value": { "$ref": "Color/Text/Inverse" },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:badge:4",
-          "com.figma.scopes": ["ALL_SCOPES"],
-          "com.figma.codeSyntax": { "WEB": "var(--badge-brand-text-color)" },
-          "com.figma.isOverride": true
         }
       }
     },
     "Success": {
+      "Text Color": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Text/Inverse"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2385:1172",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--badge-success-text-color)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:327",
+            "targetVariableName": "Color/Text/Inverse",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Border Color": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Transparent"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2385:1183",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--badge-success-border-color)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2006:195",
+            "targetVariableName": "Color/Transparent",
+            "targetVariableSetId": "VariableCollectionId:1:200",
+            "targetVariableSetName": "Core (Primitives)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
       "Container": {
         "Background": {
           "$type": "color",
-          "$value": { "$ref": "Color/Fill/Success" },
+          "$value": {
+            "$ref": "Color/Fill/Success"
+          },
           "$extensions": {
-            "com.figma.variableId": "VariableID:badge:5",
-            "com.figma.scopes": ["ALL_SCOPES"],
-            "com.figma.codeSyntax": { "WEB": "var(--badge-success-container-background)" },
+            "com.figma.variableId": "VariableID:2385:1197",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "var(--badge-success-container-background)"
+            },
+            "com.figma.aliasData": {
+              "targetVariableId": "VariableID:2007:376",
+              "targetVariableName": "Color/Fill/Success",
+              "targetVariableSetId": "VariableCollectionId:2007:325",
+              "targetVariableSetName": "Appearance (Modes)"
+            },
             "com.figma.isOverride": true
           }
         }
+      }
+    },
+    "Font Family": {
+      "$type": "string",
+      "$value": {
+        "$ref": "Brand/Font/Lead"
       },
-      "Text Color": {
-        "$type": "color",
-        "$value": { "$ref": "Color/Text/Inverse" },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:badge:6",
-          "com.figma.scopes": ["ALL_SCOPES"],
-          "com.figma.codeSyntax": { "WEB": "var(--badge-success-text-color)" },
-          "com.figma.isOverride": true
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2385:1175",
+        "com.figma.scopes": [
+          "FONT_FAMILY"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--badge-font-family)"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:2006:214",
+          "targetVariableName": "Brand/Font/Lead",
+          "targetVariableSetId": "VariableCollectionId:1:177",
+          "targetVariableSetName": "Themes (Brands)"
+        },
+        "com.figma.isOverride": true
+      }
+    },
+    "Font Weight": {
+      "$type": "string",
+      "$value": {
+        "$ref": "Typography/Label/Font Weight"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2385:1178",
+        "com.figma.scopes": [
+          "FONT_STYLE"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--badge-font-weight)"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:15:36",
+          "targetVariableName": "Typography/Label/Font Weight",
+          "targetVariableSetId": "VariableCollectionId:1:252",
+          "targetVariableSetName": "Semantics (Roles)"
+        },
+        "com.figma.isOverride": true
+      }
+    },
+    "Font Size": {
+      "$type": "number",
+      "$value": {
+        "$ref": "Typography/Label/Font Size"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2385:1179",
+        "com.figma.scopes": [
+          "FONT_SIZE"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--badge-font-size)"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:15:37",
+          "targetVariableName": "Typography/Label/Font Size",
+          "targetVariableSetId": "VariableCollectionId:1:252",
+          "targetVariableSetName": "Semantics (Roles)"
+        },
+        "com.figma.isOverride": true
+      }
+    },
+    "Line Height": {
+      "$type": "number",
+      "$value": {
+        "$ref": "Typography/Label/Line Height"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2385:1180",
+        "com.figma.scopes": [
+          "LINE_HEIGHT"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--badge-line-height)"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:15:38",
+          "targetVariableName": "Typography/Label/Line Height",
+          "targetVariableSetId": "VariableCollectionId:1:252",
+          "targetVariableSetName": "Semantics (Roles)"
+        },
+        "com.figma.isOverride": true
+      }
+    },
+    "Border Size Default": {
+      "$type": "number",
+      "$value": {
+        "$ref": "Size/Border/100"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2385:1181",
+        "com.figma.scopes": [
+          "STROKE_FLOAT"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--badge-border-size-default)"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:1:201",
+          "targetVariableName": "Size/Border/100",
+          "targetVariableSetId": "VariableCollectionId:1:200",
+          "targetVariableSetName": "Core (Primitives)"
+        },
+        "com.figma.isOverride": true
+      }
+    },
+    "Border Radius": {
+      "$type": "number",
+      "$value": {
+        "$ref": "Brand/Corner/Input"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2385:1186",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--badge-border-radius)"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:2028:335",
+          "targetVariableName": "Brand/Corner/Input",
+          "targetVariableSetId": "VariableCollectionId:1:177",
+          "targetVariableSetName": "Themes (Brands)"
+        },
+        "com.figma.isOverride": true
+      }
+    },
+    "Padding Inline": {
+      "$type": "number",
+      "$value": {
+        "$ref": "Size/Spacing/400"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2385:1201",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--badge-padding-inline)"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:1:232",
+          "targetVariableName": "Size/Spacing/400",
+          "targetVariableSetId": "VariableCollectionId:1:200",
+          "targetVariableSetName": "Core (Primitives)"
+        },
+        "com.figma.isOverride": true
+      }
+    },
+    "Padding Inline Icon Only": {
+      "$type": "number",
+      "$value": {
+        "$ref": "Size/Spacing/200"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2385:1202",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--badge-padding-inline-icon-only)"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:1:230",
+          "targetVariableName": "Size/Spacing/200",
+          "targetVariableSetId": "VariableCollectionId:1:200",
+          "targetVariableSetName": "Core (Primitives)"
+        },
+        "com.figma.isOverride": true
+      }
+    },
+    "Padding Block": {
+      "$type": "number",
+      "$value": {
+        "$ref": "Size/Spacing/200"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2385:1203",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--badge-padding-block)"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:1:230",
+          "targetVariableName": "Size/Spacing/200",
+          "targetVariableSetId": "VariableCollectionId:1:200",
+          "targetVariableSetName": "Core (Primitives)"
+        },
+        "com.figma.isOverride": true
+      }
+    },
+    "Gap": {
+      "$type": "number",
+      "$value": {
+        "$ref": "Size/Spacing/200"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2385:1204",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--badge-gap)"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:1:230",
+          "targetVariableName": "Size/Spacing/200",
+          "targetVariableSetId": "VariableCollectionId:1:200",
+          "targetVariableSetName": "Core (Primitives)"
+        },
+        "com.figma.isOverride": true
+      }
+    },
+    "Height Min": {
+      "$type": "number",
+      "$value": 40,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2385:1211",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--badge-height-min)"
+        }
+      }
+    },
+    "Width Min": {
+      "$type": "number",
+      "$value": 40,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:2385:1212",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "var(--badge-width-min)"
         }
       }
     },
@@ -3006,144 +3360,70 @@
       "Container": {
         "Background": {
           "$type": "color",
-          "$value": { "$ref": "Color/Fill/Danger" },
+          "$value": {
+            "$ref": "Color/Fill/Danger"
+          },
           "$extensions": {
-            "com.figma.variableId": "VariableID:badge:7",
-            "com.figma.scopes": ["ALL_SCOPES"],
-            "com.figma.codeSyntax": { "WEB": "var(--badge-danger-container-background)" },
+            "com.figma.variableId": "VariableID:2467:2",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "var(--badge-danger-container-background)"
+            },
+            "com.figma.aliasData": {
+              "targetVariableId": "VariableID:2007:357",
+              "targetVariableName": "Color/Fill/Danger",
+              "targetVariableSetId": "VariableCollectionId:2007:325",
+              "targetVariableSetName": "Appearance (Modes)"
+            },
+            "com.figma.isOverride": true
+          }
+        },
+        "Border Color": {
+          "$type": "color",
+          "$value": {
+            "$ref": "Color/Transparent"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2458:614",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "var(--badge-danger-border-color)"
+            },
+            "com.figma.aliasData": {
+              "targetVariableId": "VariableID:2006:195",
+              "targetVariableName": "Color/Transparent",
+              "targetVariableSetId": "VariableCollectionId:1:200",
+              "targetVariableSetName": "Core (Primitives)"
+            },
             "com.figma.isOverride": true
           }
         }
       },
       "Text Color": {
         "$type": "color",
-        "$value": { "$ref": "Color/Text/Inverse" },
+        "$value": {
+          "$ref": "Color/Text/Inverse"
+        },
         "$extensions": {
-          "com.figma.variableId": "VariableID:badge:8",
-          "com.figma.scopes": ["ALL_SCOPES"],
-          "com.figma.codeSyntax": { "WEB": "var(--badge-danger-text-color)" },
+          "com.figma.variableId": "VariableID:2467:3",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--badge-danger-text-color)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2007:327",
+            "targetVariableName": "Color/Text/Inverse",
+            "targetVariableSetId": "VariableCollectionId:2007:325",
+            "targetVariableSetName": "Appearance (Modes)"
+          },
           "com.figma.isOverride": true
         }
-      }
-    },
-    "Border Radius": {
-      "$type": "number",
-      "$value": { "$ref": "Size/Radius/Full" },
-      "$extensions": {
-        "com.figma.variableId": "VariableID:badge:9",
-        "com.figma.scopes": ["CORNER_RADIUS"],
-        "com.figma.codeSyntax": { "WEB": "var(--badge-border-radius)" },
-        "com.figma.isOverride": true
-      }
-    },
-    "Font Family": {
-      "$type": "string",
-      "$value": { "$ref": "Typography/Label/Font Family" },
-      "$extensions": {
-        "com.figma.variableId": "VariableID:badge:10",
-        "com.figma.scopes": ["FONT_FAMILY"],
-        "com.figma.codeSyntax": { "WEB": "var(--badge-font-family)" },
-        "com.figma.isOverride": true
-      }
-    },
-    "Font Weight": {
-      "$type": "string",
-      "$value": { "$ref": "Font/Weight/700" },
-      "$extensions": {
-        "com.figma.variableId": "VariableID:badge:11",
-        "com.figma.scopes": ["FONT_STYLE"],
-        "com.figma.codeSyntax": { "WEB": "var(--badge-font-weight)" },
-        "com.figma.isOverride": true
-      }
-    },
-    "Font Size Sm": {
-      "$type": "number",
-      "$value": { "$ref": "Font/Size/xs" },
-      "$extensions": {
-        "com.figma.variableId": "VariableID:badge:12",
-        "com.figma.scopes": ["FONT_SIZE"],
-        "com.figma.codeSyntax": { "WEB": "var(--badge-font-size-sm)" },
-        "com.figma.isOverride": true
-      }
-    },
-    "Font Size Md": {
-      "$type": "number",
-      "$value": { "$ref": "Font/Size/sm" },
-      "$extensions": {
-        "com.figma.variableId": "VariableID:badge:13",
-        "com.figma.scopes": ["FONT_SIZE"],
-        "com.figma.codeSyntax": { "WEB": "var(--badge-font-size-md)" },
-        "com.figma.isOverride": true
-      }
-    },
-    "Line Height Sm": {
-      "$type": "number",
-      "$value": { "$ref": "Line Height/xs" },
-      "$extensions": {
-        "com.figma.variableId": "VariableID:badge:14",
-        "com.figma.scopes": ["LINE_HEIGHT"],
-        "com.figma.codeSyntax": { "WEB": "var(--badge-line-height-sm)" },
-        "com.figma.isOverride": true
-      }
-    },
-    "Line Height Md": {
-      "$type": "number",
-      "$value": { "$ref": "Line Height/sm" },
-      "$extensions": {
-        "com.figma.variableId": "VariableID:badge:15",
-        "com.figma.scopes": ["LINE_HEIGHT"],
-        "com.figma.codeSyntax": { "WEB": "var(--badge-line-height-md)" },
-        "com.figma.isOverride": true
-      }
-    },
-    "Padding Inline Sm": {
-      "$type": "number",
-      "$value": { "$ref": "Size/Spacing/200" },
-      "$extensions": {
-        "com.figma.variableId": "VariableID:badge:16",
-        "com.figma.scopes": ["GAP"],
-        "com.figma.codeSyntax": { "WEB": "var(--badge-padding-inline-sm)" },
-        "com.figma.isOverride": true
-      }
-    },
-    "Padding Inline Md": {
-      "$type": "number",
-      "$value": { "$ref": "Size/Spacing/300" },
-      "$extensions": {
-        "com.figma.variableId": "VariableID:badge:17",
-        "com.figma.scopes": ["GAP"],
-        "com.figma.codeSyntax": { "WEB": "var(--badge-padding-inline-md)" },
-        "com.figma.isOverride": true
-      }
-    },
-    "Padding Block Sm": {
-      "$type": "number",
-      "$value": { "$ref": "Size/Spacing/000" },
-      "$extensions": {
-        "com.figma.variableId": "VariableID:badge:18",
-        "com.figma.scopes": ["GAP"],
-        "com.figma.codeSyntax": { "WEB": "var(--badge-padding-block-sm)" },
-        "com.figma.isOverride": true
-      }
-    },
-    "Padding Block Md": {
-      "$type": "number",
-      "$value": { "$ref": "Size/Spacing/100" },
-      "$extensions": {
-        "com.figma.variableId": "VariableID:badge:19",
-        "com.figma.scopes": ["GAP"],
-        "com.figma.codeSyntax": { "WEB": "var(--badge-padding-block-md)" },
-        "com.figma.isOverride": true
-      }
-    },
-    "Gap": {
-      "$type": "number",
-      "$value": { "$ref": "Size/Spacing/100" },
-      "$extensions": {
-        "com.figma.variableId": "VariableID:badge:20",
-        "com.figma.scopes": ["GAP"],
-        "com.figma.codeSyntax": { "WEB": "var(--badge-gap)" },
-        "com.figma.isOverride": true
       }
     }
   }

--- a/figma/exports/Core (Primitives).tokens.json
+++ b/figma/exports/Core (Primitives).tokens.json
@@ -2937,6 +2937,1364 @@
           }
         }
       }
+    },
+    "Brand C": {
+      "Blue": {
+        "10": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.10588235408067703,
+              0.06666667014360428,
+              0.3607843220233917
+            ],
+            "alpha": 1,
+            "hex": "#1B115C"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:2",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-blue-10"
+            }
+          }
+        },
+        "20": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.028235292062163353,
+              0.1764705926179886,
+              0.5717647075653076
+            ],
+            "alpha": 1,
+            "hex": "#072D92"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:3",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-blue-20"
+            }
+          }
+        },
+        "30": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.03921568766236305,
+              0.23529411852359772,
+              0.7607843279838562
+            ],
+            "alpha": 1,
+            "hex": "#0A3CC2"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:4",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-blue-30"
+            }
+          }
+        },
+        "40": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.0470588244497776,
+              0.29411765933036804,
+              0.9529411792755127
+            ],
+            "alpha": 1,
+            "hex": "#0C4BF3"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:5",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-blue-40"
+            }
+          }
+        },
+        "50": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.2078431397676468,
+              0.40392157435417175,
+              0.9647058844566345
+            ],
+            "alpha": 1,
+            "hex": "#3567F6"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:6",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-blue-50"
+            }
+          }
+        },
+        "60": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.4282352924346924,
+              0.5764706134796143,
+              0.9717646837234497
+            ],
+            "alpha": 1,
+            "hex": "#6D93F8"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:7",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-blue-60"
+            }
+          }
+        },
+        "70": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.5803921818733215,
+              0.6901960968971252,
+              0.9803921580314636
+            ],
+            "alpha": 1,
+            "hex": "#94B0FA"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:8",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-blue-70"
+            }
+          }
+        },
+        "80": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.7137255072593689,
+              0.7843137383460999,
+              0.9882352948188782
+            ],
+            "alpha": 1,
+            "hex": "#B6C8FC"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:9",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-blue-80"
+            }
+          }
+        },
+        "90": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.8470588326454163,
+              0.886274516582489,
+              0.9921568632125854
+            ],
+            "alpha": 1,
+            "hex": "#D8E2FD"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:10",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-blue-90"
+            }
+          }
+        },
+        "100": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.10588235408067703,
+              0.06666667014360428,
+              0.3607843220233917
+            ],
+            "alpha": 1,
+            "hex": "#1B115C"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2435:780",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-blue-100"
+            }
+          }
+        }
+      },
+      "Coolblue": {
+        "10": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.019607843831181526,
+              0.2666666805744171,
+              0.3803921639919281
+            ],
+            "alpha": 1,
+            "hex": "#054461"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:11",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-coolblue-10"
+            }
+          }
+        },
+        "20": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.027450980618596077,
+              0.4000000059604645,
+              0.572549045085907
+            ],
+            "alpha": 1,
+            "hex": "#076692"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:12",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-coolblue-20"
+            }
+          }
+        },
+        "30": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.03921568766236305,
+              0.5333333611488342,
+              0.7607843279838562
+            ],
+            "alpha": 1,
+            "hex": "#0A88C2"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:13",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-coolblue-30"
+            }
+          }
+        },
+        "40": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.0470588244497776,
+              0.6666666865348816,
+              0.9529411792755127
+            ],
+            "alpha": 1,
+            "hex": "#0CAAF3"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:14",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-coolblue-40"
+            }
+          }
+        },
+        "50": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.21960784494876862,
+              0.7254902124404907,
+              0.9607843160629272
+            ],
+            "alpha": 1,
+            "hex": "#38B9F5"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:15",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-coolblue-50"
+            }
+          }
+        },
+        "60": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.43921568989753723,
+              0.7960784435272217,
+              0.95686274766922
+            ],
+            "alpha": 1,
+            "hex": "#70CBF4"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:16",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-coolblue-60"
+            }
+          }
+        },
+        "70": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.6627451181411743,
+              0.8745098114013672,
+              0.9725490212440491
+            ],
+            "alpha": 1,
+            "hex": "#A9DFF8"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:17",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-coolblue-70"
+            }
+          }
+        },
+        "80": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.7764706015586853,
+              0.9176470637321472,
+              0.9843137264251709
+            ],
+            "alpha": 1,
+            "hex": "#C6EAFB"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:18",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-coolblue-80"
+            }
+          }
+        },
+        "90": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.886274516582489,
+              0.95686274766922,
+              0.9921568632125854
+            ],
+            "alpha": 1,
+            "hex": "#E2F4FD"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:19",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-coolblue-90"
+            }
+          }
+        },
+        "100": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.04313725605607033,
+              0.2666666805744171,
+              0.3803921639919281
+            ],
+            "alpha": 1,
+            "hex": "#0B4461"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2435:784",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-coolblue-100"
+            }
+          }
+        }
+      },
+      "Green": {
+        "10": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.019607843831181526,
+              0.25882354378700256,
+              0.239215686917305
+            ],
+            "alpha": 1,
+            "hex": "#05423D"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:20",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-green-10"
+            }
+          }
+        },
+        "20": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.1411764770746231,
+              0.43529412150382996,
+              0.2862745225429535
+            ],
+            "alpha": 1,
+            "hex": "#246F49"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:21",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-green-20"
+            }
+          }
+        },
+        "30": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.16862745583057404,
+              0.6313725709915161,
+              0.40784314274787903
+            ],
+            "alpha": 1,
+            "hex": "#2BA168"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:22",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-green-30"
+            }
+          }
+        },
+        "40": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.1882352977991104,
+              0.7137255072593689,
+              0.4588235318660736
+            ],
+            "alpha": 1,
+            "hex": "#30B675"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:23",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-green-40"
+            }
+          }
+        },
+        "50": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.3803921639919281,
+              0.7686274647712708,
+              0.5529412031173706
+            ],
+            "alpha": 1,
+            "hex": "#61C48D"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:24",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-green-50"
+            }
+          }
+        },
+        "60": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.529411792755127,
+              0.8235294222831726,
+              0.6509804129600525
+            ],
+            "alpha": 1,
+            "hex": "#87D2A6"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:25",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-green-60"
+            }
+          }
+        },
+        "70": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.6627451181411743,
+              0.8784313797950745,
+              0.7490196228027344
+            ],
+            "alpha": 1,
+            "hex": "#A9E0BF"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:26",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-green-70"
+            }
+          }
+        },
+        "80": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.772549033164978,
+              0.8941176533699036,
+              0.8039215803146362
+            ],
+            "alpha": 1,
+            "hex": "#C5E4CD"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:27",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-green-80"
+            }
+          }
+        },
+        "90": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.8745098114013672,
+              0.9647058844566345,
+              0.9215686321258545
+            ],
+            "alpha": 1,
+            "hex": "#DFF6EB"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:28",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-green-90"
+            }
+          }
+        },
+        "100": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.9372549057006836,
+              0.9843137264251709,
+              0.9607843160629272
+            ],
+            "alpha": 1,
+            "hex": "#EFFBF5"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:29",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-green-100"
+            }
+          }
+        }
+      },
+      "Red": {
+        "10": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.3764705955982208,
+              0.0235294122248888,
+              0.03529411926865578
+            ],
+            "alpha": 1,
+            "hex": "#600609"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:2",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-red-10"
+            }
+          }
+        },
+        "20": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.5647059082984924,
+              0.03529411926865578,
+              0.054901961237192154
+            ],
+            "alpha": 1,
+            "hex": "#90090E"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:3",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-red-20"
+            }
+          }
+        },
+        "30": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.7529411911964417,
+              0.0470588244497776,
+              0.07058823853731155
+            ],
+            "alpha": 1,
+            "hex": "#C00C12"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:4",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-red-30"
+            }
+          }
+        },
+        "40": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.9411764740943909,
+              0.05882352963089943,
+              0.09019608050584793
+            ],
+            "alpha": 1,
+            "hex": "#F00F17"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:5",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-red-40"
+            }
+          }
+        },
+        "50": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.9490196108818054,
+              0.22745098173618317,
+              0.2549019753932953
+            ],
+            "alpha": 1,
+            "hex": "#F23A41"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:6",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-red-50"
+            }
+          }
+        },
+        "60": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.9647058844566345,
+              0.43529412150382996,
+              0.45490196347236633
+            ],
+            "alpha": 1,
+            "hex": "#F66F74"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:7",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-red-60"
+            }
+          }
+        },
+        "70": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.9725490212440491,
+              0.5882353186607361,
+              0.6000000238418579
+            ],
+            "alpha": 1,
+            "hex": "#F89699"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:8",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-red-70"
+            }
+          }
+        },
+        "80": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.9803921580314636,
+              0.7176470756530762,
+              0.7254902124404907
+            ],
+            "alpha": 1,
+            "hex": "#FAB7B9"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:9",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-red-80"
+            }
+          }
+        },
+        "90": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.9921568632125854,
+              0.886274516582489,
+              0.8901960849761963
+            ],
+            "alpha": 1,
+            "hex": "#FDE2E3"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:10",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-red-90"
+            }
+          }
+        },
+        "100": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.9960784316062927,
+              0.9254902005195618,
+              0.9254902005195618
+            ],
+            "alpha": 1,
+            "hex": "#FEECEC"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:11",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-red-100"
+            }
+          }
+        }
+      },
+      "Orange": {
+        "10": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.4000000059604645,
+              0.239215686917305,
+              0
+            ],
+            "alpha": 1,
+            "hex": "#663D00"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:12",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-orange-10"
+            }
+          }
+        },
+        "20": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.6000000238418579,
+              0.3607843220233917,
+              0
+            ],
+            "alpha": 1,
+            "hex": "#995C00"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:13",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-orange-20"
+            }
+          }
+        },
+        "30": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.800000011920929,
+              0.47843137383461,
+              0
+            ],
+            "alpha": 1,
+            "hex": "#CC7A00"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:14",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-orange-30"
+            }
+          }
+        },
+        "40": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              1,
+              0.6000000238418579,
+              0
+            ],
+            "alpha": 1,
+            "hex": "#FF9900"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:15",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-orange-40"
+            }
+          }
+        },
+        "50": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              1,
+              0.6705882549285889,
+              0.18039216101169586
+            ],
+            "alpha": 1,
+            "hex": "#FFAB2E"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:16",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-orange-50"
+            }
+          }
+        },
+        "60": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              1,
+              0.7607843279838562,
+              0.4000000059604645
+            ],
+            "alpha": 1,
+            "hex": "#FFC266"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:17",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-orange-60"
+            }
+          }
+        },
+        "70": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              1,
+              0.8235294222831726,
+              0.5607843399047852
+            ],
+            "alpha": 1,
+            "hex": "#FFD28F"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:18",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-orange-70"
+            }
+          }
+        },
+        "80": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              1,
+              0.8784313797950745,
+              0.6980392336845398
+            ],
+            "alpha": 1,
+            "hex": "#FFE0B2"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:19",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-orange-80"
+            }
+          }
+        },
+        "90": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              1,
+              0.9372549057006836,
+              0.8392156958580017
+            ],
+            "alpha": 1,
+            "hex": "#FFEFD6"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:20",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-orange-90"
+            }
+          }
+        },
+        "100": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              1,
+              0.9686274528503418,
+              0.9215686321258545
+            ],
+            "alpha": 1,
+            "hex": "#FFF7EB"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:21",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-orange-100"
+            }
+          }
+        }
+      },
+      "Purple": {
+        "10": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.2235294133424759,
+              0.06666667014360428,
+              0.3607843220233917
+            ],
+            "alpha": 1,
+            "hex": "#39115C"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:22",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-purple-10"
+            }
+          }
+        },
+        "20": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.3176470696926117,
+              0.027450980618596077,
+              0.572549045085907
+            ],
+            "alpha": 1,
+            "hex": "#510792"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:23",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-purple-20"
+            }
+          }
+        },
+        "30": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.42352941632270813,
+              0.03921568766236305,
+              0.7607843279838562
+            ],
+            "alpha": 1,
+            "hex": "#6C0AC2"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:24",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-purple-30"
+            }
+          }
+        },
+        "40": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.529411792755127,
+              0.0470588244497776,
+              0.9529411792755127
+            ],
+            "alpha": 1,
+            "hex": "#870CF3"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:25",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-purple-40"
+            }
+          }
+        },
+        "50": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.6117647290229797,
+              0.2078431397676468,
+              0.9647058844566345
+            ],
+            "alpha": 1,
+            "hex": "#9C35F6"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:26",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-purple-50"
+            }
+          }
+        },
+        "60": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.7176470756530762,
+              0.4274509847164154,
+              0.9725490212440491
+            ],
+            "alpha": 1,
+            "hex": "#B76DF8"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:27",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-purple-60"
+            }
+          }
+        },
+        "70": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.7921568751335144,
+              0.5803921818733215,
+              0.9803921580314636
+            ],
+            "alpha": 1,
+            "hex": "#CA94FA"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:28",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-purple-70"
+            }
+          }
+        },
+        "80": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.8588235378265381,
+              0.7137255072593689,
+              0.9882352948188782
+            ],
+            "alpha": 1,
+            "hex": "#DBB6FC"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:29",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-purple-80"
+            }
+          }
+        },
+        "90": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.9254902005195618,
+              0.8470588326454163,
+              0.9921568632125854
+            ],
+            "alpha": 1,
+            "hex": "#ECD8FD"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:30",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-purple-90"
+            }
+          }
+        },
+        "100": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.9607843160629272,
+              0.9254902005195618,
+              0.9960784316062927
+            ],
+            "alpha": 1,
+            "hex": "#F5ECFE"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:31",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-purple-100"
+            }
+          }
+        }
+      },
+      "Midnight": {
+        "10": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.04313725605607033,
+              0.03529411926865578,
+              0.1764705926179886
+            ],
+            "alpha": 1,
+            "hex": "#0B092D"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:32",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-midnight-10"
+            }
+          }
+        }
+      }
     }
   },
   "Shadow": {
@@ -2950,1364 +4308,6 @@
         ],
         "com.figma.codeSyntax": {
           "WEB": "var(--shadow-focus)"
-        }
-      }
-    }
-  },
-  "Brand C": {
-    "Blue": {
-      "10": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.10588235294117647,
-            0.06666666666666667,
-            0.3607843137254902
-          ],
-          "alpha": 1,
-          "hex": "#1B115C"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001100",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-blue-10)"
-          }
-        }
-      },
-      "20": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.027450980392156862,
-            0.17647058823529413,
-            0.5725490196078431
-          ],
-          "alpha": 1,
-          "hex": "#072D92"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001101",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-blue-20)"
-          }
-        }
-      },
-      "30": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.0392156862745098,
-            0.23529411764705882,
-            0.7607843137254902
-          ],
-          "alpha": 1,
-          "hex": "#0A3CC2"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001102",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-blue-30)"
-          }
-        }
-      },
-      "40": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.047058823529411764,
-            0.29411764705882354,
-            0.9529411764705882
-          ],
-          "alpha": 1,
-          "hex": "#0C4BF3"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001103",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-blue-40)"
-          }
-        }
-      },
-      "50": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.20784313725490197,
-            0.403921568627451,
-            0.9647058823529412
-          ],
-          "alpha": 1,
-          "hex": "#3567F6"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001104",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-blue-50)"
-          }
-        }
-      },
-      "60": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.42745098039215684,
-            0.5764705882352941,
-            0.9725490196078431
-          ],
-          "alpha": 1,
-          "hex": "#6D93F8"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001105",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-blue-60)"
-          }
-        }
-      },
-      "70": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.5803921568627451,
-            0.6901960784313725,
-            0.9803921568627451
-          ],
-          "alpha": 1,
-          "hex": "#94B0FA"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001106",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-blue-70)"
-          }
-        }
-      },
-      "80": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.7137254901960784,
-            0.7843137254901961,
-            0.9882352941176471
-          ],
-          "alpha": 1,
-          "hex": "#B6C8FC"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001107",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-blue-80)"
-          }
-        }
-      },
-      "90": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.8470588235294118,
-            0.8862745098039215,
-            0.9921568627450981
-          ],
-          "alpha": 1,
-          "hex": "#D8E2FD"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001108",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-blue-90)"
-          }
-        }
-      },
-      "100": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.9254901960784314,
-            0.9450980392156862,
-            0.996078431372549
-          ],
-          "alpha": 1,
-          "hex": "#ECF1FE"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001109",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-blue-100)"
-          }
-        }
-      }
-    },
-    "Coolblue": {
-      "10": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.0196078431372549,
-            0.26666666666666666,
-            0.3803921568627451
-          ],
-          "alpha": 1,
-          "hex": "#054461"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001110",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-coolblue-10)"
-          }
-        }
-      },
-      "20": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.027450980392156862,
-            0.4,
-            0.5725490196078431
-          ],
-          "alpha": 1,
-          "hex": "#076692"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001111",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-coolblue-20)"
-          }
-        }
-      },
-      "30": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.0392156862745098,
-            0.5333333333333333,
-            0.7607843137254902
-          ],
-          "alpha": 1,
-          "hex": "#0A88C2"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001112",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-coolblue-30)"
-          }
-        }
-      },
-      "40": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.047058823529411764,
-            0.6666666666666666,
-            0.9529411764705882
-          ],
-          "alpha": 1,
-          "hex": "#0CAAF3"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001113",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-coolblue-40)"
-          }
-        }
-      },
-      "50": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.2196078431372549,
-            0.7254901960784313,
-            0.9607843137254902
-          ],
-          "alpha": 1,
-          "hex": "#38B9F5"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001114",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-coolblue-50)"
-          }
-        }
-      },
-      "60": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.4392156862745098,
-            0.796078431372549,
-            0.9568627450980393
-          ],
-          "alpha": 1,
-          "hex": "#70CBF4"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001115",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-coolblue-60)"
-          }
-        }
-      },
-      "70": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.6627450980392157,
-            0.8745098039215686,
-            0.9725490196078431
-          ],
-          "alpha": 1,
-          "hex": "#A9DFF8"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001116",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-coolblue-70)"
-          }
-        }
-      },
-      "80": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.7764705882352941,
-            0.9176470588235294,
-            0.984313725490196
-          ],
-          "alpha": 1,
-          "hex": "#C6EAFB"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001117",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-coolblue-80)"
-          }
-        }
-      },
-      "90": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.8862745098039215,
-            0.9568627450980393,
-            0.9921568627450981
-          ],
-          "alpha": 1,
-          "hex": "#E2F4FD"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001118",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-coolblue-90)"
-          }
-        }
-      },
-      "100": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.9411764705882353,
-            0.9803921568627451,
-            0.996078431372549
-          ],
-          "alpha": 1,
-          "hex": "#F0FAFE"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001119",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-coolblue-100)"
-          }
-        }
-      }
-    },
-    "Green": {
-      "10": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.0196078431372549,
-            0.25882352941176473,
-            0.23921568627450981
-          ],
-          "alpha": 1,
-          "hex": "#05423D"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001120",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-green-10)"
-          }
-        }
-      },
-      "20": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.1411764705882353,
-            0.43529411764705883,
-            0.28627450980392155
-          ],
-          "alpha": 1,
-          "hex": "#246F49"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001121",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-green-20)"
-          }
-        }
-      },
-      "30": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.16862745098039217,
-            0.6313725490196078,
-            0.40784313725490196
-          ],
-          "alpha": 1,
-          "hex": "#2BA168"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001122",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-green-30)"
-          }
-        }
-      },
-      "40": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.18823529411764706,
-            0.7137254901960784,
-            0.4588235294117647
-          ],
-          "alpha": 1,
-          "hex": "#30B675"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001123",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-green-40)"
-          }
-        }
-      },
-      "50": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.3803921568627451,
-            0.7686274509803922,
-            0.5529411764705883
-          ],
-          "alpha": 1,
-          "hex": "#61C48D"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001124",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-green-50)"
-          }
-        }
-      },
-      "60": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.5294117647058824,
-            0.8235294117647058,
-            0.6509803921568628
-          ],
-          "alpha": 1,
-          "hex": "#87D2A6"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001125",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-green-60)"
-          }
-        }
-      },
-      "70": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.6627450980392157,
-            0.8784313725490196,
-            0.7490196078431373
-          ],
-          "alpha": 1,
-          "hex": "#A9E0BF"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001126",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-green-70)"
-          }
-        }
-      },
-      "80": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.7725490196078432,
-            0.8941176470588236,
-            0.803921568627451
-          ],
-          "alpha": 1,
-          "hex": "#C5E4CD"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001127",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-green-80)"
-          }
-        }
-      },
-      "90": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.8745098039215686,
-            0.9647058823529412,
-            0.9215686274509803
-          ],
-          "alpha": 1,
-          "hex": "#DFF6EB"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001128",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-green-90)"
-          }
-        }
-      },
-      "100": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.9372549019607843,
-            0.984313725490196,
-            0.9607843137254902
-          ],
-          "alpha": 1,
-          "hex": "#EFFBF5"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001129",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-green-100)"
-          }
-        }
-      }
-    },
-    "Red": {
-      "10": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.3764705882352941,
-            0.023529411764705882,
-            0.03529411764705882
-          ],
-          "alpha": 1,
-          "hex": "#600609"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001130",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-red-10)"
-          }
-        }
-      },
-      "20": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.5647058823529412,
-            0.03529411764705882,
-            0.054901960784313725
-          ],
-          "alpha": 1,
-          "hex": "#90090E"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001131",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-red-20)"
-          }
-        }
-      },
-      "30": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.7529411764705882,
-            0.047058823529411764,
-            0.07058823529411765
-          ],
-          "alpha": 1,
-          "hex": "#C00C12"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001132",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-red-30)"
-          }
-        }
-      },
-      "40": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.9411764705882353,
-            0.058823529411764705,
-            0.09019607843137255
-          ],
-          "alpha": 1,
-          "hex": "#F00F17"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001133",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-red-40)"
-          }
-        }
-      },
-      "50": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.9490196078431372,
-            0.22745098039215686,
-            0.2549019607843137
-          ],
-          "alpha": 1,
-          "hex": "#F23A41"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001134",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-red-50)"
-          }
-        }
-      },
-      "60": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.9647058823529412,
-            0.43529411764705883,
-            0.4549019607843137
-          ],
-          "alpha": 1,
-          "hex": "#F66F74"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001135",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-red-60)"
-          }
-        }
-      },
-      "70": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.9725490196078431,
-            0.5882352941176471,
-            0.6
-          ],
-          "alpha": 1,
-          "hex": "#F89699"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001136",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-red-70)"
-          }
-        }
-      },
-      "80": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.9803921568627451,
-            0.7176470588235294,
-            0.7254901960784313
-          ],
-          "alpha": 1,
-          "hex": "#FAB7B9"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001137",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-red-80)"
-          }
-        }
-      },
-      "90": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.9921568627450981,
-            0.8862745098039215,
-            0.8901960784313725
-          ],
-          "alpha": 1,
-          "hex": "#FDE2E3"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001138",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-red-90)"
-          }
-        }
-      },
-      "100": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.996078431372549,
-            0.9254901960784314,
-            0.9254901960784314
-          ],
-          "alpha": 1,
-          "hex": "#FEECEC"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001139",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-red-100)"
-          }
-        }
-      }
-    },
-    "Orange": {
-      "10": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.4,
-            0.23921568627450981,
-            0
-          ],
-          "alpha": 1,
-          "hex": "#663D00"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001140",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-orange-10)"
-          }
-        }
-      },
-      "20": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.6,
-            0.3607843137254902,
-            0
-          ],
-          "alpha": 1,
-          "hex": "#995C00"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001141",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-orange-20)"
-          }
-        }
-      },
-      "30": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.8,
-            0.47843137254901963,
-            0
-          ],
-          "alpha": 1,
-          "hex": "#CC7A00"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001142",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-orange-30)"
-          }
-        }
-      },
-      "40": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            1,
-            0.6,
-            0
-          ],
-          "alpha": 1,
-          "hex": "#FF9900"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001143",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-orange-40)"
-          }
-        }
-      },
-      "50": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            1,
-            0.6705882352941176,
-            0.1803921568627451
-          ],
-          "alpha": 1,
-          "hex": "#FFAB2E"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001144",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-orange-50)"
-          }
-        }
-      },
-      "60": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            1,
-            0.7607843137254902,
-            0.4
-          ],
-          "alpha": 1,
-          "hex": "#FFC266"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001145",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-orange-60)"
-          }
-        }
-      },
-      "70": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            1,
-            0.8235294117647058,
-            0.5607843137254902
-          ],
-          "alpha": 1,
-          "hex": "#FFD28F"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001146",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-orange-70)"
-          }
-        }
-      },
-      "80": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            1,
-            0.8784313725490196,
-            0.6980392156862745
-          ],
-          "alpha": 1,
-          "hex": "#FFE0B2"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001147",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-orange-80)"
-          }
-        }
-      },
-      "90": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            1,
-            0.9372549019607843,
-            0.8392156862745098
-          ],
-          "alpha": 1,
-          "hex": "#FFEFD6"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001148",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-orange-90)"
-          }
-        }
-      },
-      "100": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            1,
-            0.9686274509803922,
-            0.9215686274509803
-          ],
-          "alpha": 1,
-          "hex": "#FFF7EB"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001149",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-orange-100)"
-          }
-        }
-      }
-    },
-    "Purple": {
-      "10": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.2235294117647059,
-            0.06666666666666667,
-            0.3607843137254902
-          ],
-          "alpha": 1,
-          "hex": "#39115C"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001150",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-purple-10)"
-          }
-        }
-      },
-      "20": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.3176470588235294,
-            0.027450980392156862,
-            0.5725490196078431
-          ],
-          "alpha": 1,
-          "hex": "#510792"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001151",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-purple-20)"
-          }
-        }
-      },
-      "30": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.4235294117647059,
-            0.0392156862745098,
-            0.7607843137254902
-          ],
-          "alpha": 1,
-          "hex": "#6C0AC2"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001152",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-purple-30)"
-          }
-        }
-      },
-      "40": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.5294117647058824,
-            0.047058823529411764,
-            0.9529411764705882
-          ],
-          "alpha": 1,
-          "hex": "#870CF3"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001153",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-purple-40)"
-          }
-        }
-      },
-      "50": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.611764705882353,
-            0.20784313725490197,
-            0.9647058823529412
-          ],
-          "alpha": 1,
-          "hex": "#9C35F6"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001154",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-purple-50)"
-          }
-        }
-      },
-      "60": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.7176470588235294,
-            0.42745098039215684,
-            0.9725490196078431
-          ],
-          "alpha": 1,
-          "hex": "#B76DF8"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001155",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-purple-60)"
-          }
-        }
-      },
-      "70": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.792156862745098,
-            0.5803921568627451,
-            0.9803921568627451
-          ],
-          "alpha": 1,
-          "hex": "#CA94FA"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001156",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-purple-70)"
-          }
-        }
-      },
-      "80": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.8588235294117647,
-            0.7137254901960784,
-            0.9882352941176471
-          ],
-          "alpha": 1,
-          "hex": "#DBB6FC"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001157",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-purple-80)"
-          }
-        }
-      },
-      "90": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.9254901960784314,
-            0.8470588235294118,
-            0.9921568627450981
-          ],
-          "alpha": 1,
-          "hex": "#ECD8FD"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001158",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-purple-90)"
-          }
-        }
-      },
-      "100": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.9607843137254902,
-            0.9254901960784314,
-            0.996078431372549
-          ],
-          "alpha": 1,
-          "hex": "#F5ECFE"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001159",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-purple-100)"
-          }
-        }
-      }
-    },
-    "Midnight": {
-      "10": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.043137254901960784,
-            0.03529411764705882,
-            0.17647058823529413
-          ],
-          "alpha": 1,
-          "hex": "#0B092D"
-        },
-        "$extensions": {
-          "com.figma.variableId": "VariableID:3001160",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
-          "com.figma.codeSyntax": {
-            "WEB": "var(--color-brand-c-midnight-10)"
-          }
         }
       }
     }

--- a/figma/exports/Themes (Brands).tokens.json
+++ b/figma/exports/Themes (Brands).tokens.json
@@ -5,7 +5,7 @@
         "Success": {
           "$type": "color",
           "$value": {
-            "$ref": "Color/Brand A/Green/600"
+            "$ref": "Color/Brand C/Green/30"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:2006:198",
@@ -16,21 +16,21 @@
               "WEB": "var(--brand-color-functional-success)"
             },
             "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2006:207",
-              "targetVariableName": "Color/Brand A/Green/600",
+              "targetVariableId": "VariableID:2438:22",
+              "targetVariableName": "Color/Brand C/Green/30",
               "targetVariableSetId": "VariableCollectionId:1:200",
               "targetVariableSetName": "Core (Primitives)"
             },
             "com.figma.isOverride": true,
             "com.figma.modeValues": {
               "Brand A": {
-                "$ref": "Color/Brand A/Green/600"
+                "$ref": "Color/Brand C/Green/30"
               },
               "Brand B": {
                 "$ref": "Color/Brand B/Green/600"
               },
               "Brand C": {
-                "$ref": "Color/Brand C/Green/30"
+                "$ref": "Color/Brand A/Green/600"
               }
             }
           }
@@ -38,7 +38,7 @@
         "Danger": {
           "$type": "color",
           "$value": {
-            "$ref": "Color/Brand A/Red/600"
+            "$ref": "Color/Brand C/Red/30"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:2006:206",
@@ -49,21 +49,21 @@
               "WEB": "var(--brand-color-functional-danger)"
             },
             "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2006:208",
-              "targetVariableName": "Color/Brand A/Red/600",
+              "targetVariableId": "VariableID:2439:4",
+              "targetVariableName": "Color/Brand C/Red/30",
               "targetVariableSetId": "VariableCollectionId:1:200",
               "targetVariableSetName": "Core (Primitives)"
             },
             "com.figma.isOverride": true,
             "com.figma.modeValues": {
               "Brand A": {
-                "$ref": "Color/Brand A/Red/600"
+                "$ref": "Color/Brand C/Red/30"
               },
               "Brand B": {
                 "$ref": "Color/Brand B/Red/600"
               },
               "Brand C": {
-                "$ref": "Color/Brand C/Red/30"
+                "$ref": "Color/Brand A/Red/600"
               }
             }
           }
@@ -71,7 +71,7 @@
         "Base": {
           "$type": "color",
           "$value": {
-            "$ref": "Color/Brand A/Green/700"
+            "$ref": "Color/Brand C/Blue/10"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:2006:211",
@@ -82,21 +82,21 @@
               "WEB": "var(--brand-color-functional-base)"
             },
             "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2006:210",
-              "targetVariableName": "Color/Brand A/Green/700",
+              "targetVariableId": "VariableID:2438:2",
+              "targetVariableName": "Color/Brand C/Blue/10",
               "targetVariableSetId": "VariableCollectionId:1:200",
               "targetVariableSetName": "Core (Primitives)"
             },
             "com.figma.isOverride": true,
             "com.figma.modeValues": {
               "Brand A": {
-                "$ref": "Color/Brand A/Green/700"
+                "$ref": "Color/Brand C/Blue/10"
               },
               "Brand B": {
                 "$ref": "Color/Brand B/Purple/700"
               },
               "Brand C": {
-                "$ref": "Color/Brand C/Blue/10"
+                "$ref": "Color/Brand A/Green/700"
               }
             }
           }
@@ -104,7 +104,7 @@
         "Base Dark": {
           "$type": "color",
           "$value": {
-            "$ref": "Color/Brand A/Green/900"
+            "$ref": "Color/Brand C/Midnight/10"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:2007:379",
@@ -115,21 +115,21 @@
               "WEB": "var(--brand-color-functional-base-dark)"
             },
             "com.figma.aliasData": {
-              "targetVariableId": "VariableID:2258:595",
-              "targetVariableName": "Color/Brand A/Green/900",
+              "targetVariableId": "VariableID:2439:32",
+              "targetVariableName": "Color/Brand C/Midnight/10",
               "targetVariableSetId": "VariableCollectionId:1:200",
               "targetVariableSetName": "Core (Primitives)"
             },
             "com.figma.isOverride": true,
             "com.figma.modeValues": {
               "Brand A": {
-                "$ref": "Color/Brand A/Green/900"
+                "$ref": "Color/Brand C/Midnight/10"
               },
               "Brand B": {
                 "$ref": "Color/Brand B/Purple/900"
               },
               "Brand C": {
-                "$ref": "Color/Brand C/Midnight/10"
+                "$ref": "Color/Brand A/Green/900"
               }
             }
           }
@@ -138,7 +138,7 @@
       "Primary": {
         "$type": "color",
         "$value": {
-          "$ref": "Color/Brand A/Sand/700"
+          "$ref": "Color/Brand C/Blue/40"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:2006:200",
@@ -149,21 +149,21 @@
             "WEB": "var(--brand-color-primary)"
           },
           "com.figma.aliasData": {
-            "targetVariableId": "VariableID:2258:420",
-            "targetVariableName": "Color/Brand A/Sand/700",
+            "targetVariableId": "VariableID:2438:5",
+            "targetVariableName": "Color/Brand C/Blue/40",
             "targetVariableSetId": "VariableCollectionId:1:200",
             "targetVariableSetName": "Core (Primitives)"
           },
           "com.figma.isOverride": true,
           "com.figma.modeValues": {
             "Brand A": {
-              "$ref": "Color/Brand A/Sand/700"
+              "$ref": "Color/Brand C/Blue/40"
             },
             "Brand B": {
               "$ref": "Color/Brand B/Purple/600"
             },
             "Brand C": {
-              "$ref": "Color/Brand C/Blue/40"
+              "$ref": "Color/Brand A/Sand/700"
             }
           }
         }
@@ -171,7 +171,7 @@
       "Accent": {
         "$type": "color",
         "$value": {
-          "$ref": "Color/Brand A/Green/400"
+          "$ref": "Color/Brand C/Coolblue/60"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:2006:203",
@@ -182,21 +182,21 @@
             "WEB": "var(--brand-color-accent)"
           },
           "com.figma.aliasData": {
-            "targetVariableId": "VariableID:2258:425",
-            "targetVariableName": "Color/Brand A/Green/400",
+            "targetVariableId": "VariableID:2438:16",
+            "targetVariableName": "Color/Brand C/Coolblue/60",
             "targetVariableSetId": "VariableCollectionId:1:200",
             "targetVariableSetName": "Core (Primitives)"
           },
           "com.figma.isOverride": true,
           "com.figma.modeValues": {
             "Brand A": {
-              "$ref": "Color/Brand A/Green/400"
+              "$ref": "Color/Brand C/Coolblue/60"
             },
             "Brand B": {
               "$ref": "Color/Brand B/Green/400"
             },
             "Brand C": {
-              "$ref": "Color/Brand C/Coolblue/60"
+              "$ref": "Color/Brand A/Green/400"
             }
           }
         }
@@ -204,7 +204,7 @@
       "Primary Dark": {
         "$type": "color",
         "$value": {
-          "$ref": "Color/Brand A/Sand/900"
+          "$ref": "Color/Brand C/Blue/10"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:2007:377",
@@ -215,21 +215,21 @@
             "WEB": "var(--brand-color-primary-dark)"
           },
           "com.figma.aliasData": {
-            "targetVariableId": "VariableID:2258:422",
-            "targetVariableName": "Color/Brand A/Sand/900",
+            "targetVariableId": "VariableID:2438:2",
+            "targetVariableName": "Color/Brand C/Blue/10",
             "targetVariableSetId": "VariableCollectionId:1:200",
             "targetVariableSetName": "Core (Primitives)"
           },
           "com.figma.isOverride": true,
           "com.figma.modeValues": {
             "Brand A": {
-              "$ref": "Color/Brand A/Sand/900"
+              "$ref": "Color/Brand C/Blue/10"
             },
             "Brand B": {
               "$ref": "Color/Brand B/Purple/800"
             },
             "Brand C": {
-              "$ref": "Color/Brand C/Blue/10"
+              "$ref": "Color/Brand A/Sand/900"
             }
           }
         }
@@ -237,7 +237,7 @@
       "Accent Dark": {
         "$type": "color",
         "$value": {
-          "$ref": "Color/Brand A/Green/600"
+          "$ref": "Color/Brand C/Coolblue/10"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:2007:378",
@@ -248,21 +248,21 @@
             "WEB": "var(--brand-color-accent-dark)"
           },
           "com.figma.aliasData": {
-            "targetVariableId": "VariableID:2006:207",
-            "targetVariableName": "Color/Brand A/Green/600",
+            "targetVariableId": "VariableID:2438:11",
+            "targetVariableName": "Color/Brand C/Coolblue/10",
             "targetVariableSetId": "VariableCollectionId:1:200",
             "targetVariableSetName": "Core (Primitives)"
           },
           "com.figma.isOverride": true,
           "com.figma.modeValues": {
             "Brand A": {
-              "$ref": "Color/Brand A/Green/600"
+              "$ref": "Color/Brand C/Coolblue/10"
             },
             "Brand B": {
               "$ref": "Color/Brand B/Green/800"
             },
             "Brand C": {
-              "$ref": "Color/Brand C/Coolblue/10"
+              "$ref": "Color/Brand A/Green/600"
             }
           }
         }
@@ -439,7 +439,7 @@
       "Button": {
         "$type": "number",
         "$value": {
-          "$ref": "Size/Radius/700"
+          "$ref": "Size/Radius/full"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:2006:215",
@@ -450,21 +450,21 @@
             "WEB": "var(--brand-corner-button)"
           },
           "com.figma.aliasData": {
-            "targetVariableId": "VariableID:1:248",
-            "targetVariableName": "Size/Radius/700",
+            "targetVariableId": "VariableID:1:251",
+            "targetVariableName": "Size/Radius/full",
             "targetVariableSetId": "VariableCollectionId:1:200",
             "targetVariableSetName": "Core (Primitives)"
           },
           "com.figma.isOverride": true,
           "com.figma.modeValues": {
             "Brand A": {
-              "$ref": "Size/Radius/700"
+              "$ref": "Size/Radius/full"
             },
             "Brand B": {
               "$ref": "Size/Radius/000"
             },
             "Brand C": {
-              "$ref": "Size/Radius/full"
+              "$ref": "Size/Radius/700"
             }
           }
         }
@@ -472,7 +472,7 @@
       "Card": {
         "$type": "number",
         "$value": {
-          "$ref": "Size/Radius/200"
+          "$ref": "Size/Radius/300"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:2006:216",
@@ -483,21 +483,21 @@
             "WEB": "var(--brand-corner-card)"
           },
           "com.figma.aliasData": {
-            "targetVariableId": "VariableID:1:243",
-            "targetVariableName": "Size/Radius/200",
+            "targetVariableId": "VariableID:1:244",
+            "targetVariableName": "Size/Radius/300",
             "targetVariableSetId": "VariableCollectionId:1:200",
             "targetVariableSetName": "Core (Primitives)"
           },
           "com.figma.isOverride": true,
           "com.figma.modeValues": {
             "Brand A": {
-              "$ref": "Size/Radius/200"
+              "$ref": "Size/Radius/300"
             },
             "Brand B": {
               "$ref": "Size/Radius/100"
             },
             "Brand C": {
-              "$ref": "Size/Radius/300"
+              "$ref": "Size/Radius/200"
             }
           }
         }

--- a/schemas/web-badge.figma.ts
+++ b/schemas/web-badge.figma.ts
@@ -2,7 +2,7 @@ import figma, { html } from "@figma/code-connect/html";
 import { BadgeProps } from "./web-badge";
 
 figma.connect(
-  "https://www.figma.com/design/uqMsy8fV1fPbQdAzgwlmBA/UI-Foundations?node-id=PLACEHOLDER&m=dev",
+  "https://www.figma.com/design/uqMsy8fV1fPbQdAzgwlmBA/UI-Foundations?node-id=2385-709&m=dev",
   {
     props: {
       className: figma.className([


### PR DESCRIPTION
Closes #22

## Summary

Aligns Badge Figma variables and CSS tokens so they follow a consistent convention and the token pipeline produces correct output.

## Changes

**Figma variables (pushed via Plugin API):**
- Renamed Badge variants: Solid → Default, Outline → Brand, Ghost → Success
- Added Danger variant with correct semantic color bindings
- Renamed all Badge color variables to match CSS convention
- Added md/sm size tokens (font-size, line-height, padding-inline, padding-block)
- Rebound Badge sizing from Button variables to Badge-own variables
- Updated border-radius to Size/Radius/full (pill shape)

**Code changes:**
- figma/exports re-exported with aligned Badge structure
- schemas/web-badge.figma.ts updated node ID from PLACEHOLDER to 2385-709
- Code Connect mapping registered in Figma

## Validation

- tokens:generate: 0 duplicates, 0 missing
- ci:check: all steps pass