### PR TITLE
chore: feedback heuristic traceability + spec index

### DIFF
--- a/.kiro/steering/README.md
+++ b/.kiro/steering/README.md
@@ -52,6 +52,19 @@ These are included in every prompt automatically:
 
 1. `workflows/pull-requests.md`
 
+## Specs Ready for Implementation
+
+These specs have requirements, design, and tasks complete — ready to pick up:
+
+- `code-connect-all-components` — Code Connect schemas for all components
+- `docs-navbar-search` — search feature in the docs site sidebar
+
+Specs with requirements only (need design/tasks before implementation):
+- `accessibility-test-suite`
+- `component-scaffolding-cli`
+- `dark-mode-validation`
+- `token-drift-detection`
+
 ## Inclusion Modes
 
 | Mode | Front-matter | Behavior |

--- a/.kiro/steering/pattern-rules/feedback.md
+++ b/.kiro/steering/pattern-rules/feedback.md
@@ -16,6 +16,7 @@ principles:
   - principle.affordance
 heuristics:
   - heuristic.feedback
+  - heuristic.error-prevention
   - heuristic.recognition
   - heuristic.user-control
   - heuristic.accessibility
@@ -86,6 +87,7 @@ location (banners at the top, toasts in a fixed corner).
 
 ## Applied heuristics
 - `heuristic.feedback`
+- `heuristic.error-prevention`
 - `heuristic.recognition`
 - `heuristic.user-control`
 - `heuristic.accessibility`


### PR DESCRIPTION
## Summary

Two small improvements to agentic discoverability.

## What Changed

- **feedback.md**: Added `heuristic.error-prevention` to frontmatter and applied heuristics section — the rule's 'critical messages must not auto-dismiss' maps directly to error prevention
- **steering/README.md**: Added 'Specs Ready for Implementation' section listing `code-connect-all-components` and `docs-navbar-search` so agents can discover queued work without reading individual .config.kiro files