### PR TITLE
docs: add accessibility audit for interactive components

### DIFF
--- a/docs/accessibility-audit-interactive-components.md
+++ b/docs/accessibility-audit-interactive-components.md
@@ -1,0 +1,203 @@
+# Accessibility Audit — Interactive Components
+
+Date: 2026-05-04  
+Mode: Audit (read-only analysis; no component implementation changes)
+
+## Scope
+
+Included components requested:
+- Button
+- Icon Button
+- Link
+- Input
+- Select
+- Checkbox
+- Radio
+- Switch
+- Tabs
+- Accordion
+- Modal
+- Flyout
+- Dropdown
+- Tooltip
+- Pagination
+- Show More / Show Less
+- Tags
+
+Excluded (per request): Divider, Grid, Image, Skeleton, Loader, Typography utilities.
+
+## Inventory summary
+
+Implemented interactive components in this repository today: **Button, Link, Input, Checkbox, Radio, Switch** via CSS patterns + docs + Nunjucks + React wrappers.  
+Not implemented as reusable components in this repository today: **Icon Button (standalone), Select, Tabs, Accordion, Modal, Flyout, Dropdown, Tooltip, Pagination, Show More / Show Less, Tags**.
+
+---
+
+## Detailed audit
+
+### 1) Button
+- **Semantic role check:** ✅ Uses native `<button>` in Nunjucks and React wrappers.
+- **Accessible name check:** ⚠️ Text labels are supported; icon-only enforcement is incomplete in templates. React warns for missing label but does not enforce.
+- **Keyboard interaction check:** ✅ Native button keyboard semantics preserved (Enter/Space).
+- **Focus behavior check:** ✅ Focus-visible styles are implemented in CSS.
+- **ARIA/state check:** ⚠️ Toggle semantics are only present in `toggleButton` helper (`aria-pressed`), but the main button macro has no explicit toggle API guidance.
+- **Form association check:** ✅ `type` attribute supported (`button`/`submit`/`reset`) in docs and macros.
+- **Test coverage gaps:** ❌ No component-level unit/a11y tests found for button behavior, icon-only labeling, disabled focus/tab behavior.
+- **Documentation gaps:** ⚠️ No dedicated icon-only accessibility contract (required `aria-label`) in the component doc.
+- **Severity:** **medium**
+- **Recommended fix:** Add automated a11y tests (accessible-name requirements, keyboard activation, disabled/tab order) and document icon-only requirement explicitly.
+
+### 2) Icon Button
+- **Semantic role check:** ⚠️ No first-class Icon Button component; behavior piggybacks on generic Button + icon-only state.
+- **Accessible name check:** ❌ Risk of unnamed controls in Nunjucks macro path (no guard for icon-only without label).
+- **Keyboard interaction check:** ⚠️ Inherits button semantics where used, but no formal API contract/component.
+- **Focus behavior check:** ⚠️ Inherits button focus styles where used.
+- **ARIA/state check:** ⚠️ React warns in dev for missing aria label; not a runtime guarantee.
+- **Form association check:** ✅ Same as button where implemented.
+- **Test coverage gaps:** ❌ No dedicated tests for icon-only button naming.
+- **Documentation gaps:** ❌ No standalone Icon Button doc/API and no explicit accessibility checklist for icon-only actions.
+- **Severity:** **high**
+- **Recommended fix:** Introduce explicit Icon Button API requiring accessible name (compile/runtime assertion), plus tests and docs.
+
+### 3) Link
+- **Semantic role check:** ✅ Uses native `<a>`.
+- **Accessible name check:** ✅ Text content provides name by default.
+- **Keyboard interaction check:** ⚠️ Native behavior applies for valid `href`, but disabled pattern keeps `href` and does not remove from tab order.
+- **Focus behavior check:** ✅ Focus-visible styling exists in CSS link pattern.
+- **ARIA/state check:** ⚠️ `aria-disabled="true"` is set for disabled state, but interaction suppression (`tabindex="-1"`, click prevention) is not implemented in macro.
+- **Form association check:** N/A
+- **Test coverage gaps:** ❌ No tests for disabled-link keyboard/tab/click behavior.
+- **Documentation gaps:** ❌ Docs state disabled links should have `tabindex="-1"`, but macro does not implement it (doc/implementation drift).
+- **Severity:** **high**
+- **Recommended fix:** Align implementation with docs for disabled links (`tabindex=-1`, prevent activation) or remove disabled-link pattern and recommend button for disabled actions.
+
+### 4) Input
+- **Semantic role check:** ✅ Uses native `<input>`.
+- **Accessible name check:** ⚠️ Supports `id/name`, but no built-in label coupling; relies on consumer to provide `<label>`/`aria-label`.
+- **Keyboard interaction check:** ✅ Native text input keyboard behavior retained.
+- **Focus behavior check:** ✅ Focus-visible state styling is present.
+- **ARIA/state check:** ⚠️ No first-class invalid/error ARIA guidance (`aria-invalid`, `aria-describedby`) in component API.
+- **Form association check:** ⚠️ Possible via `id`/`name`, but not enforced.
+- **Test coverage gaps:** ❌ No tests for accessible labeling and error semantics.
+- **Documentation gaps:** ⚠️ Guidance exists generally, but no strict API examples requiring label association in all snippets.
+- **Severity:** **medium**
+- **Recommended fix:** Add examples and tests requiring label association + error/help text semantics.
+
+### 5) Select
+- **Semantic role check:** ❌ No reusable Select component implementation found.
+- **Accessible name check:** ❌ No component contract.
+- **Keyboard interaction check:** ❌ No component contract.
+- **Focus behavior check:** ❌ No component contract.
+- **ARIA/state check:** ❌ No component contract.
+- **Form association check:** ❌ No component contract.
+- **Test coverage gaps:** ❌ No tests.
+- **Documentation gaps:** ❌ No component doc.
+- **Severity:** **blocker**
+- **Recommended fix:** Define and implement native `<select>` component with documented labeling/error patterns and keyboard expectations.
+
+### 6) Checkbox
+- **Semantic role check:** ✅ Native `<input type="checkbox">` used.
+- **Accessible name check:** ✅ Wrapped in `<label>` when label text provided; React warns if unnamed.
+- **Keyboard interaction check:** ✅ Native checkbox keyboard semantics preserved.
+- **Focus behavior check:** ✅ Focus-visible styles included.
+- **ARIA/state check:** ✅/⚠️ Indeterminate is supported (`aria-checked="mixed"` + React `indeterminate` property), but requires careful sync when controlled externally.
+- **Form association check:** ✅ `name/value/id` supported.
+- **Test coverage gaps:** ❌ No tests for indeterminate semantics and keyboard behavior.
+- **Documentation gaps:** ⚠️ Could better specify grouping with `<fieldset>/<legend>` in all form examples.
+- **Severity:** **medium**
+- **Recommended fix:** Add unit/a11y tests for mixed state, labeling, and keyboard behavior; tighten docs with grouped-form examples.
+
+### 7) Radio
+- **Semantic role check:** ✅ Native `<input type="radio">` used.
+- **Accessible name check:** ✅ Labeled via wrapper label.
+- **Keyboard interaction check:** ⚠️ Native behavior depends on correct same-`name` grouping; examples include names, but enforcement is consumer-driven.
+- **Focus behavior check:** ✅ Focus-visible styles included.
+- **ARIA/state check:** ✅ Native radio semantics are used.
+- **Form association check:** ⚠️ Requires `name` for proper group behavior; not enforced by API.
+- **Test coverage gaps:** ❌ No tests for arrow-key movement/group semantics.
+- **Documentation gaps:** ⚠️ Docs correctly call for `<fieldset>/<legend>`, but reusable grouped abstraction is absent.
+- **Severity:** **medium**
+- **Recommended fix:** Add `RadioGroup` abstraction or validation helper + tests for group keyboard behavior and naming.
+
+### 8) Switch
+- **Semantic role check:** ✅ Uses `<input type="checkbox" role="switch">`.
+- **Accessible name check:** ✅ Label wrapper present; React warns if unlabeled.
+- **Keyboard interaction check:** ✅ Native checkbox keyboard behavior (Space toggle) retained.
+- **Focus behavior check:** ✅ Focus-visible styles included.
+- **ARIA/state check:** ✅ Uses role switch with native checked state.
+- **Form association check:** ✅ Supports `name/value/id`.
+- **Test coverage gaps:** ❌ No tests for role/state announcements and keyboard toggling.
+- **Documentation gaps:** ⚠️ Draft status; needs stronger screen reader expectation examples.
+- **Severity:** **low**
+- **Recommended fix:** Add focused a11y tests and finalize docs from draft to stable once verified.
+
+### 9) Tabs
+- **Semantic role check:** ❌ No reusable Tabs component.
+- **Accessible name check:** ❌ Missing component contract.
+- **Keyboard interaction check:** ❌ Missing roving tabindex/arrow-key pattern.
+- **Focus behavior check:** ❌ Missing.
+- **ARIA/state check:** ❌ Missing `tablist/tab/tabpanel` relationships.
+- **Form association check:** N/A
+- **Test coverage gaps:** ❌ None.
+- **Documentation gaps:** ❌ None.
+- **Severity:** **blocker**
+- **Recommended fix:** Implement APG-aligned tabs with full keyboard and ARIA relationships.
+
+### 10) Accordion
+- **Severity:** **blocker**
+- **Findings:** No reusable implementation/tests/docs; no verified heading/button/`aria-expanded`/`aria-controls` pattern.
+- **Recommended fix:** Implement APG accordion pattern and tests.
+
+### 11) Modal
+- **Severity:** **blocker**
+- **Findings:** No reusable implementation/tests/docs; no focus trap, initial focus, escape handling, restore-focus contract verified.
+- **Recommended fix:** Implement dialog with robust focus management and inert/background interaction strategy.
+
+### 12) Flyout
+- **Severity:** **blocker**
+- **Findings:** No reusable implementation/tests/docs.
+- **Recommended fix:** Define flyout semantics (menu/dialog/popover) first, then implement with matching keyboard/ARIA behavior.
+
+### 13) Dropdown
+- **Severity:** **blocker**
+- **Findings:** No reusable implementation/tests/docs; ambiguous whether it means select-like or menu-like behavior.
+- **Recommended fix:** Split into explicit components (Select vs MenuButton) and implement each with proper patterns.
+
+### 14) Tooltip
+- **Severity:** **blocker**
+- **Findings:** No reusable implementation/tests/docs; no trigger/focus/escape semantics.
+- **Recommended fix:** Implement non-interactive tooltip pattern (`role=tooltip`, `aria-describedby`) and keyboard/focus behavior.
+
+### 15) Pagination
+- **Severity:** **blocker**
+- **Findings:** No reusable implementation/tests/docs.
+- **Recommended fix:** Implement nav landmark + current page semantics (`aria-current="page"`) + keyboard/focus checks.
+
+### 16) Show More / Show Less
+- **Severity:** **blocker**
+- **Findings:** No reusable implementation/tests/docs.
+- **Recommended fix:** Implement as disclosure button with `aria-expanded` + controlled region.
+
+### 17) Tags
+- **Severity:** **high**
+- **Findings:** Only non-interactive `badge` exists; no interactive tag/chip with remove/action semantics.
+- **Recommended fix:** Define Tag vs Badge distinction and implement interactive Tag API with button semantics and accessible names.
+
+---
+
+## Cross-cutting gaps
+
+1. **Automated accessibility test coverage is effectively absent for interactive components.**  
+   Severity: **high**
+2. **Documentation-to-implementation drift exists (notably Link disabled behavior).**  
+   Severity: **high**
+3. **Large portion of requested interactive catalog is not implemented as system components.**  
+   Severity: **blocker**
+
+## Recommended remediation order
+
+1. **Blockers first:** implement missing high-impact primitives (Select, Tabs, Accordion, Modal, Tooltip, Pagination, disclosure).
+2. **Close current high-risk defects:** Icon Button naming contract; Link disabled behavior parity.
+3. **Add baseline a11y test harness:** component-level keyboard, role/name/state assertions.
+4. **Promote draft docs/components after verification:** Link/Switch and newly added components.
+

