### PR TITLE
fix(tokens): correct Input component code syntax (remove double segme…

### DIFF
--- a/figma/exports/Components (UI).tokens.json
+++ b/figma/exports/Components (UI).tokens.json
@@ -1254,7 +1254,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-text-text-color-default)"
+            "WEB": "var(--input-text-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:326",
@@ -1276,7 +1276,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-text-text-color-hover)"
+            "WEB": "var(--input-text-color-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:340",
@@ -1298,7 +1298,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-text-text-color-active)"
+            "WEB": "var(--input-text-color-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:326",
@@ -1320,7 +1320,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-text-text-color-disabled)"
+            "WEB": "var(--input-text-color-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:328",
@@ -1342,7 +1342,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-text-text-color-placeholder)"
+            "WEB": "var(--input-text-color-placeholder)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:341",
@@ -1366,7 +1366,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-border-color-default)"
+            "WEB": "var(--input-border-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:342",
@@ -1388,7 +1388,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-border-color-hover)"
+            "WEB": "var(--input-border-color-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:345",
@@ -1410,7 +1410,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-border-color-active)"
+            "WEB": "var(--input-border-color-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:345",
@@ -1432,7 +1432,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-border-color-focus)"
+            "WEB": "var(--input-border-color-focus)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:345",
@@ -1454,7 +1454,7 @@
             "STROKE_FLOAT"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-border-size-default)"
+            "WEB": "var(--input-border-size-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:1:201",
@@ -1476,7 +1476,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-border-size-hover)"
+            "WEB": "var(--input-border-size-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:1:201",
@@ -1498,7 +1498,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-border-size-active)"
+            "WEB": "var(--input-border-size-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:1:202",
@@ -1520,7 +1520,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-border-radius)"
+            "WEB": "var(--input-border-radius)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2028:335",
@@ -1542,7 +1542,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-border-color-disabled)"
+            "WEB": "var(--input-border-color-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:346",
@@ -1564,7 +1564,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-border-color-invalid)"
+            "WEB": "var(--input-border-color-invalid)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:356",
@@ -1586,7 +1586,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-border-color-valid)"
+            "WEB": "var(--input-border-color-valid)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:344",


### PR DESCRIPTION
…nts)

Fix codeSyntax.WEB in Figma and local export for 16 Input variables:
- --input-text-text-color-* → --input-text-color-*
- --input-border-border-color-* → --input-border-color-*
- --input-border-border-size-* → --input-border-size-*
- --input-border-border-radius → --input-border-radius

Resolves validate-token-usage failing with 22 missing references.