### PR TITLE
feat(tokens): add --color-text-on-disabled + clean up Input variable …

### DIFF
--- a/figma/exports/Appearance (Modes).tokens.json
+++ b/figma/exports/Appearance (Modes).tokens.json
@@ -390,6 +390,36 @@
             }
           }
         }
+      },
+      "On Disabled": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Neutral/800"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:2624:2",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--color-text-on-disabled)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2006:169",
+            "targetVariableName": "Color/Neutral/800",
+            "targetVariableSetId": "VariableCollectionId:1:200",
+            "targetVariableSetName": "Core (Primitives)"
+          },
+          "com.figma.isOverride": true,
+          "com.figma.modeValues": {
+            "Light Mode": {
+              "$ref": "Color/Neutral/800"
+            },
+            "Dark Mode": {
+              "$ref": "Color/Neutral/800"
+            }
+          }
+        }
       }
     },
     "Fill": {


### PR DESCRIPTION
…paths in Figma

- Add Color/Text/On Disabled (Neutral/800 for both modes) for text on disabled fills
- Rename 16 Input variables in Figma to remove redundant path segments (Input/Text/Text Color → Input/Text Color, Input/Border/Border Color → Input/Border Color)
- Verified: Core Primitives export was an unrelated artifact, reverted

ci:check passes: 493 defined tokens, 384 references validated, 560 DTCG tokens