### PR TITLE
docs(steering): add session learnings to steering files

### DIFF
--- a/.kiro/steering/figma/figma-components.md
+++ b/.kiro/steering/figma/figma-components.md
@@ -77,8 +77,43 @@ This mirrors the CSS approach: `var(--token)` for everything, never raw values.
 - New components go into the Atoms section (node `2530:523` on the Components page).
 - Use `targetSection.appendChild(componentSet)` to place them.
 - Set `layoutSizingVertical = "HUG"` (height auto) on every component set.
-- Compound/molecule components → Molecules section.
+- Compound/molecule components → Molecules section (node `2530:524`).
 - Always position new component sets after existing ones (increment x position).
+- **CRITICAL**: Always call `await figma.setCurrentPageAsync(componentsPage)` before
+  creating components — `combineAsVariants` requires children and parent to be on
+  the same page.
+
+## Plugin API Pitfalls (learned from experience)
+
+### combineAsVariants requires COMPONENT nodes
+- `combineAsVariants([...], parent)` only accepts `COMPONENT` type children.
+- Use `figma.createComponent()`, not `figma.createFrame()`.
+- The parent frame must be on the same page as the component nodes.
+
+### layoutSizingHorizontal requires Auto Layout parent
+- `node.layoutSizingHorizontal = "FILL"` only works AFTER the node is appended
+  to an Auto Layout frame.
+- Pattern: `parent.appendChild(child)` → then → `child.layoutSizingHorizontal = "FILL"`.
+
+### Component Sets with 1 variant are broken
+- If you remove variants until only 1 remains, the Component Set enters an error
+  state and `componentPropertyDefinitions` throws.
+- To convert a Component Set to a simple Component: create a fresh
+  `figma.createComponent()`, rebuild the content, delete the old set.
+- Never use `combineAsVariants` for components without true variants.
+
+### Instances are immutable
+- You cannot `insertChild()` into an INSTANCE or any node inside one.
+- Slots in instances are filled by the designer at usage time, not programmatically.
+- For component previews, rely on the Slot's defaultContent.
+
+### Height after resize
+- After `comp.resize(width, 1)` with `primaryAxisSizingMode = "AUTO"`, the height
+  may stay at 1px. Always follow with `comp.layoutSizingVertical = "HUG"` to fix.
+
+### Variable scopes for COLOR type
+- Use `variable.scopes = ["ALL_SCOPES"]` for color variables.
+- Text-specific scopes like `"TEXT_CONTENT"` are invalid for COLOR type.
 
 ## After Creation
 

--- a/.kiro/steering/foundations/design-system-context.md
+++ b/.kiro/steering/foundations/design-system-context.md
@@ -52,7 +52,7 @@ Figma exports are the source. Generated files in `dist/` are never edited direct
 
 ## Current Components
 
-Label, Button (solid/outline/ghost), ButtonGroup, Input, Icon, Checkbox, Radio, Switch, Slider, Link
+Label, Button (solid/outline/ghost), ButtonGroup, Input, Icon, Checkbox, Radio, Switch, Slider, Link, Badge, Divider, Textarea, Avatar, Accordion, Tabs, Tooltip, Form (bordered/none), Form Group
 
 ## Component Promotion Workflow
 

--- a/.kiro/steering/foundations/token-exports.md
+++ b/.kiro/steering/foundations/token-exports.md
@@ -27,3 +27,34 @@ When working with files in `figma/exports/`, these rules apply:
 ## After Changes
 - Run `npm run tokens:generate` and verify zero "missing alias targets"
 - Run `npm run ci:check` to validate the full pipeline
+
+## Code Syntax Naming (codeSyntax.WEB)
+
+The CSS variable name is derived from `codeSyntax.WEB` in Figma, NOT from the
+JSON key structure. Common pitfalls:
+
+- **Double segments**: If a Figma variable path is `Input/Border/Border Color Default`,
+  the auto-generated syntax becomes `--input-border-border-color-default` (doubled).
+  Fix: manually set codeSyntax to `var(--input-border-color-default)`.
+- **Title Case duplicates**: Figma allows both `Badge/font-size/sm` and
+  `Badge/Font Size Sm` — they produce the same CSS var name and cause duplicates.
+  Fix: delete the redundant variable in Figma.
+- **Validation**: `npm run tokens:generate` reports duplicates. Zero duplicates
+  is required for CI to pass.
+
+## On-Color Token Pattern
+
+For text on colored surfaces, use `--color-text-on-*` tokens (not `--color-text-inverse`):
+
+| Token | Use on |
+|-------|--------|
+| `--color-text-on-brand` | `--color-fill-brand` |
+| `--color-text-on-danger` | `--color-fill-danger` |
+| `--color-text-on-success` | `--color-fill-success` |
+| `--color-text-on-subtle` | `--color-fill-subtle` |
+| `--color-text-on-active` | `--color-fill-active` |
+| `--color-text-on-disabled` | `--color-fill-disabled` |
+
+These resolve per brand and mode. Prefer them over generic `--color-text-inverse`
+in component tokens. Example: `--button-solid-text-color-default` references
+`--color-text-on-brand`, not `--color-text-inverse`.

--- a/.kiro/steering/workflows/component-creation.md
+++ b/.kiro/steering/workflows/component-creation.md
@@ -260,3 +260,39 @@ npm run ci:check           # Full pipeline
 | 8 | Playground Page | `site/components/{component}-playground.md` |
 | 9 | Playground Renderer | `site/assets/playground/renderers.js` |
 | 10 | Code Connect | `schemas/web-{component}.figma.ts` |
+
+---
+
+## Design Decision Checklist
+
+Before building, resolve these questions. They prevent rework mid-session:
+
+### Container ownership
+- **Does this component own its visual container (border, background, radius)?**
+- If yes → make it a variant property (e.g. `Container=bordered|none`)
+- If no → the component is layout-only; containers come from parent (Card, Modal, Page)
+- Rule: Only **one** component in the tree should own the container. Never nest
+  containers (Form inside Card both with borders).
+
+### Atom vs Molecule
+- **Does this component compose other existing components?**
+- If yes → it's a Molecule. Place in Molecules section. Use INSTANCES of existing
+  atoms (Input, Button, Label), not placeholder frames.
+- If no → it's an Atom. Place in Atoms section.
+
+### Component Set vs Simple Component
+- **Does this component need variant properties (state, size, orientation)?**
+- If yes → create a Component Set with `combineAsVariants()`
+- If no → create a simple `figma.createComponent()`
+- Rule: A Component Set with only 1 variant is invalid. If you remove variants
+  until 1 remains, convert to a simple Component.
+
+### Fieldset reset
+- **Does the HTML use `<fieldset>`?**
+- If yes → add explicit reset in CSS: `margin: 0; padding: 0; border: 0; min-inline-size: 0;`
+- Browsers apply default padding and borders to fieldsets that break layouts.
+
+### Playground page template
+- Always use `{% from "macros/playground.njk" import playground as uiPlayground with context %}`
+  and `{{ uiPlayground(playground) }}` — never a raw `<div>` stage.
+- Don't forget code generators in `code-generators.js` for Nunjucks/React tabs.


### PR DESCRIPTION
- figma-components.md: Add Plugin API pitfalls section (combineAsVariants, layoutSizing order, component set with 1 variant, instance immutability, height after resize, variable scopes)
- token-exports.md: Add codeSyntax naming rules, duplicate prevention, and on-color token pattern documentation
- design-system-context.md: Update current components list (add Badge through Form)
- component-creation.md: Add Design Decision Checklist (container ownership, atom vs molecule, component set vs simple, fieldset reset, playground template)