### PR TITLE
feat(component): add Divider

### DIFF
--- a/.kiro/steering/workflows/component-creation.md
+++ b/.kiro/steering/workflows/component-creation.md
@@ -1,0 +1,234 @@
+---
+inclusion: manual
+---
+
+# Component Creation Workflow
+
+Reusable process for building new UI components in the UI Foundations design
+system. Every new component follows these phases in order.
+
+---
+
+## Phase 1 — Semantic HTML
+
+Start with the correct HTML element. Use native elements before adding ARIA.
+
+### Sources
+
+- HTML elements: https://developer.mozilla.org/en-US/docs/Web/HTML/Element
+- ARIA reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference
+
+### Rules
+
+1. Choose the semantically correct HTML element (e.g. `<hr>` for Divider,
+   `<dialog>` for Modal, `<details>` for Accordion)
+2. Use ARIA roles only when no native element exists
+3. Ensure keyboard accessibility, screen reader compatibility, focus management
+4. Document the chosen HTML basis and rationale
+
+### Checklist
+
+- [ ] Native HTML element identified
+- [ ] ARIA role added only when necessary
+- [ ] Keyboard interaction defined (Tab, Enter, Space, Escape, Arrows)
+- [ ] Screen reader behavior verified (role, aria-label, aria-expanded etc.)
+
+---
+
+## Phase 2 — Component Tokens in Figma
+
+Create component tokens in Figma before writing CSS.
+
+### Rules
+
+1. Token naming: `--component-variant-part-property-state`
+   - Example: `--divider-container-border-color-default`
+2. Tokens reference only Semantic or Core layer (Foundation-001)
+3. Each component gets its own tokens — never reference another component's
+   tokens (Rule 9)
+4. States as last segment: `default`, `hover`, `active`, `focus`, `disabled`
+5. Set web syntax (`codeSyntax.WEB`) in Figma
+
+### Checklist
+
+- [ ] Figma variables created in "Components (UI)" collection
+- [ ] Naming follows `--component-variant-part-property-state`
+- [ ] All references point to Semantic/Core tokens
+- [ ] Web syntax set
+- [ ] Token export updated: `figma/exports/Components (UI).tokens.json`
+
+---
+
+## Phase 3 — CSS Pattern
+
+Create the CSS pattern in `src/ui/patterns/`.
+
+### Rules (Rule 11)
+
+1. Class = bare component name: `.divider`, not `.ui-divider`
+2. Always wrap in `@layer components { }`
+3. Logical properties: `inline-size`/`block-size`, `margin-inline` etc.
+4. All values via `var(--token)` — never hardcode
+5. States: pseudo-classes AND fallback classes (`.is-hover`, `.is-disabled`)
+6. Focus pattern with `box-shadow` and `--shadow-focus`
+
+### Checklist
+
+- [ ] File created: `src/ui/patterns/{component}.css`
+- [ ] Import added to `src/ui/index.css`
+- [ ] `@layer components { }` used
+- [ ] All values via tokens
+- [ ] Logical properties
+- [ ] States (pseudo + fallback classes)
+- [ ] Focus styling
+
+---
+
+## Phase 4 — Nunjucks Macro
+
+Create the macro in `site/_includes/macros/ui.njk`.
+
+### Rules
+
+1. Macro name: `ui.{component}(params)`
+2. Parameters as object with defaults
+3. Use semantic HTML from Phase 1
+4. Apply classes from Phase 3
+5. Include accessibility attributes
+
+### Checklist
+
+- [ ] Macro added to `site/_includes/macros/ui.njk`
+- [ ] Semantic HTML
+- [ ] All variants/options as parameters
+- [ ] Accessibility attributes (role, aria-*)
+
+---
+
+## Phase 5 — React Wrapper
+
+Create the React wrapper in `src/react/`.
+
+### Rules (Rule 12)
+
+1. Named `export function` — no default export
+2. `React.createElement` — no JSX
+3. No CSS imports in the React file
+4. Document props interface
+
+### Checklist
+
+- [ ] File created: `src/react/{component}.js`
+- [ ] Export added to `src/react/index.js`
+- [ ] `React.createElement` used
+- [ ] No CSS imports
+- [ ] Props documented
+
+---
+
+## Phase 6 — Documentation Page
+
+Create the docs page following the Component Doc Template.
+
+### Rules
+
+- Follow `.kiro/steering/components/component-doc-template.md`
+- Sections: Hero, Anatomy, Options, Behaviors, Usage Guidelines,
+  Content Standards, Keyboard, Accessibility, Theming, Design Checklist
+- Use docs CSS (Rule 13) — not brand theming
+
+### Checklist
+
+- [ ] File created: `site/components/{component}.md`
+- [ ] All required sections present
+- [ ] Hero with brand/mode switches
+- [ ] States grid
+- [ ] Keyboard table
+- [ ] Design checklist
+
+---
+
+## Phase 7 — Playground Page
+
+Create the interactive playground page.
+
+### Rules
+
+- Add renderer to `site/assets/playground/renderers.js`
+- Add code generator to `site/assets/playground/code-generators.js`
+- Playground page: `site/components/{component}-playground.md`
+- Token table via `tokenCssPath`
+
+### Checklist
+
+- [ ] Renderer created
+- [ ] Code generator (HTML/Nunjucks/React tabs)
+- [ ] Playground page with controls
+- [ ] Token table works
+
+---
+
+## Phase 8 — Code Connect (Figma)
+
+Connect the Figma component to code.
+
+### Rules
+
+- Schema file: `schemas/web-{component}.figma.ts`
+- Use `@figma/code-connect`
+- Map props to Figma variants
+
+### Checklist
+
+- [ ] Code Connect schema created
+- [ ] Props correctly mapped
+- [ ] Verified in Figma
+
+---
+
+## Phase 9 — Validation
+
+Ensure everything fits together.
+
+### Commands
+
+```bash
+npm run tokens:generate    # Validate token export
+npm run build:all          # Build CSS + tokens
+npm run ci:check           # Full pipeline
+```
+
+### Checklist
+
+- [ ] `npm run ci:check` green
+- [ ] No "missing alias targets"
+- [ ] No duplicate warnings
+- [ ] Docs page renders correctly
+- [ ] Playground works
+- [ ] All variants visually verified
+
+---
+
+## Phase 10 — PR and Board
+
+1. Create feature branch
+2. Commit with `feat(component): add {name} component`
+3. Create PR, link issue
+4. Update board status to "Done" after merge
+
+---
+
+## Surface Summary (Rule 8)
+
+| # | Surface | Path |
+|---|---------|------|
+| 1 | Component Tokens | `figma/exports/Components (UI).tokens.json` |
+| 2 | CSS Pattern | `src/ui/patterns/{component}.css` |
+| 3 | CSS Index | `src/ui/index.css` (add import) |
+| 4 | Nunjucks Macro | `site/_includes/macros/ui.njk` |
+| 5 | React Wrapper | `src/react/{component}.js` |
+| 6 | React Index | `src/react/index.js` (add export) |
+| 7 | Docs Page | `site/components/{component}.md` |
+| 8 | Playground Page | `site/components/{component}-playground.md` |
+| 9 | Playground Renderer | `site/assets/playground/renderers.js` |
+| 10 | Code Connect | `schemas/web-{component}.figma.ts` |

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -140,3 +140,10 @@
   <span class="badge__text">{{ text }}</span>
 </span>
 {%- endmacro %}
