### PR TITLE
feat(component): add Form layout component

### DIFF
--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -201,3 +201,36 @@
 {%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
 <span class="{{ classes }}">{{ caller() }}<span class="tooltip" role="tooltip" data-placement="{{ placement }}">{{ text }}</span></span>
 {%- endmacro %}
+
+{% macro form(borderless=false, className='') -%}
+{%- set classes = "form" -%}
+{%- if borderless -%}{%- set classes = classes + " borderless" -%}{%- endif -%}
+{%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
+<form class="{{ classes }}" novalidate>{{ caller() }}</form>
+{%- endmacro %}
+
+{% macro formGroup(title='', className='') -%}
+{%- set classes = "form-group" -%}
+{%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
+<fieldset class="{{ classes }}">
+  {%- if title %}<legend class="form-group__title">{{ title }}</legend>{% endif -%}
+  {{ caller() }}
+</fieldset>
+{%- endmacro %}
+
+{% macro formField(labelPosition='top', invalid=false, className='') -%}
+{%- set classes = "form-field" -%}
+{%- if invalid -%}{%- set classes = classes + " is-invalid" -%}{%- endif -%}
+{%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
+<div class="{{ classes }}"{% if labelPosition == "side" %} data-label-position="side"{% endif %}>{{ caller() }}</div>
+{%- endmacro %}
+
+{% macro formHelper(text='') -%}
+<p class="form-field__helper">{{ text }}</p>
+{%- endmacro %}
+
+{% macro formActions(align='end', className='') -%}
+{%- set classes = "form-actions" -%}
+{%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
+<div class="{{ classes }}"{% if align != "end" %} data-align="{{ align }}"{% endif %}>{{ caller() }}</div>
+{%- endmacro %}

--- a/site/assets/docs.css
+++ b/site/assets/docs.css
@@ -453,52 +453,6 @@ details[open] > .docs-nav-group-toggle::before {
   max-inline-size: 28rem;
 }
 
-.example-form {
-  display: grid;
-  gap: var(--form-gap, 1rem);
-  border-style: solid;
-  border-width: var(--form-border-size, 1px);
-  border-color: var(--form-container-border-color, var(--color-border-subtle, #ccc));
-  border-radius: var(
-    --form-border-radius,
-    var(--corner-form-radius, var(--size-radius-300, 0.375rem))
-  );
-  background: var(--form-container-background, var(--color-fill-surface, #fff));
-  padding-inline: var(--form-padding-inline, 1rem);
-  padding-block: var(--form-padding-block, 1rem);
-}
-
-.example-form__group {
-  min-inline-size: 0;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  display: grid;
-  gap: var(--form-group-gap, 1rem);
-}
-
-.example-form__group-title {
-  margin: 0;
-  font-size: var(--typography-label-font-size, 1rem);
-  line-height: var(--typography-label-line-height, 1.5);
-  font-weight: var(--typography-label-font-weight, 600);
-  color: var(--form-group-title-color, currentColor);
-}
-
-.example-form__intro {
-  margin: 0;
-  color: var(--color-text-subtle, #555);
-}
-
-.example-form__field {
-  display: grid;
-  gap: var(--form-field-gap, 0.5rem);
-}
-
-.example-form__actions {
-  padding-top: var(--form-actions-padding-block-start, 0.25rem);
-}
-
 .playground-grid {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;

--- a/site/assets/playground/code-generators.js
+++ b/site/assets/playground/code-generators.js
@@ -148,18 +148,68 @@
     return "<Badge" + (attrs.length ? " " + attrs.join(" ") : "") + ">" + quoteAttr(text) + "</Badge>";
   }
 
+  function njkForm(state) {
+    var p = state.props;
+    var borderless = p.borderless === true || p.borderless === "true";
+    var labelPosition = p.labelPosition || "top";
+    var invalid = p.invalid === true || p.invalid === "true";
+    var actionsAlign = p.actionsAlign || "end";
+    var lines = [];
+    lines.push("{% call ui.form(" + (borderless ? "borderless=true" : "") + ") %}");
+    lines.push("  {% call ui.formField(" + (invalid ? "invalid=true" : "") + (labelPosition === "side" ? 'labelPosition="side"' : "") + ") %}");
+    lines.push('    {{ ui.fieldLabel("Email", htmlFor="email", required=true) }}');
+    lines.push('    {{ ui.input(type="email", id="email", placeholder="you@example.com") }}');
+    if (invalid) lines.push('    {{ ui.formHelper("Please enter a valid email address.") }}');
+    lines.push("  {% endcall %}");
+    lines.push("  {% call ui.formField() %}");
+    lines.push('    {{ ui.fieldLabel("Password", htmlFor="pw") }}');
+    lines.push('    {{ ui.input(type="password", id="pw") }}');
+    lines.push("  {% endcall %}");
+    lines.push('  {% call ui.formActions(' + (actionsAlign !== "end" ? 'align="' + actionsAlign + '"' : "") + ') %}');
+    lines.push('    {{ ui.button("Sign in", variant="solid", type="submit") }}');
+    lines.push("  {% endcall %}");
+    lines.push("{% endcall %}");
+    return lines.join("\n");
+  }
+
+  function reactForm(state) {
+    var p = state.props;
+    var borderless = p.borderless === true || p.borderless === "true";
+    var labelPosition = p.labelPosition || "top";
+    var invalid = p.invalid === true || p.invalid === "true";
+    var actionsAlign = p.actionsAlign || "end";
+    var lines = [];
+    lines.push("<Form" + (borderless ? " borderless" : "") + ">");
+    lines.push("  <FormField" + (invalid ? " invalid" : "") + (labelPosition === "side" ? ' labelPosition="side"' : "") + ">");
+    lines.push('    <FieldLabel htmlFor="email" required>Email</FieldLabel>');
+    lines.push('    <Input type="email" id="email" placeholder="you@example.com" />');
+    if (invalid) lines.push("    <FormHelper text=\"Please enter a valid email address.\" />");
+    lines.push("  </FormField>");
+    lines.push("  <FormField>");
+    lines.push('    <FieldLabel htmlFor="pw">Password</FieldLabel>');
+    lines.push('    <Input type="password" id="pw" />');
+    lines.push("  </FormField>");
+    lines.push("  <FormActions" + (actionsAlign !== "end" ? ' align="' + actionsAlign + '"' : "") + ">");
+    lines.push('    <Button type="submit">Sign in</Button>');
+    lines.push("  </FormActions>");
+    lines.push("</Form>");
+    return lines.join("\n");
+  }
+
   global.UIPlaygroundCodeGenerators = {
     njk: {
       button: njkButton, input: njkInput, checkbox: njkCheckbox,
       "switch": njkSwitch, icon: njkIcon, radio: njkRadio, badge: njkBadge,
       label: function () { return '{{ ui.labelContent("text", "icon") }}'; },
       "button-group": function () { return '{% call ui.buttonGroup() %}...{% endcall %}'; },
+      form: njkForm,
     },
     react: {
       button: reactButton, input: reactInput, checkbox: reactCheckbox,
       "switch": reactSwitch, icon: reactIcon, radio: reactRadio, badge: reactBadge,
       label: function () { return "<LabelContent>...</LabelContent>"; },
       "button-group": function () { return "<ButtonGroup>...</ButtonGroup>"; },
+      form: reactForm,
     },
   };
 })(window);

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -678,6 +678,111 @@
     return { element: wrapper, code: codeLines.join("\n") };
   };
 
+  const renderVanillaForm = ({ props }) => {
+    const borderless = asBoolean(props.borderless);
+    const labelPosition = String(props.labelPosition || "top");
+    const invalid = asBoolean(props.invalid);
+    const actionsAlign = String(props.actionsAlign || "end");
+
+    const form = document.createElement("form");
+    const formClasses = ["form"];
+    if (borderless) formClasses.push("borderless");
+    form.className = formClasses.join(" ");
+    form.setAttribute("novalidate", "");
+
+    // Field 1
+    const field1 = document.createElement("div");
+    const field1Classes = ["form-field"];
+    if (invalid) field1Classes.push("is-invalid");
+    field1.className = field1Classes.join(" ");
+    if (labelPosition === "side") field1.dataset.labelPosition = "side";
+
+    const label1 = document.createElement("label");
+    label1.className = "field-label";
+    label1.innerHTML = '<span class="label-content"><span class="label-content__text">Email</span></span><span class="field-label__required" aria-hidden="true">*</span>';
+
+    const input1 = document.createElement("input");
+    input1.className = "input";
+    input1.type = "email";
+    input1.placeholder = "you@example.com";
+
+    if (labelPosition === "side") {
+      const body1 = document.createElement("div");
+      body1.className = "form-field__body";
+      body1.append(input1);
+      if (invalid) {
+        const helper = document.createElement("p");
+        helper.className = "form-field__helper";
+        helper.textContent = "Please enter a valid email address.";
+        body1.append(helper);
+      }
+      field1.append(label1, body1);
+    } else {
+      field1.append(label1, input1);
+      if (invalid) {
+        const helper = document.createElement("p");
+        helper.className = "form-field__helper";
+        helper.textContent = "Please enter a valid email address.";
+        field1.append(helper);
+      }
+    }
+
+    // Field 2
+    const field2 = document.createElement("div");
+    field2.className = "form-field";
+    if (labelPosition === "side") field2.dataset.labelPosition = "side";
+
+    const label2 = document.createElement("label");
+    label2.className = "field-label";
+    label2.innerHTML = '<span class="label-content"><span class="label-content__text">Password</span></span>';
+
+    const input2 = document.createElement("input");
+    input2.className = "input";
+    input2.type = "password";
+
+    if (labelPosition === "side") {
+      const body2 = document.createElement("div");
+      body2.className = "form-field__body";
+      body2.append(input2);
+      field2.append(label2, body2);
+    } else {
+      field2.append(label2, input2);
+    }
+
+    // Actions
+    const actions = document.createElement("div");
+    actions.className = "form-actions";
+    if (actionsAlign !== "end") actions.dataset.align = actionsAlign;
+
+    const btn = document.createElement("button");
+    btn.className = "button solid";
+    btn.type = "submit";
+    btn.innerHTML = '<span class="label-content"><span class="label-content__text">Sign in</span></span>';
+    actions.append(btn);
+
+    form.append(field1, field2, actions);
+
+    const lp = labelPosition === "side" ? ' data-label-position="side"' : "";
+    const inv = invalid ? " is-invalid" : "";
+    const alignAttr = actionsAlign !== "end" ? ` data-align="${actionsAlign}"` : "";
+    const helperCode = invalid ? '\n    <p class="form-field__helper">Please enter a valid email address.</p>' : "";
+    const code = `<form class="${formClasses.join(" ")}" novalidate>
+  <div class="form-field${inv}"${lp}>
+    <label class="field-label"><span class="label-content"><span class="label-content__text">Email</span></span><span class="field-label__required" aria-hidden="true">*</span></label>
+    <input class="input" type="email" placeholder="you@example.com" />${helperCode}
+  </div>
+  <div class="form-field"${lp}>
+    <label class="field-label"><span class="label-content"><span class="label-content__text">Password</span></span></label>
+    <input class="input" type="password" />
+  </div>
+  <div class="form-actions"${alignAttr}>
+    <button class="button solid" type="submit"><span class="label-content"><span class="label-content__text">Sign in</span></span></button>
+  </div>
+</form>`;
+
+    return { element: form, code };
+  };
+
   const renderVanillaTooltip = ({ props, children }) => {
     const text = String(props.text || "Tooltip");
     const placement = String(props.placement || "top");
@@ -722,6 +827,7 @@
       accordion: renderVanillaAccordion,
       tabs: renderVanillaTabs,
       tooltip: renderVanillaTooltip,
+      form: renderVanillaForm,
     },
   };
 })(window);

--- a/site/components/form-playground.md
+++ b/site/components/form-playground.md
@@ -56,6 +56,6 @@ playground:
           value: stretch
 ---
 
-{% import "macros/ui.njk" as ui %}
+{% from "macros/playground.njk" import playground as uiPlayground with context %}
 
-<div class="docs-playground-stage" id="form-playground"></div>
+{{ uiPlayground(playground) }}

--- a/site/components/form-playground.md
+++ b/site/components/form-playground.md
@@ -1,0 +1,61 @@
+---
+layout: layouts/docs.njk
+title: Form Playground
+description: Interactive preview for form layout, grouping, and validation patterns.
+navTitle: Form Playground
+order: 71
+permalink: /components/form-playground/
+templateEngineOverride: njk
+isPlayground: true
+breadcrumb:
+  - label: Components
+    url: /components/
+  - label: Form
+    url: /components/form/
+  - label: Playground
+playground:
+  id: form-playground
+  queryPrefix: form
+  runtime: vanilla
+  renderer: form
+  tokenCssPath: src/ui/patterns/form.css
+  controls:
+    - kind: boolean
+      name: borderless
+      label: Borderless
+      valueType: boolean
+      query: true
+      default: false
+    - kind: select
+      name: labelPosition
+      label: Label Position
+      query: true
+      default: top
+      options:
+        - label: Top
+          value: top
+        - label: Side
+          value: side
+    - kind: boolean
+      name: invalid
+      label: Show Invalid
+      valueType: boolean
+      query: true
+      default: false
+    - kind: select
+      name: actionsAlign
+      label: Actions Align
+      query: true
+      default: end
+      options:
+        - label: Start
+          value: start
+        - label: End
+          value: end
+        - label: Stretch
+          value: stretch
+---
+
+{% import "macros/ui.njk" as ui %}
+
+<div class="docs-playground-stage" id="form-playground"></div>

--- a/site/components/form.md
+++ b/site/components/form.md
@@ -1,0 +1,190 @@
+---
+layout: layouts/docs.njk
+title: Form
+description: Form provides layout structure for grouping fields, labels, helper text, and actions into a cohesive form experience.
+navTitle: Form
+order: 70
+permalink: /components/form/
+playgroundUrl: /components/form-playground/
+playgroundLabel: Open Form Playground
+---
+
+{% import "macros/ui.njk" as ui %}
+
+<div class="docs-hero">
+  <div class="docs-hero-preview">
+    <div class="docs-hero-preview-controls">
+      <span class="docs-hero-switch" data-hero-group="brand">
+        <button type="button" data-hero-brand="a" aria-pressed="true">Brand A</button>
+        <button type="button" data-hero-brand="b" aria-pressed="false">Brand B</button>
+        <button type="button" data-hero-brand="c" aria-pressed="false">Brand C</button>
+      </span>
+      <span class="docs-hero-switch" data-hero-group="mode">
+        <button type="button" data-hero-mode="light" aria-pressed="true">Light</button>
+        <button type="button" data-hero-mode="dark" aria-pressed="false">Dark</button>
+      </span>
+    </div>
+    <div class="docs-hero-preview-stage">
+      {% call ui.form() %}
+        {% call ui.formField() %}
+          {{ ui.fieldLabel("Email", htmlFor="hero-email", required=true) }}
+          {{ ui.input(type="email", id="hero-email", placeholder="you@example.com") }}
+        {% endcall %}
+        {% call ui.formField() %}
+          {{ ui.fieldLabel("Password", htmlFor="hero-pw", required=true) }}
+          {{ ui.input(type="password", id="hero-pw") }}
+        {% endcall %}
+        {% call ui.formActions() %}
+          {{ ui.button("Sign in", variant="solid", type="submit") }}
+        {% endcall %}
+      {% endcall %}
+    </div>
+  </div>
+  <div class="docs-hero-meta">
+    <span class="docs-status" data-status="stable">Stable</span>
+    {% if playgroundUrl %}
+    <a class="docs-page-link docs-page-link--playground" href="{{ playgroundUrl }}">{{ playgroundLabel or "Open Playground" }}</a>
+    {% endif %}
+  </div>
+</div>
+
+<h2 id="anatomy">Anatomy</h2>
+
+<div class="docs-anatomy">
+  <ol class="docs-anatomy-list">
+    <li><strong>Form container</strong> — wraps all fields with padding, border, and background</li>
+    <li><strong>Form group</strong> — fieldset with optional legend for related fields</li>
+    <li><strong>Form field</strong> — single field row: label + input + helper</li>
+    <li><strong>Helper text</strong> — description or error message below a field</li>
+    <li><strong>Form actions</strong> — button area for submit/cancel</li>
+  </ol>
+</div>
+
+<h2 id="options">Options</h2>
+
+<table class="docs-options-table">
+  <thead><tr><th>Option</th><th>Values</th><th>Description</th></tr></thead>
+  <tbody>
+    <tr><td>Borderless</td><td><code>true</code> / <code>false</code></td><td>Remove border and background for inline forms</td></tr>
+    <tr><td>Label position</td><td><code>top</code> / <code>side</code></td><td>Per-field label placement</td></tr>
+    <tr><td>Actions align</td><td><code>start</code> / <code>end</code> / <code>stretch</code></td><td>Button alignment in the actions area</td></tr>
+    <tr><td>Invalid</td><td><code>true</code> / <code>false</code></td><td>Marks a field as having a validation error</td></tr>
+  </tbody>
+</table>
+
+<h2 id="behaviors">Behaviors</h2>
+
+<h3>Field grouping</h3>
+
+Use `.form-group` with a `<fieldset>` and `<legend>` to group related fields. The legend provides an accessible name for the group.
+
+<div class="docs-example">
+{% call ui.form() %}
+  {% call ui.formGroup(title="Personal Information") %}
+    {% call ui.formField() %}
+      {{ ui.fieldLabel("First name", htmlFor="fn") }}
+      {{ ui.input(id="fn") }}
+    {% endcall %}
+    {% call ui.formField() %}
+      {{ ui.fieldLabel("Last name", htmlFor="ln") }}
+      {{ ui.input(id="ln") }}
+    {% endcall %}
+  {% endcall %}
+  {% call ui.formGroup(title="Preferences") %}
+    {{ ui.checkbox("Send newsletter") }}
+    {{ ui.checkbox("Accept terms", checked=true) }}
+  {% endcall %}
+{% endcall %}
+</div>
+
+<h3>Validation and helper text</h3>
+
+Mark a field as invalid with `.is-invalid` on `.form-field`. Helper text switches to danger color automatically.
+
+<div class="docs-example">
+{% call ui.form() %}
+  {% call ui.formField(invalid=true) %}
+    {{ ui.fieldLabel("Email", htmlFor="val-email", required=true) }}
+    {{ ui.input(type="email", id="val-email", placeholder="you@example.com") }}
+    {{ ui.formHelper("Please enter a valid email address.") }}
+  {% endcall %}
+  {% call ui.formField() %}
+    {{ ui.fieldLabel("Name", htmlFor="val-name") }}
+    {{ ui.input(id="val-name", placeholder="Jane Doe") }}
+    {{ ui.formHelper("Your display name across the platform.") }}
+  {% endcall %}
+{% endcall %}
+</div>
+
+<h3>Side labels</h3>
+
+Use `data-label-position="side"` for horizontal label layout. Best suited for wider viewports and settings forms.
+
+<div class="docs-example">
+{% call ui.form() %}
+  {% call ui.formField(labelPosition="side") %}
+    {{ ui.fieldLabel("Username") }}
+    <div class="form-field__body">
+      {{ ui.input(placeholder="janedoe") }}
+      {{ ui.formHelper("Visible to other users.") }}
+    </div>
+  {% endcall %}
+{% endcall %}
+</div>
+
+<h3>Borderless</h3>
+
+Use the borderless variant when the form is embedded in a card or modal that already provides its own container.
+
+<div class="docs-example">
+{% call ui.form(borderless=true) %}
+  {% call ui.formField() %}
+    {{ ui.fieldLabel("Search") }}
+    {{ ui.input(type="search", placeholder="Search...") }}
+  {% endcall %}
+{% endcall %}
+</div>
+
+<h2 id="usage-guidelines">Usage Guidelines</h2>
+
+<div class="docs-guideline-grid">
+  <div class="docs-guideline do">
+    <div class="docs-guideline-body">
+      <p class="docs-guideline-label">Do</p>
+      <p>Group related fields with <code>formGroup</code> and a descriptive title.</p>
+    </div>
+  </div>
+  <div class="docs-guideline dont">
+    <div class="docs-guideline-body">
+      <p class="docs-guideline-label">Don't</p>
+      <p>Don't place unrelated fields in the same group or omit labels.</p>
+    </div>
+  </div>
+</div>
+
+<h2 id="accessibility">Accessibility</h2>
+
+- Form groups use `<fieldset>` + `<legend>` for accessible grouping.
+- Every input must have an associated `<label>` via `for`/`id` pairing.
+- Required fields are communicated with a visual indicator and `aria-required`.
+- Error messages should be linked to the input via `aria-describedby`.
+- The form uses `novalidate` to allow custom validation patterns.
+
+<h2 id="theming">Theming</h2>
+
+Form adapts to brands and modes through its component tokens:
+
+| Token | Purpose |
+|-------|---------|
+| `--form-gap` | Spacing between fields |
+| `--form-group-gap` | Spacing between fields in a group |
+| `--form-padding-inline` | Horizontal padding |
+| `--form-padding-block` | Vertical padding |
+| `--form-border-radius` | Container corner radius |
+| `--form-container-background` | Background color |
+| `--form-container-border-color` | Border color |
+| `--form-border-size` | Border width |
+| `--form-field-gap` | Gap between label, input, helper |
+| `--form-field-helper-text-color-default` | Helper text color |
+| `--form-field-helper-text-color-invalid` | Error text color |
+| `--form-group-title-color` | Group legend color |

--- a/site/examples/login-form.md
+++ b/site/examples/login-form.md
@@ -31,38 +31,22 @@ breadcrumb:
   <div class="docs-hero-preview-stage">
 
 <div class="example-form-shell">
-  <form id="example-login-form" class="example-form" action="#" method="post" novalidate>
-    <fieldset class="example-form__group">
-      <legend class="example-form__group-title">Sign in</legend>
-      <p class="example-form__intro">Use your account email and password.</p>
-
-      <div class="example-form__field">
-        <label class="field-label" for="login-email" style="line-height: 24px;">
-          <span class="label-content">
-            <span class="label-content__text">Email address</span>
-          </span>
-          <span class="field-label__required" aria-hidden="true">*</span>
-          <span class="field-label__required-text"> (required)</span>
-        </label>
+  {% call ui.form(borderless=true) %}
+    {% call ui.formGroup(title="Sign in") %}
+      <p class="form-field__helper">Use your account email and password.</p>
+      {% call ui.formField() %}
+        {{ ui.fieldLabel("Email address", htmlFor="login-email", required=true) }}
         {{ ui.input(type="email", id="login-email", name="email", placeholder="name@example.com") }}
-      </div>
-
-      <div class="example-form__field">
-        <label class="field-label" for="login-password" style="line-height: 24px;">
-          <span class="label-content">
-            <span class="label-content__text">Password</span>
-          </span>
-          <span class="field-label__required" aria-hidden="true">*</span>
-          <span class="field-label__required-text"> (required)</span>
-        </label>
+      {% endcall %}
+      {% call ui.formField() %}
+        {{ ui.fieldLabel("Password", htmlFor="login-password", required=true) }}
         {{ ui.input(type="password", id="login-password", name="password", placeholder="Enter password") }}
-      </div>
-    </fieldset>
-
-    <div class="example-form__actions">
+      {% endcall %}
+    {% endcall %}
+    {% call ui.formActions() %}
       {{ ui.button(label="Sign in", type="submit") }}
-    </div>
-  </form>
+    {% endcall %}
+  {% endcall %}
 </div>
 
   </div>

--- a/site/examples/login-form.md
+++ b/site/examples/login-form.md
@@ -43,7 +43,7 @@ breadcrumb:
         {{ ui.input(type="password", id="login-password", name="password", placeholder="Enter password") }}
       {% endcall %}
     {% endcall %}
-    {% call ui.formActions() %}
+    {% call ui.formActions(align="stretch") %}
       {{ ui.button(label="Sign in", type="submit") }}
     {% endcall %}
   {% endcall %}

--- a/src/react/form.js
+++ b/src/react/form.js
@@ -1,0 +1,111 @@
+import React from "react";
+
+/**
+ * Form — layout container for form fields.
+ *
+ * @param {object} props
+ * @param {boolean} [props.borderless=false] - Remove border and background
+ * @param {string} [props.className=""] - Additional class names
+ * @param {React.ReactNode} props.children - Form content
+ */
+export function Form({
+  borderless = false,
+  className = "",
+  children,
+  ...props
+}) {
+  const classes = ["form"];
+  if (borderless) classes.push("borderless");
+  if (className) classes.push(className);
+
+  return React.createElement(
+    "form",
+    { className: classes.join(" "), noValidate: true, ...props },
+    children,
+  );
+}
+
+/**
+ * FormGroup — groups related fields with an optional title.
+ *
+ * @param {object} props
+ * @param {string} [props.title=""] - Group legend
+ * @param {string} [props.className=""] - Additional class names
+ * @param {React.ReactNode} props.children - Grouped fields
+ */
+export function FormGroup({ title = "", className = "", children, ...props }) {
+  const classes = ["form-group"];
+  if (className) classes.push(className);
+
+  return React.createElement(
+    "fieldset",
+    { className: classes.join(" "), ...props },
+    title
+      ? React.createElement("legend", { className: "form-group__title" }, title)
+      : null,
+    children,
+  );
+}
+
+/**
+ * FormField — single field wrapper with optional side label layout.
+ *
+ * @param {object} props
+ * @param {"top"|"side"} [props.labelPosition="top"] - Label placement
+ * @param {boolean} [props.invalid=false] - Show invalid state
+ * @param {string} [props.className=""] - Additional class names
+ * @param {React.ReactNode} props.children - Label + input + helper
+ */
+export function FormField({
+  labelPosition = "top",
+  invalid = false,
+  className = "",
+  children,
+  ...props
+}) {
+  const classes = ["form-field"];
+  if (invalid) classes.push("is-invalid");
+  if (className) classes.push(className);
+
+  const attrs = { className: classes.join(" "), ...props };
+  if (labelPosition === "side") attrs["data-label-position"] = "side";
+
+  return React.createElement("div", attrs, children);
+}
+
+/**
+ * FormHelper — helper or error text below a field.
+ *
+ * @param {object} props
+ * @param {string} props.text - Helper message
+ */
+export function FormHelper({ text, ...props }) {
+  return React.createElement(
+    "p",
+    { className: "form-field__helper", ...props },
+    text,
+  );
+}
+
+/**
+ * FormActions — button area at the bottom of a form.
+ *
+ * @param {object} props
+ * @param {"start"|"end"|"stretch"} [props.align="end"] - Button alignment
+ * @param {string} [props.className=""] - Additional class names
+ * @param {React.ReactNode} props.children - Action buttons
+ */
+export function FormActions({
+  align = "end",
+  className = "",
+  children,
+  ...props
+}) {
+  const classes = ["form-actions"];
+  if (className) classes.push(className);
+
+  const attrs = { className: classes.join(" "), ...props };
+  if (align !== "end") attrs["data-align"] = align;
+
+  return React.createElement("div", attrs, children);
+}

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -12,3 +12,4 @@ export { Avatar } from "./avatar.js";
 export { Accordion, AccordionItem } from "./accordion.js";
 export { TabList, Tab, TabPanel } from "./tabs.js";
 export { Tooltip } from "./tooltip.js";
+export { Form, FormGroup, FormField, FormHelper, FormActions } from "./form.js";

--- a/src/ui/index.css
+++ b/src/ui/index.css
@@ -12,3 +12,4 @@
 @import url("./patterns/accordion.css") layer(components);
 @import url("./patterns/tabs.css") layer(components);
 @import url("./patterns/tooltip.css") layer(components);
+@import url("./patterns/form.css") layer(components);

--- a/src/ui/patterns/form.css
+++ b/src/ui/patterns/form.css
@@ -1,0 +1,108 @@
+@layer components {
+  /* ----------------------------------------------------------------
+   * Form — layout container for form fields
+   * ---------------------------------------------------------------- */
+
+  .form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--form-gap);
+    padding-inline: var(--form-padding-inline);
+    padding-block: var(--form-padding-block);
+    background: var(--form-container-background);
+    border: var(--form-border-size) solid var(--form-container-border-color);
+    border-radius: var(--form-border-radius);
+  }
+
+  .form.borderless {
+    border: none;
+    padding: 0;
+    background: transparent;
+  }
+
+  /* ----------------------------------------------------------------
+   * Form Group — groups related fields with an optional title
+   * ---------------------------------------------------------------- */
+
+  .form-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--form-group-gap);
+  }
+
+  .form-group__title {
+    font-family: var(--typography-heading-font-family);
+    font-weight: var(--typography-heading-font-weight);
+    font-size: var(--typography-heading-font-size-sm);
+    line-height: var(--typography-heading-line-height-sm);
+    color: var(--form-group-title-color);
+    margin: 0;
+  }
+
+  /* ----------------------------------------------------------------
+   * Form Field — single field with label, input, and helper/error
+   * ---------------------------------------------------------------- */
+
+  .form-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--form-field-gap);
+  }
+
+  .form-field[data-label-position="side"] {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+
+  .form-field[data-label-position="side"] > .field-label {
+    flex-shrink: 0;
+    inline-size: 8rem;
+    padding-block-start: var(--size-spacing-200);
+  }
+
+  .form-field[data-label-position="side"] > .form-field__body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: var(--form-field-gap);
+  }
+
+  /* ----------------------------------------------------------------
+   * Helper and error text
+   * ---------------------------------------------------------------- */
+
+  .form-field__helper {
+    font-family: var(--typography-body-font-family);
+    font-size: var(--font-size-sm);
+    line-height: var(--line-height-sm);
+    color: var(--form-field-helper-text-color-default);
+    margin: 0;
+  }
+
+  .form-field.is-invalid .form-field__helper {
+    color: var(--form-field-helper-text-color-invalid);
+  }
+
+  /* ----------------------------------------------------------------
+   * Form Actions — button area at the bottom
+   * ---------------------------------------------------------------- */
+
+  .form-actions {
+    display: flex;
+    gap: var(--size-spacing-200);
+    justify-content: flex-end;
+    padding-block-start: var(--size-spacing-200);
+  }
+
+  .form-actions[data-align="start"] {
+    justify-content: flex-start;
+  }
+
+  .form-actions[data-align="stretch"] {
+    flex-direction: column;
+  }
+
+  .form-actions[data-align="stretch"] > * {
+    inline-size: 100%;
+  }
+}

