### PR TITLE
chore: add GitHub issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,78 @@
+---
+name: Bug report
+about: Create a report to help me improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+---
+name: Bug Report
+about: Report a visual, functional, or token-related issue in UI Foundations
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## Affected area
+
+<!-- Check all that apply -->
+
+- [ ] CSS pattern (e.g. button, input, checkbox)
+- [ ] Design tokens (value, naming, or mapping)
+- [ ] React wrapper
+- [ ] Documentation site
+- [ ] Playground
+- [ ] Icons / assets
+- [ ] Build / CI pipeline
+
+## Component (if applicable)
+
+<!-- e.g. Button, Input, Checkbox, Switch, Label, Icon, Radio, Slider, Link, Badge -->
+
+**Component:** 
+**Variant/State:** 
+
+## Token layer (if applicable)
+
+<!-- Which layer is affected? -->
+
+- [ ] Core (Primitives)
+- [ ] Color Modes (Light/Dark)
+- [ ] Semantics (Roles)
+- [ ] Components (UI)
+- [ ] Brand override
+
+## To reproduce
+
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Screenshots
+
+If applicable, add screenshots to help explain your problem.
+
+## Environment
+
+- **OS:** [e.g. macOS 15, Windows 11]
+- **Browser:** [e.g. Chrome 125, Safari 18, Firefox 128]
+- **Package version:** [e.g. 0.5.0]
+- **Brand:** [e.g. brand-a, brand-b, brand-c]
+- **Color mode:** [e.g. light, dark]
+
+## Additional context
+
+<!-- Anything else: related tokens, Figma link, CI output, etc. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Add project-specific issue templates tailored to the design system workflow:

- Bug report template with fields for affected area, component/variant,
  token layer, brand, and color mode
- Feature request template with scope checkboxes, token impact assessment,
  and Figma reference field

Both templates reflect the token-first architecture (Core → Semantic →
Component → Brand) and multi-brand/multi-mode setup so that reporters
provide the context needed for efficient triage.