--- a/docs/accessibility-audit-interactive-components.md
+++ b/docs/accessibility-audit-interactive-components.md
@@ -1,203 +1,30 @@
-# Accessibility Audit — Interactive Components
+# Accessibility Audit — Interactive Components (Workflow-First)
 
-Date: 2026-05-04  
-Mode: Audit (read-only analysis; no component implementation changes)
+Date: 2026-05-04
 
-## Scope
+## Objective of this PR
 
-Included components requested:
-- Button
-- Icon Button
-- Link
-- Input
-- Select
-- Checkbox
-- Radio
-- Switch
-- Tabs
-- Accordion
-- Modal
-- Flyout
-- Dropdown
-- Tooltip
-- Pagination
-- Show More / Show Less
-- Tags
+This PR intentionally focuses on establishing a **reusable audit workflow** and **finding format** before broad component remediation.
 
-Excluded (per request): Divider, Grid, Image, Skeleton, Loader, Typography utilities.
+## Primary deliverable
 
-## Inventory summary
+Use the reusable skill document:
 
-Implemented interactive components in this repository today: **Button, Link, Input, Checkbox, Radio, Switch** via CSS patterns + docs + Nunjucks + React wrappers.  
-Not implemented as reusable components in this repository today: **Icon Button (standalone), Select, Tabs, Accordion, Modal, Flyout, Dropdown, Tooltip, Pagination, Show More / Show Less, Tags**.
+- `docs/agentic/skills/component-accessibility-audit.md`
 