--- a/src/ui/patterns/form.css
+++ b/src/ui/patterns/form.css
@@ -28,6 +28,10 @@
     display: flex;
     flex-direction: column;
     gap: var(--form-group-gap);
+    margin: 0;
+    padding: 0;
+    border: 0;
+    min-inline-size: 0;
   }
 
   .form-group__title {


### PR DESCRIPTION
Closes #41

## Summary

Form layout component with built-in structure for field grouping, validation patterns, and flexible action placement.

## Surfaces Implemented

| # | Surface | Status |
|---|---------|--------|
| 1 | Component Tokens | ✅ Already in Figma (--form-*) |
| 2 | CSS Pattern | ✅ src/ui/patterns/form.css |
| 3 | CSS Index | ✅ Import added |
| 4 | Nunjucks Macros | ✅ form, formGroup, formField, formHelper, formActions |
| 5 | React Wrappers | ✅ Form, FormGroup, FormField, FormHelper, FormActions |
| 6 | React Index | ✅ Export added |
| 7 | Docs Page | ✅ Anatomy, options, behaviors, accessibility, theming |
| 8 | Playground Page | ✅ 4 controls + renderer + code generators |
| 9 | Playground Renderer | ✅ renderVanillaForm |
| 10 | Figma Component | ✅ Form (Container=bordered/none) + Form Group |

## Figma Structure

- **Form** — Component Set (Container=bordered / Container=none)
- **Form Group** — Simple Component (Title + Form Field instances)
- All properties bound to semantic tokens
- Uses existing Form Field + Input + Button instances

## Additional Changes

- Migrated login-form example to use Form macros (removed 50 lines custom CSS)
- Fixed fieldset browser reset in .form-group
- Added Form code generators for Nunjucks/React playground tabs

## Tested

- `npm run ci:check` passes (407 token refs, 493 defined tokens)
- Docs build: 48 pages
- Login-form example renders correctly with new macros