### PR TITLE
docs: reframe React as optional, add Web Components to roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ Components reference only Semantic or Core. Never raw values.
 ### Component Integration
 
 Every component ships with:
-CSS pattern, React wrapper, Nunjucks macro, playground page, docs page,
-and Code Connect mapping.
+CSS pattern, Nunjucks macro, playground page, docs page,
+and Code Connect mapping. React wrappers are available as an optional
+convenience layer but are not required — the CSS classes work in any framework.
 
 All surfaces must be present for the component to work predictably across
 docs, playgrounds, and consumer apps.
@@ -108,10 +109,28 @@ npm install ui-foundations
 
 ### Import
 
-```js
-import "ui-foundations/core.css";
-import "ui-foundations/ui.css";
+```css
+@import "ui-foundations/core.css";
+@import "ui-foundations/ui.css";
 ```
+
+### Use Components (plain HTML)
+
+```html
+<button class="button">Label</button>
+<button class="button outline">Outline</button>
+<input class="input" type="text" />
+```
+
+### Optional: React Wrappers
+
+```js
+import { Button } from "ui-foundations/react/button";
+```
+
+The React wrappers are thin convenience layers that apply CSS classes and
+add dev-mode accessibility warnings. They contain no framework-specific
+logic — the same result is achievable with plain HTML + CSS classes.
 
 ### Apply Theming
 
@@ -247,8 +266,14 @@ npm run release:publish
 
 ## Tech Stack
 
-Vanilla CSS (Custom Properties, `@layer`) · Node.js · Eleventy · React (optional wrappers) · Nunjucks macros · Figma MCP
+Vanilla CSS (Custom Properties, `@layer`) · Node.js · Eleventy · Nunjucks macros · Figma MCP · React (optional wrappers)
 
 ---
 
-MIT License
+## Roadmap
+
+- **Web Components** — replace React wrappers with framework-agnostic custom elements (light DOM, no shadow DOM) so the library is truly platform-independent.
+
+---
+
+PolyForm Noncommercial License 1.0.0

--- a/docs/working-context.md
+++ b/docs/working-context.md
@@ -10,6 +10,10 @@ Provide a compact operating context for humans and agents.
 - Ensure token parity
 - Improve agent-readiness
 
+## Roadmap
+
+- Replace React wrappers with Web Components (light DOM custom elements)
+
 ## Theming
 
 - `data-brand`


### PR DESCRIPTION
- README: position library as CSS-first, framework-agnostic
- README: show plain HTML usage before React
- README: add Roadmap section with Web Components plan
- README: fix license footer (MIT → PolyForm Noncommercial)
- working-context: add WC migration to roadmap