----
+This skill defines:
+- required governance references
+- repeatable audit workflow
+- severity model (blocker/high/medium/low)
+- standardized findings template
+- minimal-fix strategy
+- manual screen reader validation requirements
+- example single-component audit prompt
 
-## Detailed audit
+## Follow-up plan
 
-### 1) Button
-- **Semantic role check:** ✅ Uses native `<button>` in Nunjucks and React wrappers.
-- **Accessible name check:** ⚠️ Text labels are supported; icon-only enforcement is incomplete in templates. React warns for missing label but does not enforce.
-- **Keyboard interaction check:** ✅ Native button keyboard semantics preserved (Enter/Space).
-- **Focus behavior check:** ✅ Focus-visible styles are implemented in CSS.
-- **ARIA/state check:** ⚠️ Toggle semantics are only present in `toggleButton` helper (`aria-pressed`), but the main button macro has no explicit toggle API guidance.
-- **Form association check:** ✅ `type` attribute supported (`button`/`submit`/`reset`) in docs and macros.
-- **Test coverage gaps:** ❌ No component-level unit/a11y tests found for button behavior, icon-only labeling, disabled focus/tab behavior.
-- **Documentation gaps:** ⚠️ No dedicated icon-only accessibility contract (required `aria-label`) in the component doc.
-- **Severity:** **medium**
-- **Recommended fix:** Add automated a11y tests (accessible-name requirements, keyboard activation, disabled/tab order) and document icon-only requirement explicitly.
-
-### 2) Icon Button
-- **Semantic role check:** ⚠️ No first-class Icon Button component; behavior piggybacks on generic Button + icon-only state.
-- **Accessible name check:** ❌ Risk of unnamed controls in Nunjucks macro path (no guard for icon-only without label).
-- **Keyboard interaction check:** ⚠️ Inherits button semantics where used, but no formal API contract/component.
-- **Focus behavior check:** ⚠️ Inherits button focus styles where used.
-- **ARIA/state check:** ⚠️ React warns in dev for missing aria label; not a runtime guarantee.
-- **Form association check:** ✅ Same as button where implemented.
-- **Test coverage gaps:** ❌ No dedicated tests for icon-only button naming.
-- **Documentation gaps:** ❌ No standalone Icon Button doc/API and no explicit accessibility checklist for icon-only actions.
-- **Severity:** **high**
-- **Recommended fix:** Introduce explicit Icon Button API requiring accessible name (compile/runtime assertion), plus tests and docs.
-
-### 3) Link
-- **Semantic role check:** ✅ Uses native `<a>`.
-- **Accessible name check:** ✅ Text content provides name by default.
-- **Keyboard interaction check:** ⚠️ Native behavior applies for valid `href`, but disabled pattern keeps `href` and does not remove from tab order.
-- **Focus behavior check:** ✅ Focus-visible styling exists in CSS link pattern.
-- **ARIA/state check:** ⚠️ `aria-disabled="true"` is set for disabled state, but interaction suppression (`tabindex="-1"`, click prevention) is not implemented in macro.
-- **Form association check:** N/A
-- **Test coverage gaps:** ❌ No tests for disabled-link keyboard/tab/click behavior.
-- **Documentation gaps:** ❌ Docs state disabled links should have `tabindex="-1"`, but macro does not implement it (doc/implementation drift).
-- **Severity:** **high**
-- **Recommended fix:** Align implementation with docs for disabled links (`tabindex=-1`, prevent activation) or remove disabled-link pattern and recommend button for disabled actions.
-
-### 4) Input
-- **Semantic role check:** ✅ Uses native `<input>`.
-- **Accessible name check:** ⚠️ Supports `id/name`, but no built-in label coupling; relies on consumer to provide `<label>`/`aria-label`.
-- **Keyboard interaction check:** ✅ Native text input keyboard behavior retained.
-- **Focus behavior check:** ✅ Focus-visible state styling is present.
-- **ARIA/state check:** ⚠️ No first-class invalid/error ARIA guidance (`aria-invalid`, `aria-describedby`) in component API.
-- **Form association check:** ⚠️ Possible via `id`/`name`, but not enforced.
-- **Test coverage gaps:** ❌ No tests for accessible labeling and error semantics.
-- **Documentation gaps:** ⚠️ Guidance exists generally, but no strict API examples requiring label association in all snippets.
-- **Severity:** **medium**
-- **Recommended fix:** Add examples and tests requiring label association + error/help text semantics.
-
-### 5) Select
-- **Semantic role check:** ❌ No reusable Select component implementation found.
-- **Accessible name check:** ❌ No component contract.
-- **Keyboard interaction check:** ❌ No component contract.
-- **Focus behavior check:** ❌ No component contract.
-- **ARIA/state check:** ❌ No component contract.
-- **Form association check:** ❌ No component contract.
-- **Test coverage gaps:** ❌ No tests.
-- **Documentation gaps:** ❌ No component doc.
-- **Severity:** **blocker**
-- **Recommended fix:** Define and implement native `<select>` component with documented labeling/error patterns and keyboard expectations.
-
-### 6) Checkbox
-- **Semantic role check:** ✅ Native `<input type="checkbox">` used.
-- **Accessible name check:** ✅ Wrapped in `<label>` when label text provided; React warns if unnamed.
-- **Keyboard interaction check:** ✅ Native checkbox keyboard semantics preserved.
-- **Focus behavior check:** ✅ Focus-visible styles included.
-- **ARIA/state check:** ✅/⚠️ Indeterminate is supported (`aria-checked="mixed"` + React `indeterminate` property), but requires careful sync when controlled externally.
-- **Form association check:** ✅ `name/value/id` supported.
-- **Test coverage gaps:** ❌ No tests for indeterminate semantics and keyboard behavior.
-- **Documentation gaps:** ⚠️ Could better specify grouping with `<fieldset>/<legend>` in all form examples.
-- **Severity:** **medium**
-- **Recommended fix:** Add unit/a11y tests for mixed state, labeling, and keyboard behavior; tighten docs with grouped-form examples.
-
-### 7) Radio
-- **Semantic role check:** ✅ Native `<input type="radio">` used.
-- **Accessible name check:** ✅ Labeled via wrapper label.
-- **Keyboard interaction check:** ⚠️ Native behavior depends on correct same-`name` grouping; examples include names, but enforcement is consumer-driven.
-- **Focus behavior check:** ✅ Focus-visible styles included.
-- **ARIA/state check:** ✅ Native radio semantics are used.
-- **Form association check:** ⚠️ Requires `name` for proper group behavior; not enforced by API.
-- **Test coverage gaps:** ❌ No tests for arrow-key movement/group semantics.
-- **Documentation gaps:** ⚠️ Docs correctly call for `<fieldset>/<legend>`, but reusable grouped abstraction is absent.
-- **Severity:** **medium**
-- **Recommended fix:** Add `RadioGroup` abstraction or validation helper + tests for group keyboard behavior and naming.
-
-### 8) Switch
-- **Semantic role check:** ✅ Uses `<input type="checkbox" role="switch">`.
-- **Accessible name check:** ✅ Label wrapper present; React warns if unlabeled.
-- **Keyboard interaction check:** ✅ Native checkbox keyboard behavior (Space toggle) retained.
-- **Focus behavior check:** ✅ Focus-visible styles included.
-- **ARIA/state check:** ✅ Uses role switch with native checked state.
-- **Form association check:** ✅ Supports `name/value/id`.
-- **Test coverage gaps:** ❌ No tests for role/state announcements and keyboard toggling.
-- **Documentation gaps:** ⚠️ Draft status; needs stronger screen reader expectation examples.
-- **Severity:** **low**
-- **Recommended fix:** Add focused a11y tests and finalize docs from draft to stable once verified.
-
-### 9) Tabs
-- **Semantic role check:** ❌ No reusable Tabs component.
-- **Accessible name check:** ❌ Missing component contract.
-- **Keyboard interaction check:** ❌ Missing roving tabindex/arrow-key pattern.
-- **Focus behavior check:** ❌ Missing.
-- **ARIA/state check:** ❌ Missing `tablist/tab/tabpanel` relationships.
-- **Form association check:** N/A
-- **Test coverage gaps:** ❌ None.
-- **Documentation gaps:** ❌ None.
-- **Severity:** **blocker**
-- **Recommended fix:** Implement APG-aligned tabs with full keyboard and ARIA relationships.
-
-### 10) Accordion
-- **Severity:** **blocker**
-- **Findings:** No reusable implementation/tests/docs; no verified heading/button/`aria-expanded`/`aria-controls` pattern.
-- **Recommended fix:** Implement APG accordion pattern and tests.
-
-### 11) Modal
-- **Severity:** **blocker**
-- **Findings:** No reusable implementation/tests/docs; no focus trap, initial focus, escape handling, restore-focus contract verified.
-- **Recommended fix:** Implement dialog with robust focus management and inert/background interaction strategy.
-
-### 12) Flyout
-- **Severity:** **blocker**
-- **Findings:** No reusable implementation/tests/docs.
-- **Recommended fix:** Define flyout semantics (menu/dialog/popover) first, then implement with matching keyboard/ARIA behavior.
-
-### 13) Dropdown
-- **Severity:** **blocker**
-- **Findings:** No reusable implementation/tests/docs; ambiguous whether it means select-like or menu-like behavior.
-- **Recommended fix:** Split into explicit components (Select vs MenuButton) and implement each with proper patterns.
-
-### 14) Tooltip
-- **Severity:** **blocker**
-- **Findings:** No reusable implementation/tests/docs; no trigger/focus/escape semantics.
-- **Recommended fix:** Implement non-interactive tooltip pattern (`role=tooltip`, `aria-describedby`) and keyboard/focus behavior.
-
-### 15) Pagination
-- **Severity:** **blocker**
-- **Findings:** No reusable implementation/tests/docs.
-- **Recommended fix:** Implement nav landmark + current page semantics (`aria-current="page"`) + keyboard/focus checks.
-
-### 16) Show More / Show Less
-- **Severity:** **blocker**
-- **Findings:** No reusable implementation/tests/docs.
-- **Recommended fix:** Implement as disclosure button with `aria-expanded` + controlled region.
-
-### 17) Tags
-- **Severity:** **high**
-- **Findings:** Only non-interactive `badge` exists; no interactive tag/chip with remove/action semantics.
-- **Recommended fix:** Define Tag vs Badge distinction and implement interactive Tag API with button semantics and accessible names.
-
----
-
-## Cross-cutting gaps
-
-1. **Automated accessibility test coverage is effectively absent for interactive components.**  
-   Severity: **high**
-2. **Documentation-to-implementation drift exists (notably Link disabled behavior).**  
-   Severity: **high**
-3. **Large portion of requested interactive catalog is not implemented as system components.**  
-   Severity: **blocker**
-
-## Recommended remediation order
-
-1. **Blockers first:** implement missing high-impact primitives (Select, Tabs, Accordion, Modal, Tooltip, Pagination, disclosure).
-2. **Close current high-risk defects:** Icon Button naming contract; Link disabled behavior parity.
-3. **Add baseline a11y test harness:** component-level keyboard, role/name/state assertions.
-4. **Promote draft docs/components after verification:** Link/Switch and newly added components.
-
+After this workflow-first PR, create **small component-specific PRs** that:
+1. run the skill for one component,
+2. publish findings using the standard template,
+3. apply minimal scoped fixes,
+4. add/adjust tests and docs for that component only.