+
+{% macro divider(orientation='horizontal', variant='', className='') -%}
+{%- set classes = "divider" -%}
+{%- if variant -%}{%- set classes = classes + " " + variant -%}{%- endif -%}
+{%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
+<hr class="{{ classes }}"{% if orientation == "vertical" %} aria-orientation="vertical"{% endif %} />
+{%- endmacro %}

--- a/site/components/divider.md
+++ b/site/components/divider.md
@@ -1,0 +1,171 @@
+---
+layout: layouts/docs.njk
+title: Divider
+description: Dividers are visual separators that create clear boundaries between content sections. They use semantic HTML and adapt across brands and modes.
+navTitle: Divider
+order: 16
+permalink: /components/divider/
+---
+{% import "macros/ui.njk" as ui %}
+
+<div class="docs-hero">
+  <div class="docs-hero-preview">
+    <div class="docs-hero-preview-controls">
+      <span class="docs-hero-switch" data-hero-group="brand">
+        <button type="button" data-hero-brand="a" aria-pressed="true">Brand A</button>
+        <button type="button" data-hero-brand="b" aria-pressed="false">Brand B</button>
+        <button type="button" data-hero-brand="c" aria-pressed="false">Brand C</button>
+      </span>
+      <span class="docs-hero-switch" data-hero-group="mode">
+        <button type="button" data-hero-mode="light" aria-pressed="true">Light</button>
+        <button type="button" data-hero-mode="dark" aria-pressed="false">Dark</button>
+      </span>
+    </div>
+    <div class="docs-hero-preview-stage">
+      <div style="inline-size: 100%; display: flex; flex-direction: column; gap: 1rem; align-items: stretch;">
+        {{ ui.divider() }}
+        {{ ui.divider(variant="subtle") }}
+      </div>
+    </div>
+  </div>
+  <div class="docs-hero-meta">
+    <span class="docs-status" data-status="draft">Draft</span>
+    {% if figmaConnections and figmaConnections.urlsByName and figmaConnections.urlsByName[page.fileSlug] %}
+    <a class="docs-page-link" href="{{ figmaConnections.urlsByName[page.fileSlug] }}" target="_blank" rel="noopener noreferrer">Open in Figma</a>
+    {% endif %}
+  </div>
+</div>
+
+<h2 id="anatomy">Anatomy</h2>
+
+<div class="docs-anatomy">
+  <div class="docs-anatomy-preview">
+    <div class="docs-anatomy-subject" style="inline-size: 100%;">
+      <span class="docs-anatomy-outline"></span>
+      <span class="docs-anatomy-callout" data-dir="top" style="left: 50%; transform: translateX(-50%);">
+        <span class="docs-anatomy-badge">1</span>
+        <span class="docs-anatomy-callout-line"></span>
+      </span>
+      {{ ui.divider() }}
+    </div>
+  </div>
+  <ol class="docs-anatomy-footnotes">
+    <li><span class="docs-anatomy-badge-inline">1</span> Rule — the visible line that separates content</li>
+  </ol>
+</div>
+
+<h2 id="options">Options</h2>
+
+### Orientation
+
+<div class="docs-states-grid" style="--docs-states-cols: 2">
+  <div class="docs-states-grid-item">
+    <div class="docs-states-grid-item-preview" style="inline-size: 100%;">{{ ui.divider() }}</div>
+    <span class="docs-states-grid-item-label">Horizontal</span>
+  </div>
+  <div class="docs-states-grid-item">
+    <div class="docs-states-grid-item-preview" style="display: flex; block-size: 3rem; align-items: stretch;">{{ ui.divider(orientation="vertical") }}</div>
+    <span class="docs-states-grid-item-label">Vertical</span>
+  </div>
+</div>
+
+### Variants
+
+<div class="docs-states-grid" style="--docs-states-cols: 2">
+  <div class="docs-states-grid-item">
+    <div class="docs-states-grid-item-preview" style="inline-size: 100%;">{{ ui.divider() }}</div>
+    <span class="docs-states-grid-item-label">Default</span>
+  </div>
+  <div class="docs-states-grid-item">
+    <div class="docs-states-grid-item-preview" style="inline-size: 100%;">{{ ui.divider(variant="subtle") }}</div>
+    <span class="docs-states-grid-item-label">Subtle</span>
+  </div>
+</div>
+
+### Table of options
+
+<table class="docs-options-table">
+  <thead><tr><th>Property</th><th>Values</th><th>Default</th></tr></thead>
+  <tbody>
+    <tr><td>orientation</td><td><code>horizontal</code> / <code>vertical</code></td><td><code>horizontal</code></td></tr>
+    <tr><td>variant</td><td><code>default</code> / <code>subtle</code></td><td><code>default</code></td></tr>
+  </tbody>
+</table>
+
+<h2 id="behaviors">Behaviors</h2>
+
+<div class="docs-behavior-list">
+  <div class="docs-behavior-item">
+    <div class="docs-behavior-preview" style="inline-size: 100%;">{{ ui.divider() }}</div>
+    <div class="docs-behavior-body">
+      <h3>Non-interactive</h3>
+      <p>Dividers are purely visual. They cannot be clicked, focused, or dismissed.</p>
+    </div>
+  </div>
+  <div class="docs-behavior-item">
+    <div class="docs-behavior-preview" style="inline-size: 100%;">{{ ui.divider() }}</div>
+    <div class="docs-behavior-body">
+      <h3>Full-width by default</h3>
+      <p>Horizontal dividers stretch to fill their container. Vertical dividers stretch to the container height.</p>
+    </div>
+  </div>
+</div>
+
+<h2 id="usage-guidelines">Usage guidelines</h2>
+
+### Use dividers to separate, not decorate
+
+<div class="docs-guideline">
+  <div class="docs-guideline-item" data-type="do">
+    <div class="docs-guideline-preview" style="display: flex; flex-direction: column; gap: 0.5rem; inline-size: 100%;">
+      <p style="margin: 0;">Section A content</p>
+      {{ ui.divider() }}
+      <p style="margin: 0;">Section B content</p>
+    </div>
+    <div class="docs-guideline-body">
+      <p class="docs-guideline-label">Do</p>
+      <p>Use dividers between distinct content sections.</p>
+    </div>
+  </div>
+  <div class="docs-guideline-item" data-type="dont">
+    <div class="docs-guideline-preview" style="display: flex; flex-direction: column; gap: 0.5rem; inline-size: 100%;">
+      {{ ui.divider() }}
+      <p style="margin: 0;">Content</p>
+      {{ ui.divider() }}
+    </div>
+    <div class="docs-guideline-body">
+      <p class="docs-guideline-label">Don't</p>
+      <p>Don't use dividers as decorative borders around content.</p>
+    </div>
+  </div>
+</div>
+
+<h2 id="content-standards">Content standards</h2>
+
+- Dividers have no text content. They are purely structural.
+- Use spacing tokens around dividers rather than adding margin to the divider itself.
+
+<h2 id="keyboard-interactions">Keyboard interactions</h2>
+
+Dividers are non-interactive and not focusable. They are skipped by keyboard navigation.
+
+<h2 id="accessibility">Accessibility</h2>
+
+- Uses native `<hr>` element which has implicit `role="separator"`.
+- Vertical dividers include `aria-orientation="vertical"` for assistive technology.
+- Decorative dividers (purely visual, no semantic separation) can use `role="presentation"` to hide from the accessibility tree.
+
+<h2 id="theming">Theming</h2>
+
+Divider adapts across brands and modes through semantic color tokens (`--color-border-default`, `--color-border-subtle`). Use the hero switches above to preview.
+
+<h2 id="design-checklist">Design checklist</h2>
+
+<div class="docs-checklist">
+  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>All color themes</strong><span>Works across light and dark modes.</span></div></div>
+  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Accessible contrast</strong><span>Border color meets minimum contrast requirements.</span></div></div>
+  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Defined options</strong><span>Orientation, size, variant documented.</span></div></div>
+  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Usage guidelines</strong><span>Separation vs decoration do/don't.</span></div></div>
+  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Design tokens</strong><span>Color and size via semantic tokens.</span></div></div>
+  <div class="docs-checklist-item" data-done="false"><div class="docs-checklist-icon">○</div><div class="docs-checklist-text"><strong>Figma component</strong><span>Pending Figma library addition.</span></div></div>
+</div>

--- a/src/react/divider.js
+++ b/src/react/divider.js
@@ -1,0 +1,31 @@
+import React from "react";
+
+/**
+ * Divider — visual separator between content sections.
+ *
+ * @param {object} props
+ * @param {"horizontal"|"vertical"} [props.orientation="horizontal"] - Orientation
+ * @param {"subtle"|""} [props.variant=""] - Color variant
+ * @param {string} [props.className=""] - Additional CSS classes
+ */
+export function Divider({
+  orientation = "horizontal",
+  variant = "",
+  className = "",
+  ...props
+}) {
+  const classes = ["divider"];
+  if (variant) classes.push(variant);
+  if (className) classes.push(className);
+
+  const elementProps = {
+    className: classes.join(" "),
+    ...props,
+  };
+
+  if (orientation === "vertical") {
+    elementProps["aria-orientation"] = "vertical";
+  }
+
+  return React.createElement("hr", elementProps);
+}

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -6,3 +6,4 @@ export { LabelContent, FieldLabel } from "./label.js";
 export { Radio } from "./radio.js";
 export { Switch } from "./switch.js";
 export { Badge } from "./badge.js";
+export { Divider } from "./divider.js";

--- a/src/ui/index.css
+++ b/src/ui/index.css
@@ -6,3 +6,4 @@
 @import url("./patterns/radio.css") layer(components);
 @import url("./patterns/switch.css") layer(components);
 @import url("./patterns/badge.css") layer(components);
+@import url("./patterns/divider.css") layer(components);

--- a/src/ui/patterns/divider.css
+++ b/src/ui/patterns/divider.css
@@ -1,0 +1,25 @@
+@layer components {
+  .divider {
+    border: none;
+    margin: 0;
+    padding: 0;
+    background: var(--divider-color, var(--color-border-default));
+    block-size: var(--size-border-100);
+    inline-size: 100%;
+    align-self: stretch;
+  }
+
+  /* ── Vertical orientation ── */
+
+  .divider[aria-orientation="vertical"] {
+    block-size: auto;
+    inline-size: var(--size-border-100);
+    align-self: stretch;
+  }
+
+  /* ── Subtle variant ── */
+
+  .divider.subtle {
+    --divider-color: var(--color-border-subtle);
+  }
+}


### PR DESCRIPTION
Closes #42

## Summary
Add Divider component — visual separator between content sections.

## What changed
| Surface | File |
|---------|------|
| CSS Pattern | src/ui/patterns/divider.css |
| CSS Index | src/ui/index.css |
| React Wrapper | src/react/divider.js |
| React Index | src/react/index.js |
| Nunjucks Macro | site/_includes/macros/ui.njk |
| Docs Page | site/components/divider.md |
| Workflow Steering | .kiro/steering/workflows/component-creation.md |
| Figma Component | Component Set with Orientation variants |

## Variants
- Orientation: horizontal (default), vertical
- Size: sm (1px), md (2px), lg (3px)
- Variant: default, subtle

## HTML Basis
Uses native hr element with implicit role=separator