### PR TITLE
fix(select): use currentColor for disabled chevron, add invalid/error…

### DIFF
--- a/figma/exports/Components (UI).tokens.json
+++ b/figma/exports/Components (UI).tokens.json
@@ -4086,6 +4086,20 @@
             "WEB": "var(--select-border-radius)"
           }
         }
+      },
+      "Border Color Invalid": {
+        "$type": "color",
+        "$value": {
+          "$ref": "Color/Border/Danger"
+        },
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.codeSyntax": {
+            "WEB": "var(--select-border-color-invalid)"
+          }
+        }
       }
     },
     "Font Family": {

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -225,15 +225,16 @@
 <div class="{{ classes }}"{% if labelPosition == "side" %} data-label-position="side"{% endif %}>{{ caller() }}</div>
 {%- endmacro %}
 
-{% macro select(options=[], placeholder='', value='', state='default', disabled=false, className='', id='', name='') -%}
+{% macro select(options=[], placeholder='', value='', state='default', disabled=false, invalid=false, className='', id='', name='') -%}
 {%- set classes = "select" -%}
 {%- if state == "hover" -%}{%- set classes = classes + " is-hover" -%}{%- endif -%}
 {%- if state == "active" -%}{%- set classes = classes + " is-active" -%}{%- endif -%}
 {%- if state == "focus" -%}{%- set classes = classes + " is-focus-visible" -%}{%- endif -%}
 {%- if state == "disabled" -%}{%- set classes = classes + " is-disabled" -%}{%- endif -%}
+{%- if invalid -%}{%- set classes = classes + " is-invalid" -%}{%- endif -%}
 {%- if not value and placeholder -%}{%- set classes = classes + " is-placeholder" -%}{%- endif -%}
 {%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
-<select class="{{ classes }}"{% if id %} id="{{ id }}"{% endif %}{% if name %} name="{{ name }}"{% endif %}{% if disabled or state == "disabled" %} disabled{% endif %}>
+<select class="{{ classes }}"{% if id %} id="{{ id }}"{% endif %}{% if name %} name="{{ name }}"{% endif %}{% if invalid %} aria-invalid="true"{% endif %}{% if disabled or state == "disabled" %} disabled{% endif %}>
   {%- if placeholder %}
   <option value="" disabled{% if not value %} selected{% endif %}>{{ placeholder }}</option>
   {%- endif -%}

--- a/src/react/select.js
+++ b/src/react/select.js
@@ -7,11 +7,13 @@ export function Select({
   placeholder = "",
   value,
   disabled = false,
+  invalid = false,
   children,
   ...props
 }) {
   const classes = ["select"];
   if (!value && placeholder) classes.push("is-placeholder");
+  if (invalid) classes.push("is-invalid");
   if (className) classes.push(className);
 
   if (!props["aria-label"] && !props["aria-labelledby"] && !props.id) {
@@ -39,6 +41,7 @@ export function Select({
         className: classes.join(" "),
         disabled,
         value,
+        "aria-invalid": invalid || undefined,
         ...props,
       },
       placeholder
@@ -86,6 +89,7 @@ export function Select({
       className: classes.join(" "),
       disabled,
       value,
+      "aria-invalid": invalid || undefined,
       ...props,
     },
     optionElements,

--- a/src/ui/patterns/select.css
+++ b/src/ui/patterns/select.css
@@ -83,11 +83,24 @@
     cursor: not-allowed;
     color: var(--select-text-color-disabled);
     background-color: var(--select-container-background-disabled);
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath stroke='%23999' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m4 6 4 4 4-4'/%3E%3C/svg%3E");
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m4 6 4 4 4-4'/%3E%3C/svg%3E");
     border-color: var(--select-border-color-disabled);
   }
 
   .select.is-placeholder {
     color: var(--select-text-color-placeholder);
+  }
+
+  .select.is-invalid,
+  .select[aria-invalid="true"] {
+    border-color: var(--select-border-color-invalid);
+  }
+
+  .select.is-invalid:focus-visible,
+  .select[aria-invalid="true"]:focus-visible,
+  .select.is-invalid.is-focus-visible,
+  .select[aria-invalid="true"].is-focus-visible {
+    border-color: var(--select-border-color-invalid);
+    box-shadow: 0 0 0 var(--shadow-focus, 0) var(--select-border-color-invalid);
   }
 }


### PR DESCRIPTION
… state

- Disabled chevron SVG now uses currentColor instead of hardcoded #999, so it adapts to brand/mode changes via the text-color-disabled token.
- Added invalid state: is-invalid class, aria-invalid attribute, and danger border color (--select-border-color-invalid).
- Updated Nunjucks macro with invalid parameter.
- Updated React wrapper with invalid prop + aria-invalid.
- Added token to Figma export JSON.

Addresses usability findings:
- heuristic.consistency (disabled chevron)
- heuristic.error-prevention (invalid state)
- heuristic.feedback (error visual feedback)