--- a/docs/agentic/README.md
+++ b/docs/agentic/README.md
@@ -32,3 +32,4 @@ in the repository.
 ## Skills
 
 - `skills/ux-writing-coach.md` — multilingual UX writing review skill for product copy
+- `skills/component-accessibility-audit.md` — repeatable workflow and template for single-component accessibility audits

--- a/docs/agentic/skills/component-accessibility-audit.md
+++ b/docs/agentic/skills/component-accessibility-audit.md
@@ -1,0 +1,132 @@
+# Component Accessibility Audit Skill
+
+## Purpose
+
+Create a repeatable, component-level accessibility audit workflow before implementation fixes.
+
+Use this skill to evaluate one interactive component at a time and produce findings in a consistent format that can drive small follow-up PRs.
+
+## Governance references (must read first)
+
+1. `DESIGN.md`
+2. `AGENTS.md`
+3. `docs/playbook.md`
+4. `docs/working-context.md`
+5. `docs/ui-foundations-rules.md`
+6. `docs/foundations/`
+7. `docs/agentic/assistant-behavior-rules.md`
+8. `IMPLEMENTATION.md`
+
+Never contradict these sources. Prefer explicit, verifiable findings over assumptions.
+
+## Scope
+
+Apply this skill to interactive components (e.g., Button, Link, Input, Select, Checkbox, Radio, Switch, Tabs, Accordion, Modal, Flyout, Dropdown, Tooltip, Pagination, Show More/Show Less, Tags).
+
+Do not use this skill to implement broad fixes in the same PR. This skill is audit-first.
+
+## Audit workflow (repeatable)
+
+1. **Plan**
+   - Select exactly one component target.
+   - Confirm component surfaces in scope (CSS pattern, macro/template, React wrapper, docs, tests).
+
+2. **Collect evidence**
+   - Inspect source implementation files.
+   - Inspect usage examples and docs.
+   - Inspect test coverage.
+   - Record exact file paths and relevant lines.
+
+3. **Run checks**
+   - Semantic HTML
+   - Accessible names
+   - Keyboard behavior
+   - Focus management
+   - ARIA/state handling
+   - Form association (where relevant)
+   - Icon-only usage
+   - Contrast/token risks
+   - Test coverage
+   - Documentation gaps
+   - Manual screen reader validation needs
+
+4. **Score severity**
+   - Assign one severity per finding using the model below.
+
+5. **Propose minimal fix**
+   - Suggest the smallest safe change that resolves the finding.
+   - Keep fixes scoped to one component per follow-up PR.
+
+6. **Report**
+   - Output findings using the template in this document.
+
+## Severity model
+
+Use one of these labels:
+
+- **blocker**
+  - Breaks core accessibility behavior (e.g., no accessible name, unusable keyboard path, broken form semantics, missing focus trap in modal).
+  - Should be fixed before release.
+
+- **high**
+  - Major accessibility risk with likely user impact, but possible workaround exists.
+  - Prioritize immediately after blockers.
+
+- **medium**
+  - Important gap or drift that reduces accessibility quality/reliability.
+  - Schedule in near-term follow-up.
+
+- **low**
+  - Minor issue, documentation gap, or optimization with limited immediate impact.
+  - Track and resolve in routine improvements.
+
+## Findings template
+
+Use this exact structure for each finding:
+
+- **Component:**
+- **Check area:** (semantic HTML / accessible name / keyboard / focus / ARIA-state / form association / icon-only / contrast-token / tests / docs / manual SR)
+- **Observed behavior:**
+- **Expected behavior:**
+- **Evidence:** (file paths + line refs)
+- **Severity:** blocker | high | medium | low
+- **Minimal fix strategy:**
+- **Follow-up test need:**
+- **Manual SR validation need:**
+
+## Minimal-fix strategy
+
+When proposing a fix:
+
+1. Prefer native semantics over custom ARIA.
+2. Change the smallest surface that safely resolves the issue.
+3. Keep API compatibility unless current API is inherently inaccessible.
+4. Update docs and tests in the same small PR when behavior changes.
+5. Avoid cross-component refactors in accessibility fix PRs.
+
+## Manual screen reader validation guidance
+
+For each audited component, explicitly state whether manual SR validation is needed and why.
+
+Recommended baseline matrix:
+- VoiceOver + Safari (macOS)
+- NVDA + Firefox (Windows)
+- Optional: JAWS + Chrome for enterprise parity
+
+Validate at minimum:
+- role announcement
+- name announcement
+- state announcement
+- focus order
+- action feedback after interaction
+
+## Example audit prompt (single component)
+
+> Audit the `Link` component only using the Component Accessibility Audit Skill. Check semantic HTML, accessible names, keyboard behavior, focus management, ARIA/state handling, icon-only usage, contrast/token risks, tests, docs, and manual screen reader validation needs. Output findings using the required template and assign severity with blocker/high/medium/low. Do not implement fixes.
+
+## Output expectations
+
+- Be explicit and evidence-based.
+- Distinguish verified findings from assumptions.
+- Keep findings actionable for small follow-up PRs.
+- If not verified, mark as "not verified".


