### PR TITLE
fix(code-connect): audit Button and ButtonGroup schemas

### DIFF
--- a/schemas/web-button-group.ts
+++ b/schemas/web-button-group.ts
@@ -1,7 +1,4 @@
 export interface ButtonGroupProps {
-  className?: string;
-  orientation?: "horizontal" | "vertical";
-  attached?: boolean;
-  justify?: "start" | "stretch";
-  children?: React.ReactNode;
+  orientation: string;
+  attached: string;
 }

--- a/schemas/web-button.figma.ts
+++ b/schemas/web-button.figma.ts
@@ -25,12 +25,7 @@ figma.connect(
         }),
       ]),
       disabled: figma.boolean("Disabled"),
-      text: figma.enum("Icon Only", {
-        False: "Book now",
-        True: "",
-        false: "Book now",
-        true: "",
-      }),
+      text: figma.string("Label"),
       ariaLabel: figma.enum("Icon Only", {
         False: undefined,
         True: "Button",

--- a/schemas/web-button.ts
+++ b/schemas/web-button.ts
@@ -1,11 +1,6 @@
 export interface ButtonProps {
-  variant?: "solid" | "outline" | "ghost";
-  className?: string;
-  type?: "button" | "submit" | "reset";
-  label?: string;
-  startIcon?: React.ReactNode;
-  endIcon?: React.ReactNode;
-  iconOnly?: boolean;
-  ariaLabel?: string;
-  children?: React.ReactNode;
+  className: string;
+  disabled: boolean;
+  text: string;
+  ariaLabel: string | undefined;
 }


### PR DESCRIPTION
## Summary
Clean up Code Connect props interfaces for Button and ButtonGroup — remove React types, use plain Code Connect conventions.

## What changed
| File | Change |
|------|--------|
| schemas/web-button.ts | Replaced React-typed interface with plain props (className, disabled, text, ariaLabel) |
| schemas/web-button-group.ts | Replaced React-typed interface with plain props (orientation, attached) |
| schemas/web-button.figma.ts | Replaced hardcoded "Book now" with figma.string("Label") |

## Context
Part of the Code Connect All Components spec (.kiro/specs/code-connect-all-components/).
Switch and Link schemas are blocked until their Figma components are created.