### PR TITLE
docs: align typography foundation attribute examples with data-brand/data-mode

### DIFF
--- a/docs/foundations/foundation-007-typography-selectors-and-specificity.md
+++ b/docs/foundations/foundation-007-typography-selectors-and-specificity.md
@@ -22,7 +22,7 @@ Provide a consistent typography API with low selector specificity and predictabl
 
 4. Use `:where()` for zero-specificity size/scale selectors where possible.
 
-5. Reserve data attributes (for example `[data-theme]`, `[data-density]`) for context/state, not as primary styling API.
+5. Reserve data attributes (for example `[data-brand]`, `[data-mode]`, `[data-density]`) for context/state, not as primary styling API.
 
 ## Implications
 


### PR DESCRIPTION
### Motivation
- Align foundation guidance with the repository runtime theming model by replacing the deprecated `[data-theme]` example with the canonical `data-brand` and `data-mode` attributes to reduce ambiguity for contributors and agents.

### Description
- Edited `docs/foundations/foundation-007-typography-selectors-and-specificity.md` to replace `[data-theme]` with `[data-brand]` and `[data-mode]`; this is a docs-only, non-runtime change with very low risk and a suggested follow-up of a repo-wide docs sweep to catch any remaining deprecated theming terms.

### Testing
- Ran `npm run lint`, `npm run test:unit`, and `npm run ci:check` and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e832bd5c832997d4e5ea5b6c2fca)