### PR DESCRIPTION
### Motivation
- Produce a comprehensive, repo-aligned accessibility audit for the interactive component surface requested (Button, Icon Button, Link, Input, Select, Checkbox, Radio, Switch, Tabs, Accordion, Modal, Flyout, Dropdown, Tooltip, Pagination, Show More / Show Less, Tags). 
- Surface implementation vs documentation drift, test gaps, and a prioritized remediation plan so engineering and design can triage required fixes without making code changes yet.

### Description
- Add a new audit document at `docs/accessibility-audit-interactive-components.md` that inventories implemented components, lists missing/reused components, and provides per-component checks (semantic role, accessible name, keyboard interactions, focus behavior, ARIA/state, form association where relevant) plus severity and recommended fixes. 
- Call out cross-cutting issues including lack of automated a11y tests, documentation-to-implementation drift (notably disabled-link behavior), and many high-impact components missing from the system as blocker items. 
- Include a prioritized remediation order recommending blockers-first fixes, creation of an a11y test harness, and documentation updates; this is an audit-only change and does not modify component code or tokens. 

### Testing
- This is a documentation-only change so no automated unit or integration tests were executed against modified runtime code. 
- Recommend running the repository validation suite after implementing fixes, e.g. `npm run lint`, `npm run test:unit`, and `npm run ci:check`, to verify no regressions and to add targeted a11y tests for components.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8ec552c5883298e6db7dcf929d70a)