### PR TITLE
chore: cleanup follow-ups — a11y warnings, docs, steering

### DIFF
--- a/.kiro/steering/components/react-wrappers.md
+++ b/.kiro/steering/components/react-wrappers.md
@@ -25,6 +25,9 @@ When working with files in `src/react/`, these rules apply:
 - If component has a label, wrap in `<label>` with `<span class="component-field__text">`
 - Wrapper class: `component-field`, disabled class: `is-disabled`
 - Check `hasLabelContent()` before rendering wrapper
+- The field-wrapper pattern is intentionally inlined in each component
+  (checkbox, radio, switch). If a 4th component needs the same pattern,
+  extract a shared `FieldWrapper` helper at that point.
 
 ## After creating a new wrapper
 - Add export to `src/react/index.js`

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -40,8 +40,10 @@ Tech stack:
 Note: MCP output is a design reference, not final code.
 
 This repository uses MCP as the active Figma integration path.
-The legacy plugin under `figma/plugin/` still exists in the repo, but it is not
-part of the normal build or validation path.
+The Figma plugin under `figma/plugin/` is a standalone validation/export tool
+loaded directly in Figma. It is not part of the site build or token pipeline, but
+it is actively maintained — `scripts/generate-plugin-meta.mjs` generates its
+entry file and `tests/plugin-code.test.mjs` covers its color utilities.
 
 ---
 

--- a/src/react/input.js
+++ b/src/react/input.js
@@ -1,8 +1,15 @@
 import React from "react";
+import { warnDev } from "./warn-dev.js";
 
 export function Input({ className = "", type = "text", ...props }) {
   const classes = ["input"];
   if (className) classes.push(className);
+
+  if (!props["aria-label"] && !props["aria-labelledby"] && !props.id) {
+    warnDev(
+      "[ui-foundations] Input should be associated with a label via `id`, or include `aria-label`/`aria-labelledby`.",
+    );
+  }
 
   return React.createElement("input", {
     type,

--- a/src/react/textarea.js
+++ b/src/react/textarea.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { warnDev } from "./warn-dev.js";
 
 /**
  * TextArea — multi-line text input.
@@ -22,6 +23,12 @@ export function TextArea({
 }) {
   const classes = ["textarea"];
   if (className) classes.push(className);
+
+  if (!props["aria-label"] && !props["aria-labelledby"] && !props.id) {
+    warnDev(
+      "[ui-foundations] TextArea should be associated with a label via `id`, or include `aria-label`/`aria-labelledby`.",
+    );
+  }
 
   const elementProps = {
     className: classes.join(" "),


### PR DESCRIPTION
- Add warnDev accessibility warnings to Input and TextArea when no label association is provided (id, aria-label, or aria-labelledby)
- Clarify figma/plugin/ status in IMPLEMENTATION.md (actively maintained, not legacy)
- Document field-wrapper extraction threshold in react-wrappers steering