### PR TITLE
chore: clean up agentic setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 .DS_Store
+**/.DS_Store
 node_modules
 dist
 _site

--- a/.goose/recipes/figma-reconciliation.yaml
+++ b/.goose/recipes/figma-reconciliation.yaml
@@ -1,0 +1,45 @@
+version: 1.0.0
+title: Figma Reconciliation
+description: Detect and resolve drift between Figma design and code implementation.
+
+instructions: |
+  You are a Figma/code reconciliation agent for the ui-foundations design system.
+
+  Read these files first:
+  - AGENTS.md (operational rules)
+  - docs/ui-foundations-rules.md (design-to-code rules)
+  - docs/agentic/assistant-behavior-rules.md (component checklist)
+  - IMPLEMENTATION.md (file locations)
+
+  Review these surfaces for each component:
+  1. Token exports: figma/exports/*.tokens.json
+  2. Generated tokens: dist/tokens/css/components-ui.tokens.css
+  3. Code Connect mappings: schemas/*.figma.ts
+  4. CSS implementation: src/ui/patterns/*.css
+  5. React wrappers: src/react/*.js
+  6. Docs/playground: site/components/
+
+  For each component, check:
+  - Are all Figma tokens present in code?
+  - Do CSS variable names match Figma codeSyntax.WEB values?
+  - Are all states covered (default, hover, active, focus, disabled)?
+  - Do Code Connect node IDs point to valid Figma nodes?
+  - Is the docs page showing correct token usage?
+
+  Report format:
+  - Component name
+  - Status: ✅ aligned / ⚠️ drift found
+  - Details of any mismatches
+  - Proposed fixes
+
+extensions:
+  - type: builtin
+    name: developer
+
+activities:
+  - "Check all components for Figma/code drift"
+  - "Reconcile the checkbox component"
+  - "Verify Code Connect mappings are up to date"
+
+prompt: |
+  Run a full Figma/code reconciliation across all components and report drift.

--- a/.kiro/hooks/figma-library-sync.kiro.hook
+++ b/.kiro/hooks/figma-library-sync.kiro.hook
@@ -11,6 +11,6 @@
   },
   "then": {
     "type": "askAgent",
-    "prompt": "A new component CSS pattern was just created. Activate the figma-library-sync skill and follow its workflow to sync this component to the Figma library file. This includes: creating component-level token variables in the Components UI collection with code syntax for Web/iOS/Android, building the component set with proper variants and token bindings, adding code snippets for all three platforms, and using unicode-prefixed variant names. Ask the user for the target Figma file URL if not already known."
+    "prompt": "A new component CSS pattern was created. When the component is stable and ready for library sync, the user can activate the figma-library-sync skill to push it to the Figma library (variables, component set, code syntax, and code snippets). Mention this to the user but do not start the sync automatically — the CSS may still be in progress."
   }
 }

--- a/.kiro/skills/figma-library-sync.md
+++ b/.kiro/skills/figma-library-sync.md
@@ -18,17 +18,15 @@ Activate this skill when the user asks to:
 - Target Figma file URL with a page node ID must be provided
 - The file key is extracted from the URL: `figma.com/design/:fileKey/...`
 
-## Token Architecture (4 layers)
+## Shared Context
 
-The system uses a strict 4-layer token hierarchy. Never mix layers.
+This skill relies on shared facts defined in steering files. Do NOT duplicate
+those facts here — reference them instead:
 
-| Layer | Figma Collection | Source File | Modes |
-|---|---|---|---|
-| Core Primitives | `Core Primitives` | `dist/tokens/css/core-primitives.tokens.css` | Default |
-| Brand Themes | `Brand Themes` | `dist/tokens/css/themes-brands.tokens.*.css` | Brand A, Brand B, Brand C |
-| Appearance Modes | `Appearance Modes` | `dist/tokens/css/appearance-modes.tokens.mode-*.css` | Light, Dark |
-| Semantics Roles | `Semantics Roles` | `dist/tokens/css/semantics-roles.tokens.css` | Default |
-| Components UI | `Components UI` | `dist/tokens/css/components-ui.tokens.css` | Default |
+- **Token architecture (4 layers), file locations, component list:**
+  See `#design-system-context` steering (`foundations/design-system-context.md`)
+- **Component variants, naming, Figma structure:**
+  See `#figma-components` steering (`figma/figma-components.md`)
 
 ## Workflow
 
@@ -38,10 +36,20 @@ Read each CSS file from `dist/tokens/css/`. Extract variable names and values.
 Token names use `/` separators in Figma (e.g. `color/neutral/100`), converted from
 CSS `--color-neutral-100`.
 
+Collections and modes by layer:
+
+| Layer | Figma Collection | Modes |
+|---|---|---|
+| Core Primitives | `Core Primitives` | Default |
+| Brand Themes | `Brand Themes` | Brand A, Brand B, Brand C |
+| Appearance Modes | `Appearance Modes` | Light, Dark |
+| Semantics Roles | `Semantics Roles` | Default |
+| Components UI | `Components UI` | Default |
+
 ### Step 2: Create Variable Collections
 
-For each layer, create a Figma variable collection using `figma.variables.createVariableCollection()`.
-Add modes where needed (Brand A/B, Light/Dark).
+For each layer, create a Figma variable collection using
+`figma.variables.createVariableCollection()`. Add modes where needed.
 
 Variable types:
 - Color tokens → `'COLOR'` variables with `{ r, g, b, a }` values (0–1 range)
@@ -67,36 +75,15 @@ Naming rules:
 
 ### Step 4: Create Components
 
-Components live on a dedicated page. Each component is a `COMPONENT_SET` with variants.
-
-Current components and their variant properties:
-
-| Component | Variants |
-|---|---|
-| Icon | Single component, `Name` text property |
-| Label Content | `Has Text` (True/False) |
-| Button | `Variant` (■ Solid/□ Outline/◇ Ghost), `State` (◻ Default/◼ Hover/▣ Active), `Disabled`, `Icon Only` |
-| Input | `State` (◻ Default/◼ Hover/▣ Active/◎ Readonly/◌ Placeholder), `Disabled` |
-| Checkbox | `Checked` (☐ Unchecked/☑ Checked/▣ Indeterminate), `State` (◻ Default/◼ Hover), `Disabled` |
-| Radio | `Checked` (boolean), `State` (◻ Default/◼ Hover), `Disabled` |
-| Switch | `Checked` (boolean), `State` (◻ Default/◼ Hover/▣ Active), `Disabled` |
-| Badge | `Variant` (○ Default/● Brand/✓ Success/✕ Danger), `Size` (▬ Md/▪ Sm) |
-| Button Group | `Orientation` (→ Horizontal/↓ Vertical), `Attached` (⊞ true/⊟ false) |
-| Link | `State` (◻ Default/◼ Hover/▣ Active) |
-| Field Label | `Required` (boolean) |
-| Checkbox Field | `Checked` (☐/☑/▣ enum), `Is Disabled` — nests Checkbox instance |
-| Radio Field | `Checked` (boolean), `Is Disabled` — nests Radio instance |
-| Switch Field | `Checked` (boolean), `Is Disabled` — nests Switch instance |
-
-Variant naming rules:
-- Enum values get leading unicode symbols (→ ↓ ■ □ ◇ ☐ ☑ etc.)
-- Two-state properties (only checked/unchecked) use boolean `true`/`false`
-- Three-state properties (unchecked/checked/indeterminate) use enum with symbols
+Components live on a dedicated page. Each component is a `COMPONENT_SET` with
+variants. Refer to the `#figma-components` steering for the full variant table
+and naming conventions (unicode-prefixed enum values, boolean properties, etc.).
 
 ### Step 5: Bind Tokens to Components
 
 Use `figma.variables.setBoundVariableForPaint()` for fills and strokes.
-Use `node.setBoundVariable()` for `strokeWeight`, `topLeftRadius`, `paddingLeft`, `itemSpacing`, etc.
+Use `node.setBoundVariable()` for `strokeWeight`, `topLeftRadius`, `paddingLeft`,
+`itemSpacing`, etc.
 
 Each component variant must bind to its own component-layer tokens, never to
 semantic or core tokens directly.
@@ -112,14 +99,13 @@ node.setSharedPluginData('code_snippets', 'snippets', JSON.stringify([
 ]));
 ```
 
-Also set the component `description` field with inline code examples for all three platforms.
+Also set the component `description` field with inline code examples for all
+three platforms.
 
 ### Step 7: Nest Component Instances in Field Components
 
 Field components (Checkbox Field, Radio Field, Switch Field) must use actual
-instances of their control component — never plain shapes. This allows users to
-swap the nested instance variant to change checked/disabled state directly on the
-field component.
+instances of their control component — never plain shapes.
 
 ## Figma Plugin API Patterns
 
@@ -174,25 +160,11 @@ set.layoutWrap = 'WRAP';
 
 ## Gotchas
 
-- `setBoundVariable('fills', ...)` does NOT work — use `setBoundVariableForPaint()` on the paint object instead
-- `layoutSizingHorizontal = 'FILL'` can only be set AFTER the node is appended to an auto-layout parent
+- `setBoundVariable('fills', ...)` does NOT work — use `setBoundVariableForPaint()`
+- `layoutSizingHorizontal = 'FILL'` can only be set AFTER appending to auto-layout parent
 - `layoutWrap = 'WRAP'` only works on `layoutMode = 'HORIZONTAL'` frames
-- `figma.setCurrentPageAsync(page)` is required — `figma.currentPage = page` is not supported
+- `figma.setCurrentPageAsync(page)` is required — assignment is not supported
 - Font must be loaded before setting text: `await figma.loadFontAsync({ family: 'Inter', style: 'Semi Bold' })`
 - For "Inter" font, the style is "Semi Bold" (with space), not "SemiBold"
-- Code Connect API mappings require components to be published to a team library first
-- `currentColor` in SVGs renders as black in Figma (no CSS cascade) — this is fine for icons
-
-## Source Files Reference
-
-| Surface | Path |
-|---|---|
-| Token CSS (core) | `dist/tokens/css/core-primitives.tokens.css` |
-| Token CSS (modes) | `dist/tokens/css/appearance-modes.tokens.mode-*.css` |
-| Token CSS (semantics) | `dist/tokens/css/semantics-roles.tokens.css` |
-| Token CSS (components) | `dist/tokens/css/components-ui.tokens.css` |
-| Token CSS (brands) | `dist/tokens/css/themes-brands.tokens.*.css` |
-| CSS patterns | `src/ui/patterns/*.css` |
-| CSS index | `src/ui/index.css` |
-| Icons | `src/assets/icons/*.svg` |
-| Code Connect schemas | `schemas/web-*.figma.ts` |
+- Code Connect API mappings require components to be published first
+- `currentColor` in SVGs renders as black in Figma — this is fine for icons

--- a/.kiro/specs/accessibility-test-suite/.config.kiro
+++ b/.kiro/specs/accessibility-test-suite/.config.kiro
@@ -1,1 +1,1 @@
-{"specId": "a7e2c1d4-9f38-4b6a-b2e0-3d8f5a1c7e90", "workflowType": "requirements-first", "specType": "feature"}
+{"specId": "a7e2c1d4-9f38-4b6a-b2e0-3d8f5a1c7e90", "workflowType": "requirements-first", "specType": "feature", "status": "requirements-complete"}

--- a/.kiro/specs/code-connect-all-components/.config.kiro
+++ b/.kiro/specs/code-connect-all-components/.config.kiro
@@ -1,1 +1,1 @@
-{"specId": "9d1a23d8-c22e-4e14-a777-f79a4dd79423", "workflowType": "requirements-first", "specType": "feature"}
+{"specId": "9d1a23d8-c22e-4e14-a777-f79a4dd79423", "workflowType": "requirements-first", "specType": "feature", "status": "implementation-ready"}

--- a/.kiro/specs/component-scaffolding-cli/.config.kiro
+++ b/.kiro/specs/component-scaffolding-cli/.config.kiro
@@ -1,1 +1,1 @@
-{"specId": "b3d4e5f6-1a2b-4c3d-8e9f-0a1b2c3d4e5f", "workflowType": "requirements-first", "specType": "feature"}
+{"specId": "b3d4e5f6-1a2b-4c3d-8e9f-0a1b2c3d4e5f", "workflowType": "requirements-first", "specType": "feature", "status": "requirements-complete"}

--- a/.kiro/specs/dark-mode-validation/.config.kiro
+++ b/.kiro/specs/dark-mode-validation/.config.kiro
@@ -1,1 +1,1 @@
-{"specId": "c4e5f6a7-2b3c-4d5e-9f0a-1b2c3d4e5f6a", "workflowType": "requirements-first", "specType": "feature"}
+{"specId": "c4e5f6a7-2b3c-4d5e-9f0a-1b2c3d4e5f6a", "workflowType": "requirements-first", "specType": "feature", "status": "requirements-complete"}

--- a/.kiro/specs/docs-navbar-search/.config.kiro
+++ b/.kiro/specs/docs-navbar-search/.config.kiro
@@ -1,1 +1,1 @@
-{"specId": "4a77642f-89b3-4fd9-9833-7855539cd63a", "workflowType": "requirements-first", "specType": "feature"}
+{"specId": "4a77642f-89b3-4fd9-9833-7855539cd63a", "workflowType": "requirements-first", "specType": "feature", "status": "implementation-ready"}

--- a/.kiro/specs/token-drift-detection/.config.kiro
+++ b/.kiro/specs/token-drift-detection/.config.kiro
@@ -1,1 +1,1 @@
-{"specId": "0abccaf1-7b46-4ab8-a61b-0a6bc0e18130", "workflowType": "requirements-first", "specType": "feature"}
+{"specId": "0abccaf1-7b46-4ab8-a61b-0a6bc0e18130", "workflowType": "requirements-first", "specType": "feature", "status": "requirements-complete"}

--- a/.kiro/steering/README.md
+++ b/.kiro/steering/README.md
@@ -1,0 +1,61 @@
+# Steering Files — Task Index
+
+This file maps common task types to the steering files an agent should load.
+Use it to reduce ambiguity when multiple steering files could apply.
+
+## Always Loaded (foundations)
+
+These are included in every prompt automatically:
+
+- `foundations/design-system-context.md` — token architecture, file locations, rules, language policy
+- `foundations/design-principles.md` — composition principles with traceability IDs
+- `foundations/usability-heuristics.md` — interaction heuristics with traceability IDs
+
+## Task → Steering Map
+
+### Creating a component
+
+1. `workflows/component-creation.md`
+2. `components/component-patterns.md`
+3. `components/react-wrappers.md`
+4. `components/component-rule-map.md`
+5. `foundations/token-exports.md` (if token work needed)
+
+### Writing documentation
+
+1. `components/component-doc-template.md`
+
+### Pattern rule work
+
+1. `workflows/rule-generation.md`
+2. `foundations/design-principles.md`
+3. `foundations/usability-heuristics.md`
+4. Pattern rules in `pattern-rules/` relevant to the domain
+
+### Figma library sync
+
+1. Activate skill: `figma-library-sync`
+2. `figma/figma-components.md`
+3. `figma/figma-connections.md`
+
+### Building cheatsheet slides
+
+1. `figma/cheatsheet-builder-rules.md` (layout, style, cards)
+2. `figma/cheatsheet-builder-frames.md` (per-frame content)
+
+### Figma reconciliation
+
+1. `figma/figma-reconciliation.md`
+2. `figma/figma-components.md`
+
+### Pull requests
+
+1. `workflows/pull-requests.md`
+
+## Inclusion Modes
+
+| Mode | Front-matter | Behavior |
+|---|---|---|
+| Always | _(none or `inclusion: always`)_ | Loaded every prompt |
+| Manual | `inclusion: manual` | Only loaded when user references via `#` |
+| File match | `inclusion: fileMatch` + `fileMatchPattern` | Loaded when matching file enters context |

--- a/.kiro/steering/figma/cheatsheet-builder-frames.md
+++ b/.kiro/steering/figma/cheatsheet-builder-frames.md
@@ -1,0 +1,170 @@
+---
+inclusion: manual
+---
+
+# Cheatsheet Builder — Frame Content Definitions
+
+Per-frame content for the UI Foundations cheatsheet slide deck.
+Load `#cheatsheet-builder-rules` for layout, style, and validation rules.
+
+## Icon Names by Topic
+
+| Topic | Icons |
+|---|---|
+| Tokens | `pricetag`, `diamond`, `layers` |
+| Components | `puzzle`, `code`, `list` |
+| Tooling | `toolkit`, `linked`, `document`, `robot` |
+| Governance | `shield`, `shield-check`, `checkmark-circled` |
+| Theming | `settings`, `star`, `crown` |
+| Pipeline | `sync`, `arrow`, `folder`, `picture` |
+| Patterns | `notepad`, `compass`, `search`, `message-info` |
+| Validation | `badge-check`, `accessibility-circled` |
+| Workflow | `play`, `focus`, `light-bulb` |
+| General | `world-globe`, `exclamation-mark-circled`, `typography` |
+
+## Frame Order
+
+```
+00 Overview — Hero + pipeline flow + 4-layer grid
+01 Tokens — 3-layer cards + theming model + naming
+02 Components — Icon grid + structure card + code example
+03 Tooling — Tool highlight cards + pipeline + commands
+04 Governance — Rule bullets + CI pipeline + agent rules
+05 Token Architecture — Layer cards with file paths + reference chain
+06 Theming — Brand comparison + CSS strategy + layer order
+07 Pipeline — Step flow cards + output files
+08 Component Model — 10-surface checklist + CSS anatomy
+09 Patterns — Pattern type cards + purpose + rule pipeline
+10 Validation — Validation checks + numbered CI steps
+11 Kiro Workflow — Agent step cards + steering files + hooks
+12 Final Poster — 3-column summary + footer
+```
+
+## Frame 00 — Overview (Hero)
+
+**Header:** Dark header (`Brand/Color/Functional/Base Dark`), icon: `world-globe`
+**Body:**
+- Left column: Pipeline flow card showing Figma → Tokens → CSS → Components → Docs
+- Right column: 4-layer grid card (Core → Semantic → Component → Brand)
+- Card types: Flow + Layer
+
+## Frame 01 — Tokens
+
+**Header:** Light, icon: `pricetag`
+**Body:**
+- Left: 3 stacked layer cards (Core Primitives, Semantics, Components) with
+  example token names and values
+- Right: Theming model key-value card showing how brands override core values +
+  naming convention bullet card
+- Card types: Layer + KeyValue + Bullet
+
+## Frame 02 — Components
+
+**Header:** Light, icon: `puzzle`
+**Body:**
+- Left: Icon grid card showing a selection of available icons in a wrap layout
+- Right top: Structure card showing component anatomy (container, label, icon slots)
+- Right bottom: Code card with HTML/CSS snippet for a button
+- Card types: KeyValue + Code + Highlight
+
+## Frame 03 — Tooling
+
+**Header:** Light, icon: `toolkit`
+**Body:**
+- Left: Tool highlight cards (Figma, token pipeline, docs site, CI)
+- Right: Pipeline flow card (export → generate → build → publish) + commands
+  bullet card
+- Card types: Highlight + Flow + Bullet
+
+## Frame 04 — Governance
+
+**Header:** Light, icon: `shield`
+**Body:**
+- Left: Rule bullet cards (token rules, component rules, naming rules)
+- Right top: CI pipeline flow card
+- Right bottom: Agent rules highlight card (behavior, modes, validation)
+- Card types: Bullet + Flow + Highlight
+
+## Frame 05 — Token Architecture
+
+**Header:** Light, icon: `layers`
+**Body:**
+- Left: 4 stacked layer cards (Core → Appearance → Semantics → Components)
+  each showing file path and example tokens
+- Right: Reference chain flow card showing alias resolution
+  (`--button-bg → --color-fill-brand → --brand-primary → #0066cc`)
+- Card types: Layer + Flow
+
+## Frame 06 — Theming
+
+**Header:** Light, icon: `settings`
+**Body:**
+- Left: Brand comparison card — side-by-side columns for Brand A vs Brand B
+  showing different token values applied to the same component
+- Right top: CSS strategy bullet card (custom properties, layer order, selectors)
+- Right bottom: Layer order numbered steps (core → brand → mode → semantic → component)
+- Card types: Comparison + Bullet + Numbered steps
+
+## Frame 07 — Pipeline
+
+**Header:** Light, icon: `sync`
+**Body:**
+- Full width: Step flow cards showing the complete pipeline:
+  1. Figma export (JSON)
+  2. Token transform (CSS generation)
+  3. Component build (patterns + React)
+  4. Docs build (11ty)
+  5. CI validation
+- Below flow: Output files key-value card listing generated artifacts
+- Card types: Flow + KeyValue
+
+## Frame 08 — Component Model
+
+**Header:** Light, icon: `code`
+**Body:**
+- Left: 10-surface checklist card (tokens, CSS pattern, React wrapper, macro,
+  docs page, playground, Code Connect, Figma component, tests, icon)
+- Right: CSS anatomy code card showing `@layer components`, custom properties,
+  state selectors, logical properties
+- Card types: Numbered steps + Code
+
+## Frame 09 — Patterns
+
+**Header:** Light, icon: `notepad`
+**Body:**
+- Left: Pattern type cards (forms, navigation, cards, modals, tables, tabs,
+  accordion, search, tooltips) as a bullet list with icons per category
+- Right top: Purpose highlight card explaining pattern rules as composition guides
+- Right bottom: Rule pipeline flow (principle → heuristic → pattern → component)
+- Card types: Bullet + Highlight + Flow
+
+## Frame 10 — Validation
+
+**Header:** Light, icon: `badge-check`
+**Body:**
+- Left: Validation checks bullet card listing what `ci:check` verifies
+  (lint, test, build, smoke, tokens, assets, rules, docs)
+- Right: Numbered CI steps card showing the execution sequence with pass/fail
+  indicators
+- Card types: Bullet + Numbered steps
+
+## Frame 11 — Kiro Workflow
+
+**Header:** Light, icon: `robot`
+**Body:**
+- Left: Agent step cards showing Plan → Execute → Verify → Report workflow
+- Right top: Steering files key-value card (foundations, components, workflows,
+  pattern-rules, figma)
+- Right bottom: Hooks bullet card (file events, task events, tool gates)
+- Card types: Flow + KeyValue + Bullet
+
+## Frame 12 — Final Poster
+
+**Header:** Dark header, icon: `star`
+**Body:**
+- 3-column layout:
+  - Column 1: Architecture summary (4 layers, token pipeline)
+  - Column 2: Components summary (10 surfaces, patterns, governance)
+  - Column 3: Workflow summary (agents, CI, Figma sync)
+- Footer row: Project URL + version + date
+- Card types: Bullet + Highlight

--- a/.kiro/steering/figma/cheatsheet-builder-rules.md
+++ b/.kiro/steering/figma/cheatsheet-builder-rules.md
@@ -2,10 +2,10 @@
 inclusion: manual
 ---
 
-# Skill: UI Foundations Cheatsheet Builder
+# Skill: UI Foundations Cheatsheet Builder — Rules
 
-Interactive frame-by-frame Figma slide deck builder for the UI Foundations design system.
-You are a Design System Implementation Agent — you build Figma frames, not documentation.
+Layout, style, card types, and validation rules for building Figma cheatsheet frames.
+For per-frame content definitions, load `#cheatsheet-builder-frames`.
 
 ## Working Mode
 
@@ -113,24 +113,13 @@ card.layoutSizingHorizontal = 'FILL';
 column.layoutSizingHorizontal = 'FILL';
 ```
 
-Apply this to every direct child of a horizontal auto-layout container that
-should share the row width equally. Arrow separators and fixed-width elements
-are excluded.
-
 ## LAYOUT-FIRST EXECUTION (CRITICAL)
 
 For each frame:
-1. Build layout structure first:
-   - frame
-   - grid
-   - columns
-   - card placement
+1. Build layout structure first: frame → grid → columns → card placement
 2. THEN add content
 
-DO NOT:
-- write content first
-- design afterwards
-
+DO NOT write content first and design afterwards.
 Layout defines content, not the reverse.
 
 ## VISUAL HIERARCHY (MANDATORY)
@@ -141,23 +130,12 @@ Hierarchy must be created using:
 - layout structure (columns, stacking)
 - component variants
 
-DO NOT rely on:
-- new colors
-- arbitrary font scaling
-
-If layout feels flat:
-→ increase spacing contrast
-→ regroup elements
-→ change card composition
+DO NOT rely on new colors or arbitrary font scaling.
 
 ## Frame Positioning (MANDATORY)
 
 Each new frame must be placed to the right of the previous one with an 80px gap.
-Frames MUST NEVER overlap or share the same x position. Every frame gets a
-unique x offset calculated from the previous frame's position.
-
-When building multiple frames in one session (batch mode), calculate the x
-position immediately before creating each frame — not once at the start.
+Frames MUST NEVER overlap or share the same x position.
 
 ```js
 function nextX() {
@@ -166,7 +144,6 @@ function nextX() {
     ? existing[existing.length - 1].x + 1024 + 80
     : 0;
 }
-// Call nextX() right before each makeSlide(), not cached
 slide.x = nextX();
 slide.y = 0;
 ```
@@ -176,8 +153,7 @@ slide.y = 0;
 When the user asks to build all frames at once ("build all, I'll check later"):
 - Build frames sequentially in a single script execution
 - Use the `nextX()` function before each frame creation
-- After all frames are built, take a page-level screenshot and present a
-  summary table of all frames
+- After all frames are built, take a page-level screenshot and present a summary
 
 ## Frame Format
 
@@ -207,9 +183,6 @@ Slide (1024×576, FIXED, clipsContent=true)
 ### Icon Color Rule (CRITICAL)
 
 Icons must always match the color of their adjacent text.
-All icon child nodes are named "Vector" and share the same stroke binding,
-so rebinding the stroke color on all children recolors the whole icon.
-Also clear the instance fill to remove the white background.
 
 ```js
 function recolorIcon(icon, colorVarName) {
@@ -226,31 +199,15 @@ function recolorIcon(icon, colorVarName) {
 }
 ```
 
-Apply after every `IC()` call. Use the same color variable as the
-sibling text. Example: hero text uses `Color/Text/Inverse`, so
-call `recolorIcon(icon, 'Color/Text/Inverse')`.
-
-Default icon color is `Color/Text/Default`. Only override when the
-context requires a different color (inverse, brand, subtle, strong).
-
-Useful icon names by topic:
-- Tokens: `pricetag`, `diamond`, `layers`
-- Components: `puzzle`, `code`, `list`
-- Tooling: `toolkit`, `linked`, `document`, `robot`
-- Governance: `shield`, `shield-check`, `checkmark-circled`
-- Theming: `settings`, `star`, `crown`
-- Pipeline: `sync`, `arrow`, `folder`, `picture`
-- Patterns: `notepad`, `compass`, `search`, `message-info`
-- Validation: `badge-check`, `accessibility-circled`
-- Workflow: `play`, `focus`, `light-bulb`
-- General: `world-globe`, `exclamation-mark-circled`, `typography`
+Default icon color is `Color/Text/Default`. Only override when context requires
+a different color (inverse, brand, subtle, strong).
 
 ## Header Style Rule
 
 Default to light headers — no background fill, brand-colored icon,
 `Color/Text/Default` for title. Only use dark headers
 (`Brand/Color/Functional/Base Dark` + `Color/Text/Inverse`) for hero or
-overview frames (Frame 00). All other frames use light headers.
+overview frames (Frame 00).
 
 ## Bullet List Rule (CRITICAL)
 
@@ -262,28 +219,16 @@ const bulletText = items.map(b => '\u2022  ' + b).join('\n');
 tx(card, bulletText, { sz: 10, cv: 'Color/Text/Subtle', fw: true, lh: 16 });
 ```
 
-This produces cleaner layers, fewer nodes, and proper text reflow.
-Only use the dot-ellipse + row pattern when bullets need individual icons
-or mixed styling per line.
-
 ## CARD SELECTION RULE
 
-Each frame must:
-- use at least 2 different card types
-- choose card types based on content:
-
-Rules:
+Each frame must use at least 2 different card types. Choose based on content:
 - concepts → Bullet or Layer
 - mappings → KeyValue
 - processes → Flow
 - emphasis → Highlight
 
-If card types repeat across frames:
-→ switch layout strategy
+## Card Types
 
-## Card Types (vary across frames)
-
-Use different card compositions per frame:
 - Bullet card: icon header + bullet list
 - Code card: dark background code block
 - Key-value card: icon + label pairs in grid
@@ -301,7 +246,9 @@ Do NOT repeat identical layouts across frames. Vary:
 - Section groupings
 - Visual emphasis patterns
 
-## Spacing Token Reference
+## Token References
+
+### Spacing
 
 | Token | Use |
 |---|---|
@@ -312,7 +259,7 @@ Do NOT repeat identical layouts across frames. Vary:
 | `Size/Spacing/600` | Outer horizontal padding |
 | `Size/Spacing/800` | Hero padding |
 
-## Color Token Reference
+### Colors
 
 | Token | Use |
 |---|---|
@@ -333,39 +280,6 @@ Do NOT repeat identical layouts across frames. Vary:
 | `Brand/Corner/Card` | Card corner radius |
 | `Size/Radius/100` | Small elements (badges, tags) |
 | `Size/Radius/200` | Cards, code blocks |
-
-## Frame Order
-
-```
-00 Overview — Hero + pipeline flow + 4-layer grid
-01 Tokens — 3-layer cards + theming model + naming
-02 Components — Icon grid + structure card + code example
-03 Tooling — Tool highlight cards + pipeline + commands
-04 Governance — Rule bullets + CI pipeline + agent rules
-05 Token Architecture — Layer cards with file paths + reference chain
-06 Theming — Brand comparison + CSS strategy + layer order
-07 Pipeline — Step flow cards + output files
-08 Component Model — 10-surface checklist + CSS anatomy
-09 Patterns — Pattern type cards + purpose + rule pipeline
-10 Validation — Validation checks + numbered CI steps
-11 Kiro Workflow — Agent step cards + steering files + hooks
-12 Final Poster — 3-column summary + footer
-```
-
-## Per-Frame Output (MANDATORY)
-
-After building each frame, output:
-
-```
-### Frame [X] — [Title]
-- [What was built]
-- [Card types used]
-- [Design principles applied]
-
-Approve or adjust?
-```
-
-Then STOP and wait.
 
 ## Validation Checklist (per frame)
 
@@ -391,24 +305,28 @@ If ANY occurs, rebuild the frame:
 ## CONTENT MODE (CRITICAL)
 
 The repository is NOT documentation to display.
-It is ONLY used to:
-- extract terminology
-- ensure correctness
+It is ONLY used to extract terminology and ensure correctness.
 
-DO NOT:
-- summarize files
-- describe folder structures
-- explain implementation details
-
-INSTEAD:
-- abstract the system into visual concepts
-- keep content short, scannable, and generic
-
-If content reads like documentation:
-→ simplify and generalize
+DO NOT summarize files, describe folder structures, or explain implementation.
+INSTEAD abstract the system into visual concepts — short, scannable, generic.
 
 ## Missing Assets
 
 If a needed library asset doesn't exist:
 → Add a text annotation: "Missing library asset: [exact need]"
 → Do NOT invent colors, styles, or components
+
+## Per-Frame Output (MANDATORY)
+
+After building each frame, output:
+
+```
+### Frame [X] — [Title]
+- [What was built]
+- [Card types used]
+- [Design principles applied]
+
+Approve or adjust?
+```
+
+Then STOP and wait.

--- a/.kiro/steering/foundations/design-system-context.md
+++ b/.kiro/steering/foundations/design-system-context.md
@@ -6,6 +6,11 @@ inclusion: always
 
 This is a token-first, Figma-aligned design system. Figma is the single source of truth.
 
+## Language
+
+All documentation, code comments, commit messages, and user-facing content in
+this project must be written in English. No exceptions.
+
 ## Token Architecture (4 layers)
 
 | Layer | Purpose | Location |
@@ -96,8 +101,8 @@ JavaScript via the Figma Plugin API and can create frames, text, shapes,
 instances, and bind variables.
 
 - Activate the Figma power first to access `use_figma`.
-- For slide decks, load the `#cheatsheet-builder` steering for the full
-  frame-by-frame workflow, auto-layout rules, variable bindings, and card types.
+- For slide decks, load `#cheatsheet-builder-rules` for layout and style rules,
+  and `#cheatsheet-builder-frames` for per-frame content definitions.
 - Key pattern: cards and columns in horizontal rows need
   `layoutSizingHorizontal = 'FILL'` to expand equally.
 

--- a/.kiro/steering/foundations/language.md
+++ b/.kiro/steering/foundations/language.md
@@ -1,4 +1,0 @@
-# Language
-
-All documentation, code comments, commit messages, and user-facing content in
-this project must be written in English. No exceptions.

--- a/.kiro/steering/pattern-rules/feedback.md
+++ b/.kiro/steering/pattern-rules/feedback.md
@@ -1,0 +1,108 @@
+---
+type: pattern-rule
+domain: ui-foundations
+status: active
+pattern: feedback
+applies_to:
+  - notifications
+  - inline-alerts
+  - banners
+  - toast-messages
+  - loading-states
+  - status-messages
+principles:
+  - principle.hierarchy
+  - principle.contrast
+  - principle.affordance
+heuristics:
+  - heuristic.feedback
+  - heuristic.recognition
+  - heuristic.user-control
+  - heuristic.accessibility
+inclusion: manual
+---
+
+# Pattern: feedback
+
+## Rule type
+pattern composition rule
+
+## Scope
+pattern
+
+## Applies to
+- notifications and toast messages
+- inline alerts and banners
+- status messages (success, error, warning, info)
+- loading and progress states
+
+## Purpose
+Communicate system state, action outcomes, and transient information clearly so
+users can understand what happened, what is happening, or what needs attention.
+
+## Structure
+Feedback messages consist of:
+1. A status indicator (icon and/or color) communicating severity or type
+2. A concise message describing the state or outcome
+3. An optional action (dismiss, retry, undo) when the user can respond
+4. An optional detail or description for complex messages
+
+Place feedback close to the trigger (inline) or in a consistent, predictable
+location (banners at the top, toasts in a fixed corner).
+
+## Rules
+- Every feedback message must use a semantic functional color token
+  (`--color-fill-success`, `--color-fill-danger`, `--color-fill-warning`,
+  `--color-text-info`) to communicate severity — never rely on color alone.
+- Inline feedback must appear adjacent to the element it relates to.
+- Page-level banners must appear at a consistent position across pages.
+- Toast notifications must appear in a consistent viewport region and auto-dismiss
+  only for non-critical, recoverable messages.
+- Critical or destructive feedback (errors, data loss warnings) must NOT
+  auto-dismiss — they require explicit user acknowledgment.
+- Loading states must provide visible indication that an operation is in progress.
+
+## Interaction rules
+- Toasts with actions must persist long enough for the user to read and act.
+- Dismissible alerts must have a visible close affordance.
+- Stacked notifications must not obscure each other — use vertical stacking with
+  spacing tokens.
+- Transitions must be subtle and not distract from content.
+
+## Accessibility considerations
+- Use `role="alert"` or `role="status"` (or `aria-live` regions) to announce
+  dynamic feedback to assistive technology.
+- `role="alert"` for urgent messages (errors, destructive warnings).
+- `role="status"` for polite updates (success confirmations, progress).
+- Ensure color is not the sole indicator of severity — pair with an icon and/or
+  text label.
+- Dismiss buttons must have an accessible name.
+- Auto-dismissing toasts must respect `prefers-reduced-motion`.
+
+## Applied principles
+- `principle.hierarchy`
+- `principle.contrast`
+- `principle.affordance`
+
+## Applied heuristics
+- `heuristic.feedback`
+- `heuristic.recognition`
+- `heuristic.user-control`
+- `heuristic.accessibility`
+
+## Failure signals
+- Feedback appears with no visible severity indicator.
+- Error messages auto-dismiss before the user can read them.
+- Toast notifications stack without spacing or overflow the viewport.
+- Dynamic messages are not announced to screen readers.
+- Color is the sole differentiator between success and error states.
+- Loading state provides no indication that an operation is pending.
+
+## Agent check
+- Verify feedback elements use semantic functional tokens for color.
+- Verify each feedback message pairs color with an icon or text severity label.
+- Verify dynamic feedback uses `role="alert"` or `role="status"` (or
+  `aria-live`) as appropriate.
+- Verify critical/error feedback does not auto-dismiss.
+- Verify dismiss controls have accessible names.
+- Verify loading indicators are present for asynchronous operations.

--- a/.kiro/steering/pattern-rules/layout.md
+++ b/.kiro/steering/pattern-rules/layout.md
@@ -1,0 +1,94 @@
+---
+type: pattern-rule
+domain: ui-foundations
+status: active
+pattern: layout
+applies_to:
+  - page-layout
+  - grid-systems
+  - responsive-breakpoints
+  - section-spacing
+principles:
+  - principle.hierarchy
+  - principle.proximity
+  - principle.cognitive-load
+  - principle.consistency
+heuristics:
+  - heuristic.recognition
+  - heuristic.consistency
+  - heuristic.accessibility
+inclusion: manual
+---
+
+# Pattern: layout
+
+## Rule type
+pattern composition rule
+
+## Scope
+pattern
+
+## Applies to
+- page layouts
+- grid systems
+- responsive breakpoints
+- section spacing and stacking
+
+## Purpose
+Guide full-page composition by defining how patterns combine into coherent
+layouts with consistent spacing, predictable flow, and responsive adaptation.
+
+## Structure
+Use a top-level page container that establishes the max-width, inline padding,
+and vertical rhythm for the page. Within it, stack sections vertically using
+consistent spacing tokens. Within sections, arrange content in flexible grid
+columns that collapse at defined breakpoints.
+
+## Rules
+- Page containers must use semantic layout tokens (`--size-spacing-*`) for
+  inline padding, max-width constraints, and vertical gaps between sections.
+- Grid columns must use CSS grid or flexbox with gap tokens — never margin hacks.
+- Section spacing must be visibly larger than intra-section spacing to
+  communicate grouping.
+- Responsive breakpoints must stack columns vertically when horizontal space
+  drops below a readable threshold.
+- Nested patterns (cards, forms, tables) must fill their grid cell — they do
+  not define their own outer spacing.
+
+## Interaction rules
+- Scrollable layouts must preserve landmark navigation and focus order.
+- Sticky or fixed elements (headers, sidebars) must not obscure focused content.
+- Skip-links or landmark headings must provide quick navigation past repeated
+  layout sections.
+
+## Accessibility considerations
+- Use landmark regions (`main`, `nav`, `aside`, `header`, `footer`) to
+  communicate page structure to assistive technology.
+- Heading hierarchy (h1–h6) must reflect the visual section hierarchy.
+- Visual order and DOM order must match — never use CSS order or grid placement
+  to reorder content in a way that conflicts with reading sequence.
+
+## Applied principles
+- `principle.hierarchy`
+- `principle.proximity`
+- `principle.cognitive-load`
+- `principle.consistency`
+
+## Applied heuristics
+- `heuristic.recognition`
+- `heuristic.consistency`
+- `heuristic.accessibility`
+
+## Failure signals
+- Sections use inconsistent vertical spacing with no structural reason.
+- Grid items use hardcoded pixel widths instead of responsive fractions.
+- Visual order diverges from DOM order.
+- Landmark regions are missing or incorrectly nested.
+- Sticky elements cover focused inputs or interactive controls.
+
+## Agent check
+- Verify page containers use spacing tokens from the Core or Semantic layer.
+- Verify section gaps are larger than gaps within sections.
+- Verify landmark regions wrap major page areas.
+- Verify heading levels match visual hierarchy without skipping levels.
+- Verify responsive layout collapses columns at a defined breakpoint.

--- a/docs/agentic/MIGRATION.md
+++ b/docs/agentic/MIGRATION.md
@@ -30,9 +30,9 @@ The repo now also includes:
 
 - `docs/playbook.md`
 - `docs/agentic/README.md`
-- `docs/agentic/agent-behavior-rules.md`
+- `docs/agentic/assistant-behavior-rules.md`
 - `docs/agentic/{kiro,goose,codex}-workflow.md`
-- `docs/agentic/prompts/`
+- `docs/agentic/skills/`
 
 The detailed checklist remains in `assistant-behavior-rules.md`.
 

--- a/docs/agentic/codex-workflow.md
+++ b/docs/agentic/codex-workflow.md
@@ -8,10 +8,10 @@ Summarise the expected Codex execution style for this repository.
 
 - `AGENTS.md`
 - `IMPLEMENTATION.md`
-- `docs/validation/checklist.md`
+- `docs/validation/ci.md`
 
 ## Related docs
 
 - `docs/playbook.md`
-- `docs/agentic/agent-behavior-rules.md`
+- `docs/agentic/assistant-behavior-rules.md`
 - `docs/foundations/README.md`

--- a/docs/agentic/goose-workflow.md
+++ b/docs/agentic/goose-workflow.md
@@ -13,6 +13,6 @@ support.
 
 ## Related docs
 
-- `docs/validation/checklist.md`
+- `docs/validation/ci.md`
 - `docs/agentic/codex-workflow.md`
 - `docs/playbook.md`

--- a/docs/agentic/kiro-workflow.md
+++ b/docs/agentic/kiro-workflow.md
@@ -15,5 +15,5 @@ the Kiro configuration itself into `docs/`.
 ## Related docs
 
 - `docs/playbook.md`
-- `docs/agentic/agent-behavior-rules.md`
+- `docs/agentic/assistant-behavior-rules.md`
 - `IMPLEMENTATION.md`

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -8,7 +8,7 @@ docs pages, and Code Connect mappings.
 
 ## Canonical rules
 
-- `docs/agentic/agent-behavior-rules.md`
+- `docs/agentic/assistant-behavior-rules.md`
 - `docs/foundations/foundation-009-component-boundaries-and-utility.md`
 - `docs/foundations/foundation-010-implementation-and-pipeline-workflow.md`
 - `site/components/*.md`
@@ -23,4 +23,4 @@ docs pages, and Code Connect mappings.
 
 - `docs/patterns/README.md`
 - `docs/principles/accessibility.md`
-- `docs/validation/checklist.md`
+- `docs/validation/ci.md`

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -15,4 +15,4 @@ Point to the existing button implementation and documentation surfaces.
 
 - `docs/patterns/forms.md`
 - `docs/patterns/navigation.md`
-- `docs/agentic/agent-behavior-rules.md`
+- `docs/agentic/assistant-behavior-rules.md`

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -11,7 +11,7 @@ Track where select-component documentation should live once the component exists
 
 ## Related docs
 
-- `docs/agentic/agent-behavior-rules.md`
+- `docs/agentic/assistant-behavior-rules.md`
 - `docs/foundations/foundation-009-component-boundaries-and-utility.md`
 
 ## TODO

--- a/docs/patterns/README.md
+++ b/docs/patterns/README.md
@@ -20,4 +20,4 @@ composition logic without dropping directly into component implementation detail
 
 - `docs/principles/README.md`
 - `docs/components/README.md`
-- `docs/validation/checklist.md`
+- `docs/validation/ci.md`

--- a/docs/patterns/navigation.md
+++ b/docs/patterns/navigation.md
@@ -14,4 +14,4 @@ hierarchy, and recognisable destination structure.
 
 - `docs/components/button.md`
 - `docs/principles/perception-laws.md`
-- `docs/validation/checklist.md`
+- `docs/validation/ci.md`

--- a/docs/principles/usability-heuristics.md
+++ b/docs/principles/usability-heuristics.md
@@ -7,7 +7,7 @@ able to implement and validation should eventually check.
 
 ## Canonical rules
 
-- `.kiro/steering/usability-heuristics.md`
+- `.kiro/steering/foundations/usability-heuristics.md`
 - `docs/agentic/rule-pipeline.md`
 
 Current heuristic set:
@@ -23,4 +23,4 @@ Current heuristic set:
 
 - `docs/principles/perception-laws.md`
 - `docs/patterns/forms.md`
-- `docs/validation/checklist.md`
+- `docs/validation/ci.md`

--- a/docs/validation/ci.md
+++ b/docs/validation/ci.md
@@ -23,5 +23,4 @@ Current pipeline:
 
 ## Related docs
 
-- `docs/validation/checklist.md`
 - `docs/agentic/rule-pipeline-audit.md`


### PR DESCRIPTION
## Summary

Housekeeping pass on the agentic setup — fixing broken references, reducing duplication, improving discoverability, and adding missing pattern rules.

## What Changed

**Steering**
- Added `steering/README.md` as a task-to-file index
- Split `cheatsheet-builder.md` (330 lines) into `cheatsheet-builder-rules.md` + `cheatsheet-builder-frames.md` for independent manual activation
- Merged `language.md` (2-line English rule) into `design-system-context.md`
- Added `pattern-rules/layout.md` (page layout, grid, responsive breakpoints)
- Added `pattern-rules/feedback.md` (notifications, alerts, loading states)

**Skills & Hooks**
- Refactored `figma-library-sync` skill to reference steering files instead of duplicating token architecture and component tables
- Softened `figma-library-sync` hook to suggest sync rather than auto-triggering

**Specs**
- Added `status` field to all spec `.config.kiro` files (`requirements-complete` or `implementation-ready`)

**Cross-reference fixes**
- `agent-behavior-rules.md` → `assistant-behavior-rules.md` (6 files)
- `validation/checklist.md` → `validation/ci.md` (5 files)
- Stale `design-system-architect` skill path in Goose recipe
- Non-existent `docs/agentic/prompts/` reference in MIGRATION.md
- Wrong steering path in `docs/principles/usability-heuristics.md`

**Misc**
- Added `**/.DS_Store` to `.gitignore`