### PR TITLE
fix(tokens): rename Brand C color scale from 10-step to 100-step and …

### DIFF
--- a/figma/exports/Core (Primitives).tokens.json
+++ b/figma/exports/Core (Primitives).tokens.json
@@ -1556,28 +1556,6 @@
         }
       },
       "Alpha Inverse": {
-        "000": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              1,
-              1,
-              1
-            ],
-            "alpha": 0,
-            "hex": "#FFFFFF00"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2494:434",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "var(--color-neutral-alpha-inverse-000)"
-            }
-          }
-        },
         "100": {
           "$type": "color",
           "$value": {
@@ -1773,6 +1751,28 @@
             ],
             "com.figma.codeSyntax": {
               "WEB": "var(--color-neutral-alpha-inverse-900)"
+            }
+          }
+        },
+        "000": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              1,
+              1,
+              1
+            ],
+            "alpha": 0,
+            "hex": "#FFFFFF00"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2494:434",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "var(--color-neutral-alpha-inverse-000)"
             }
           }
         }
@@ -3162,183 +3162,7 @@
     },
     "Brand C": {
       "Blue": {
-        "10": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.10588235408067703,
-              0.06666667014360428,
-              0.3607843220233917
-            ],
-            "alpha": 1,
-            "hex": "#1B115C"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:2",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-blue-10"
-            }
-          }
-        },
-        "20": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.028235292062163353,
-              0.1764705926179886,
-              0.5717647075653076
-            ],
-            "alpha": 1,
-            "hex": "#072D92"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:3",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-blue-20"
-            }
-          }
-        },
-        "30": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.03921568766236305,
-              0.23529411852359772,
-              0.7607843279838562
-            ],
-            "alpha": 1,
-            "hex": "#0A3CC2"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:4",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-blue-30"
-            }
-          }
-        },
-        "40": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.0470588244497776,
-              0.29411765933036804,
-              0.9529411792755127
-            ],
-            "alpha": 1,
-            "hex": "#0C4BF3"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:5",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-blue-40"
-            }
-          }
-        },
-        "50": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.2078431397676468,
-              0.40392157435417175,
-              0.9647058844566345
-            ],
-            "alpha": 1,
-            "hex": "#3567F6"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:6",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-blue-50"
-            }
-          }
-        },
-        "60": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.4282352924346924,
-              0.5764706134796143,
-              0.9717646837234497
-            ],
-            "alpha": 1,
-            "hex": "#6D93F8"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:7",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-blue-60"
-            }
-          }
-        },
-        "70": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.5803921818733215,
-              0.6901960968971252,
-              0.9803921580314636
-            ],
-            "alpha": 1,
-            "hex": "#94B0FA"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:8",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-blue-70"
-            }
-          }
-        },
-        "80": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.7137255072593689,
-              0.7843137383460999,
-              0.9882352948188782
-            ],
-            "alpha": 1,
-            "hex": "#B6C8FC"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:9",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-blue-80"
-            }
-          }
-        },
-        "90": {
+        "100": {
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
@@ -3356,11 +3180,165 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-blue-90"
+              "WEB": "--color-brand-c-blue-100"
             }
           }
         },
-        "100": {
+        "200": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.7137255072593689,
+              0.7843137383460999,
+              0.9882352948188782
+            ],
+            "alpha": 1,
+            "hex": "#B6C8FC"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:9",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-blue-200"
+            }
+          }
+        },
+        "300": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.5803921818733215,
+              0.6901960968971252,
+              0.9803921580314636
+            ],
+            "alpha": 1,
+            "hex": "#94B0FA"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:8",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-blue-300"
+            }
+          }
+        },
+        "400": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.4282352924346924,
+              0.5764706134796143,
+              0.9717646837234497
+            ],
+            "alpha": 1,
+            "hex": "#6D93F8"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:7",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-blue-400"
+            }
+          }
+        },
+        "500": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.2078431397676468,
+              0.40392157435417175,
+              0.9647058844566345
+            ],
+            "alpha": 1,
+            "hex": "#3567F6"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:6",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-blue-500"
+            }
+          }
+        },
+        "600": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.0470588244497776,
+              0.29411765933036804,
+              0.9529411792755127
+            ],
+            "alpha": 1,
+            "hex": "#0C4BF3"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:5",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-blue-600"
+            }
+          }
+        },
+        "700": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.03921568766236305,
+              0.23529411852359772,
+              0.7607843279838562
+            ],
+            "alpha": 1,
+            "hex": "#0A3CC2"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:4",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-blue-700"
+            }
+          }
+        },
+        "800": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.028235292062163353,
+              0.1764705926179886,
+              0.5717647075653076
+            ],
+            "alpha": 1,
+            "hex": "#072D92"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:3",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-blue-800"
+            }
+          }
+        },
+        "900": {
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
@@ -3373,194 +3351,18 @@
             "hex": "#1B115C"
           },
           "$extensions": {
-            "com.figma.variableId": "VariableID:2435:780",
+            "com.figma.variableId": "VariableID:2438:2",
             "com.figma.scopes": [
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-blue-100"
+              "WEB": "--color-brand-c-blue-900"
             }
           }
         }
       },
       "Coolblue": {
-        "10": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.019607843831181526,
-              0.2666666805744171,
-              0.3803921639919281
-            ],
-            "alpha": 1,
-            "hex": "#054461"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:11",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-coolblue-10"
-            }
-          }
-        },
-        "20": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.027450980618596077,
-              0.4000000059604645,
-              0.572549045085907
-            ],
-            "alpha": 1,
-            "hex": "#076692"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:12",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-coolblue-20"
-            }
-          }
-        },
-        "30": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.03921568766236305,
-              0.5333333611488342,
-              0.7607843279838562
-            ],
-            "alpha": 1,
-            "hex": "#0A88C2"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:13",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-coolblue-30"
-            }
-          }
-        },
-        "40": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.0470588244497776,
-              0.6666666865348816,
-              0.9529411792755127
-            ],
-            "alpha": 1,
-            "hex": "#0CAAF3"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:14",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-coolblue-40"
-            }
-          }
-        },
-        "50": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.21960784494876862,
-              0.7254902124404907,
-              0.9607843160629272
-            ],
-            "alpha": 1,
-            "hex": "#38B9F5"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:15",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-coolblue-50"
-            }
-          }
-        },
-        "60": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.43921568989753723,
-              0.7960784435272217,
-              0.95686274766922
-            ],
-            "alpha": 1,
-            "hex": "#70CBF4"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:16",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-coolblue-60"
-            }
-          }
-        },
-        "70": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.6627451181411743,
-              0.8745098114013672,
-              0.9725490212440491
-            ],
-            "alpha": 1,
-            "hex": "#A9DFF8"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:17",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-coolblue-70"
-            }
-          }
-        },
-        "80": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.7764706015586853,
-              0.9176470637321472,
-              0.9843137264251709
-            ],
-            "alpha": 1,
-            "hex": "#C6EAFB"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:18",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-coolblue-80"
-            }
-          }
-        },
-        "90": {
+        "100": {
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
@@ -3578,232 +3380,188 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-coolblue-90"
-            }
-          }
-        },
-        "100": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.04313725605607033,
-              0.2666666805744171,
-              0.3803921639919281
-            ],
-            "alpha": 1,
-            "hex": "#0B4461"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2435:784",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
               "WEB": "--color-brand-c-coolblue-100"
             }
           }
-        }
-      },
-      "Green": {
-        "10": {
+        },
+        "200": {
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.019607843831181526,
-              0.25882354378700256,
-              0.239215686917305
+              0.7764706015586853,
+              0.9176470637321472,
+              0.9843137264251709
             ],
             "alpha": 1,
-            "hex": "#05423D"
+            "hex": "#C6EAFB"
           },
           "$extensions": {
-            "com.figma.variableId": "VariableID:2438:20",
+            "com.figma.variableId": "VariableID:2438:18",
             "com.figma.scopes": [
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-green-10"
+              "WEB": "--color-brand-c-coolblue-200"
             }
           }
         },
-        "20": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.1411764770746231,
-              0.43529412150382996,
-              0.2862745225429535
-            ],
-            "alpha": 1,
-            "hex": "#246F49"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:21",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-green-20"
-            }
-          }
-        },
-        "30": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.16862745583057404,
-              0.6313725709915161,
-              0.40784314274787903
-            ],
-            "alpha": 1,
-            "hex": "#2BA168"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:22",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-green-30"
-            }
-          }
-        },
-        "40": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.1882352977991104,
-              0.7137255072593689,
-              0.4588235318660736
-            ],
-            "alpha": 1,
-            "hex": "#30B675"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:23",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-green-40"
-            }
-          }
-        },
-        "50": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.3803921639919281,
-              0.7686274647712708,
-              0.5529412031173706
-            ],
-            "alpha": 1,
-            "hex": "#61C48D"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:24",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-green-50"
-            }
-          }
-        },
-        "60": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.529411792755127,
-              0.8235294222831726,
-              0.6509804129600525
-            ],
-            "alpha": 1,
-            "hex": "#87D2A6"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:25",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-green-60"
-            }
-          }
-        },
-        "70": {
+        "300": {
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
             "components": [
               0.6627451181411743,
-              0.8784313797950745,
-              0.7490196228027344
-            ],
-            "alpha": 1,
-            "hex": "#A9E0BF"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:26",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-green-70"
-            }
-          }
-        },
-        "80": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.772549033164978,
-              0.8941176533699036,
-              0.8039215803146362
-            ],
-            "alpha": 1,
-            "hex": "#C5E4CD"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2438:27",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-green-80"
-            }
-          }
-        },
-        "90": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
               0.8745098114013672,
-              0.9647058844566345,
-              0.9215686321258545
+              0.9725490212440491
             ],
             "alpha": 1,
-            "hex": "#DFF6EB"
+            "hex": "#A9DFF8"
           },
           "$extensions": {
-            "com.figma.variableId": "VariableID:2438:28",
+            "com.figma.variableId": "VariableID:2438:17",
             "com.figma.scopes": [
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-green-90"
+              "WEB": "--color-brand-c-coolblue-300"
             }
           }
         },
+        "400": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.43921568989753723,
+              0.7960784435272217,
+              0.95686274766922
+            ],
+            "alpha": 1,
+            "hex": "#70CBF4"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:16",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-coolblue-400"
+            }
+          }
+        },
+        "500": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.21960784494876862,
+              0.7254902124404907,
+              0.9607843160629272
+            ],
+            "alpha": 1,
+            "hex": "#38B9F5"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:15",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-coolblue-500"
+            }
+          }
+        },
+        "600": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.0470588244497776,
+              0.6666666865348816,
+              0.9529411792755127
+            ],
+            "alpha": 1,
+            "hex": "#0CAAF3"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:14",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-coolblue-600"
+            }
+          }
+        },
+        "700": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.03921568766236305,
+              0.5333333611488342,
+              0.7607843279838562
+            ],
+            "alpha": 1,
+            "hex": "#0A88C2"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:13",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-coolblue-700"
+            }
+          }
+        },
+        "800": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.027450980618596077,
+              0.4000000059604645,
+              0.572549045085907
+            ],
+            "alpha": 1,
+            "hex": "#076692"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:12",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-coolblue-800"
+            }
+          }
+        },
+        "900": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.019607843831181526,
+              0.2666666805744171,
+              0.3803921639919281
+            ],
+            "alpha": 1,
+            "hex": "#054461"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:11",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-coolblue-900"
+            }
+          }
+        }
+      },
+      "Green": {
         "100": {
           "$type": "color",
           "$value": {
@@ -3825,207 +3583,207 @@
               "WEB": "--color-brand-c-green-100"
             }
           }
+        },
+        "200": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.8745098114013672,
+              0.9647058844566345,
+              0.9215686321258545
+            ],
+            "alpha": 1,
+            "hex": "#DFF6EB"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:28",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-green-200"
+            }
+          }
+        },
+        "300": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.772549033164978,
+              0.8941176533699036,
+              0.8039215803146362
+            ],
+            "alpha": 1,
+            "hex": "#C5E4CD"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:27",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-green-300"
+            }
+          }
+        },
+        "400": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.6627451181411743,
+              0.8784313797950745,
+              0.7490196228027344
+            ],
+            "alpha": 1,
+            "hex": "#A9E0BF"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:26",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-green-400"
+            }
+          }
+        },
+        "500": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.529411792755127,
+              0.8235294222831726,
+              0.6509804129600525
+            ],
+            "alpha": 1,
+            "hex": "#87D2A6"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:25",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-green-500"
+            }
+          }
+        },
+        "600": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.3803921639919281,
+              0.7686274647712708,
+              0.5529412031173706
+            ],
+            "alpha": 1,
+            "hex": "#61C48D"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:24",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-green-600"
+            }
+          }
+        },
+        "700": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.1882352977991104,
+              0.7137255072593689,
+              0.4588235318660736
+            ],
+            "alpha": 1,
+            "hex": "#30B675"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:23",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-green-700"
+            }
+          }
+        },
+        "800": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.16862745583057404,
+              0.6313725709915161,
+              0.40784314274787903
+            ],
+            "alpha": 1,
+            "hex": "#2BA168"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:22",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-green-800"
+            }
+          }
+        },
+        "900": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.1411764770746231,
+              0.43529412150382996,
+              0.2862745225429535
+            ],
+            "alpha": 1,
+            "hex": "#246F49"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:21",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-green-900"
+            }
+          }
+        },
+        "1000": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.019607843831181526,
+              0.25882354378700256,
+              0.239215686917305
+            ],
+            "alpha": 1,
+            "hex": "#05423D"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2438:20",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-green-1000"
+            }
+          }
         }
       },
       "Red": {
-        "10": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.3764705955982208,
-              0.0235294122248888,
-              0.03529411926865578
-            ],
-            "alpha": 1,
-            "hex": "#600609"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:2",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-red-10"
-            }
-          }
-        },
-        "20": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.5647059082984924,
-              0.03529411926865578,
-              0.054901961237192154
-            ],
-            "alpha": 1,
-            "hex": "#90090E"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:3",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-red-20"
-            }
-          }
-        },
-        "30": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.7529411911964417,
-              0.0470588244497776,
-              0.07058823853731155
-            ],
-            "alpha": 1,
-            "hex": "#C00C12"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:4",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-red-30"
-            }
-          }
-        },
-        "40": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.9411764740943909,
-              0.05882352963089943,
-              0.09019608050584793
-            ],
-            "alpha": 1,
-            "hex": "#F00F17"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:5",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-red-40"
-            }
-          }
-        },
-        "50": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.9490196108818054,
-              0.22745098173618317,
-              0.2549019753932953
-            ],
-            "alpha": 1,
-            "hex": "#F23A41"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:6",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-red-50"
-            }
-          }
-        },
-        "60": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.9647058844566345,
-              0.43529412150382996,
-              0.45490196347236633
-            ],
-            "alpha": 1,
-            "hex": "#F66F74"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:7",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-red-60"
-            }
-          }
-        },
-        "70": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.9725490212440491,
-              0.5882353186607361,
-              0.6000000238418579
-            ],
-            "alpha": 1,
-            "hex": "#F89699"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:8",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-red-70"
-            }
-          }
-        },
-        "80": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.9803921580314636,
-              0.7176470756530762,
-              0.7254902124404907
-            ],
-            "alpha": 1,
-            "hex": "#FAB7B9"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:9",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-red-80"
-            }
-          }
-        },
-        "90": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.9921568632125854,
-              0.886274516582489,
-              0.8901960849761963
-            ],
-            "alpha": 1,
-            "hex": "#FDE2E3"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:10",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-red-90"
-            }
-          }
-        },
         "100": {
           "$type": "color",
           "$value": {
@@ -4047,207 +3805,207 @@
               "WEB": "--color-brand-c-red-100"
             }
           }
+        },
+        "200": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.9921568632125854,
+              0.886274516582489,
+              0.8901960849761963
+            ],
+            "alpha": 1,
+            "hex": "#FDE2E3"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:10",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-red-200"
+            }
+          }
+        },
+        "300": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.9803921580314636,
+              0.7176470756530762,
+              0.7254902124404907
+            ],
+            "alpha": 1,
+            "hex": "#FAB7B9"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:9",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-red-300"
+            }
+          }
+        },
+        "400": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.9725490212440491,
+              0.5882353186607361,
+              0.6000000238418579
+            ],
+            "alpha": 1,
+            "hex": "#F89699"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:8",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-red-400"
+            }
+          }
+        },
+        "500": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.9647058844566345,
+              0.43529412150382996,
+              0.45490196347236633
+            ],
+            "alpha": 1,
+            "hex": "#F66F74"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:7",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-red-500"
+            }
+          }
+        },
+        "600": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.9490196108818054,
+              0.22745098173618317,
+              0.2549019753932953
+            ],
+            "alpha": 1,
+            "hex": "#F23A41"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:6",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-red-600"
+            }
+          }
+        },
+        "700": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.9411764740943909,
+              0.05882352963089943,
+              0.09019608050584793
+            ],
+            "alpha": 1,
+            "hex": "#F00F17"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:5",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-red-700"
+            }
+          }
+        },
+        "800": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.7529411911964417,
+              0.0470588244497776,
+              0.07058823853731155
+            ],
+            "alpha": 1,
+            "hex": "#C00C12"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:4",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-red-800"
+            }
+          }
+        },
+        "900": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.5647059082984924,
+              0.03529411926865578,
+              0.054901961237192154
+            ],
+            "alpha": 1,
+            "hex": "#90090E"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:3",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-red-900"
+            }
+          }
+        },
+        "1000": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.3764705955982208,
+              0.0235294122248888,
+              0.03529411926865578
+            ],
+            "alpha": 1,
+            "hex": "#600609"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:2",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-red-1000"
+            }
+          }
         }
       },
       "Orange": {
-        "10": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.4000000059604645,
-              0.239215686917305,
-              0
-            ],
-            "alpha": 1,
-            "hex": "#663D00"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:12",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-orange-10"
-            }
-          }
-        },
-        "20": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.6000000238418579,
-              0.3607843220233917,
-              0
-            ],
-            "alpha": 1,
-            "hex": "#995C00"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:13",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-orange-20"
-            }
-          }
-        },
-        "30": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.800000011920929,
-              0.47843137383461,
-              0
-            ],
-            "alpha": 1,
-            "hex": "#CC7A00"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:14",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-orange-30"
-            }
-          }
-        },
-        "40": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              1,
-              0.6000000238418579,
-              0
-            ],
-            "alpha": 1,
-            "hex": "#FF9900"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:15",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-orange-40"
-            }
-          }
-        },
-        "50": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              1,
-              0.6705882549285889,
-              0.18039216101169586
-            ],
-            "alpha": 1,
-            "hex": "#FFAB2E"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:16",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-orange-50"
-            }
-          }
-        },
-        "60": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              1,
-              0.7607843279838562,
-              0.4000000059604645
-            ],
-            "alpha": 1,
-            "hex": "#FFC266"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:17",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-orange-60"
-            }
-          }
-        },
-        "70": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              1,
-              0.8235294222831726,
-              0.5607843399047852
-            ],
-            "alpha": 1,
-            "hex": "#FFD28F"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:18",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-orange-70"
-            }
-          }
-        },
-        "80": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              1,
-              0.8784313797950745,
-              0.6980392336845398
-            ],
-            "alpha": 1,
-            "hex": "#FFE0B2"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:19",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-orange-80"
-            }
-          }
-        },
-        "90": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              1,
-              0.9372549057006836,
-              0.8392156958580017
-            ],
-            "alpha": 1,
-            "hex": "#FFEFD6"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:20",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-orange-90"
-            }
-          }
-        },
         "100": {
           "$type": "color",
           "$value": {
@@ -4269,207 +4027,207 @@
               "WEB": "--color-brand-c-orange-100"
             }
           }
+        },
+        "200": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              1,
+              0.9372549057006836,
+              0.8392156958580017
+            ],
+            "alpha": 1,
+            "hex": "#FFEFD6"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:20",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-orange-200"
+            }
+          }
+        },
+        "300": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              1,
+              0.8784313797950745,
+              0.6980392336845398
+            ],
+            "alpha": 1,
+            "hex": "#FFE0B2"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:19",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-orange-300"
+            }
+          }
+        },
+        "400": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              1,
+              0.8235294222831726,
+              0.5607843399047852
+            ],
+            "alpha": 1,
+            "hex": "#FFD28F"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:18",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-orange-400"
+            }
+          }
+        },
+        "500": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              1,
+              0.7607843279838562,
+              0.4000000059604645
+            ],
+            "alpha": 1,
+            "hex": "#FFC266"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:17",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-orange-500"
+            }
+          }
+        },
+        "600": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              1,
+              0.6705882549285889,
+              0.18039216101169586
+            ],
+            "alpha": 1,
+            "hex": "#FFAB2E"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:16",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-orange-600"
+            }
+          }
+        },
+        "700": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              1,
+              0.6000000238418579,
+              0
+            ],
+            "alpha": 1,
+            "hex": "#FF9900"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:15",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-orange-700"
+            }
+          }
+        },
+        "800": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.800000011920929,
+              0.47843137383461,
+              0
+            ],
+            "alpha": 1,
+            "hex": "#CC7A00"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:14",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-orange-800"
+            }
+          }
+        },
+        "900": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.6000000238418579,
+              0.3607843220233917,
+              0
+            ],
+            "alpha": 1,
+            "hex": "#995C00"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:13",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-orange-900"
+            }
+          }
+        },
+        "1000": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.4000000059604645,
+              0.239215686917305,
+              0
+            ],
+            "alpha": 1,
+            "hex": "#663D00"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:12",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-orange-1000"
+            }
+          }
         }
       },
       "Purple": {
-        "10": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.2235294133424759,
-              0.06666667014360428,
-              0.3607843220233917
-            ],
-            "alpha": 1,
-            "hex": "#39115C"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:22",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-purple-10"
-            }
-          }
-        },
-        "20": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.3176470696926117,
-              0.027450980618596077,
-              0.572549045085907
-            ],
-            "alpha": 1,
-            "hex": "#510792"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:23",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-purple-20"
-            }
-          }
-        },
-        "30": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.42352941632270813,
-              0.03921568766236305,
-              0.7607843279838562
-            ],
-            "alpha": 1,
-            "hex": "#6C0AC2"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:24",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-purple-30"
-            }
-          }
-        },
-        "40": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.529411792755127,
-              0.0470588244497776,
-              0.9529411792755127
-            ],
-            "alpha": 1,
-            "hex": "#870CF3"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:25",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-purple-40"
-            }
-          }
-        },
-        "50": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.6117647290229797,
-              0.2078431397676468,
-              0.9647058844566345
-            ],
-            "alpha": 1,
-            "hex": "#9C35F6"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:26",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-purple-50"
-            }
-          }
-        },
-        "60": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.7176470756530762,
-              0.4274509847164154,
-              0.9725490212440491
-            ],
-            "alpha": 1,
-            "hex": "#B76DF8"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:27",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-purple-60"
-            }
-          }
-        },
-        "70": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.7921568751335144,
-              0.5803921818733215,
-              0.9803921580314636
-            ],
-            "alpha": 1,
-            "hex": "#CA94FA"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:28",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-purple-70"
-            }
-          }
-        },
-        "80": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.8588235378265381,
-              0.7137255072593689,
-              0.9882352948188782
-            ],
-            "alpha": 1,
-            "hex": "#DBB6FC"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:29",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-purple-80"
-            }
-          }
-        },
-        "90": {
-          "$type": "color",
-          "$value": {
-            "colorSpace": "srgb",
-            "components": [
-              0.9254902005195618,
-              0.8470588326454163,
-              0.9921568632125854
-            ],
-            "alpha": 1,
-            "hex": "#ECD8FD"
-          },
-          "$extensions": {
-            "com.figma.variableId": "VariableID:2439:30",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
-            "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-purple-90"
-            }
-          }
-        },
         "100": {
           "$type": "color",
           "$value": {
@@ -4491,10 +4249,208 @@
               "WEB": "--color-brand-c-purple-100"
             }
           }
+        },
+        "200": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.9254902005195618,
+              0.8470588326454163,
+              0.9921568632125854
+            ],
+            "alpha": 1,
+            "hex": "#ECD8FD"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:30",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-purple-200"
+            }
+          }
+        },
+        "300": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.8588235378265381,
+              0.7137255072593689,
+              0.9882352948188782
+            ],
+            "alpha": 1,
+            "hex": "#DBB6FC"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:29",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-purple-300"
+            }
+          }
+        },
+        "400": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.7921568751335144,
+              0.5803921818733215,
+              0.9803921580314636
+            ],
+            "alpha": 1,
+            "hex": "#CA94FA"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:28",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-purple-400"
+            }
+          }
+        },
+        "500": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.7176470756530762,
+              0.4274509847164154,
+              0.9725490212440491
+            ],
+            "alpha": 1,
+            "hex": "#B76DF8"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:27",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-purple-500"
+            }
+          }
+        },
+        "600": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.6117647290229797,
+              0.2078431397676468,
+              0.9647058844566345
+            ],
+            "alpha": 1,
+            "hex": "#9C35F6"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:26",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-purple-600"
+            }
+          }
+        },
+        "700": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.529411792755127,
+              0.0470588244497776,
+              0.9529411792755127
+            ],
+            "alpha": 1,
+            "hex": "#870CF3"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:25",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-purple-700"
+            }
+          }
+        },
+        "800": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.42352941632270813,
+              0.03921568766236305,
+              0.7607843279838562
+            ],
+            "alpha": 1,
+            "hex": "#6C0AC2"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:24",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-purple-800"
+            }
+          }
+        },
+        "900": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.3176470696926117,
+              0.027450980618596077,
+              0.572549045085907
+            ],
+            "alpha": 1,
+            "hex": "#510792"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:23",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-purple-900"
+            }
+          }
+        },
+        "1000": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [
+              0.2235294133424759,
+              0.06666667014360428,
+              0.3607843220233917
+            ],
+            "alpha": 1,
+            "hex": "#39115C"
+          },
+          "$extensions": {
+            "com.figma.variableId": "VariableID:2439:22",
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.codeSyntax": {
+              "WEB": "--color-brand-c-purple-1000"
+            }
+          }
         }
       },
       "Midnight": {
-        "10": {
+        "100": {
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
@@ -4512,7 +4468,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "--color-brand-c-midnight-10"
+              "WEB": "--color-brand-c-midnight-100"
             }
           }
         }

--- a/figma/exports/Themes (Brands).tokens.json
+++ b/figma/exports/Themes (Brands).tokens.json
@@ -5,7 +5,7 @@
         "Success": {
           "$type": "color",
           "$value": {
-            "$ref": "Color/Brand C/Green/30"
+            "$ref": "Color/Brand C/Green/800"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:2006:198",
@@ -17,14 +17,14 @@
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2438:22",
-              "targetVariableName": "Color/Brand C/Green/30",
+              "targetVariableName": "Color/Brand C/Green/800",
               "targetVariableSetId": "VariableCollectionId:1:200",
               "targetVariableSetName": "Core (Primitives)"
             },
             "com.figma.isOverride": true,
             "com.figma.modeValues": {
               "Brand A": {
-                "$ref": "Color/Brand C/Green/30"
+                "$ref": "Color/Brand C/Green/800"
               },
               "Brand B": {
                 "$ref": "Color/Brand B/Green/600"
@@ -38,7 +38,7 @@
         "Danger": {
           "$type": "color",
           "$value": {
-            "$ref": "Color/Brand C/Red/30"
+            "$ref": "Color/Brand C/Red/800"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:2006:206",
@@ -50,14 +50,14 @@
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2439:4",
-              "targetVariableName": "Color/Brand C/Red/30",
+              "targetVariableName": "Color/Brand C/Red/800",
               "targetVariableSetId": "VariableCollectionId:1:200",
               "targetVariableSetName": "Core (Primitives)"
             },
             "com.figma.isOverride": true,
             "com.figma.modeValues": {
               "Brand A": {
-                "$ref": "Color/Brand C/Red/30"
+                "$ref": "Color/Brand C/Red/800"
               },
               "Brand B": {
                 "$ref": "Color/Brand B/Red/600"
@@ -71,7 +71,7 @@
         "Base": {
           "$type": "color",
           "$value": {
-            "$ref": "Color/Brand C/Blue/10"
+            "$ref": "Color/Brand C/Blue/900"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:2006:211",
@@ -83,14 +83,14 @@
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2438:2",
-              "targetVariableName": "Color/Brand C/Blue/10",
+              "targetVariableName": "Color/Brand C/Blue/900",
               "targetVariableSetId": "VariableCollectionId:1:200",
               "targetVariableSetName": "Core (Primitives)"
             },
             "com.figma.isOverride": true,
             "com.figma.modeValues": {
               "Brand A": {
-                "$ref": "Color/Brand C/Blue/10"
+                "$ref": "Color/Brand C/Blue/900"
               },
               "Brand B": {
                 "$ref": "Color/Brand B/Purple/700"
@@ -104,7 +104,7 @@
         "Base Dark": {
           "$type": "color",
           "$value": {
-            "$ref": "Color/Brand C/Midnight/10"
+            "$ref": "Color/Brand C/Midnight/100"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:2007:379",
@@ -116,14 +116,14 @@
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2439:32",
-              "targetVariableName": "Color/Brand C/Midnight/10",
+              "targetVariableName": "Color/Brand C/Midnight/100",
               "targetVariableSetId": "VariableCollectionId:1:200",
               "targetVariableSetName": "Core (Primitives)"
             },
             "com.figma.isOverride": true,
             "com.figma.modeValues": {
               "Brand A": {
-                "$ref": "Color/Brand C/Midnight/10"
+                "$ref": "Color/Brand C/Midnight/100"
               },
               "Brand B": {
                 "$ref": "Color/Brand B/Purple/900"
@@ -138,7 +138,7 @@
       "Primary": {
         "$type": "color",
         "$value": {
-          "$ref": "Color/Brand C/Blue/40"
+          "$ref": "Color/Brand C/Blue/600"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:2006:200",
@@ -150,14 +150,14 @@
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2438:5",
-            "targetVariableName": "Color/Brand C/Blue/40",
+            "targetVariableName": "Color/Brand C/Blue/600",
             "targetVariableSetId": "VariableCollectionId:1:200",
             "targetVariableSetName": "Core (Primitives)"
           },
           "com.figma.isOverride": true,
           "com.figma.modeValues": {
             "Brand A": {
-              "$ref": "Color/Brand C/Blue/40"
+              "$ref": "Color/Brand C/Blue/600"
             },
             "Brand B": {
               "$ref": "Color/Brand B/Purple/600"
@@ -171,7 +171,7 @@
       "Accent": {
         "$type": "color",
         "$value": {
-          "$ref": "Color/Brand C/Coolblue/60"
+          "$ref": "Color/Brand C/Coolblue/400"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:2006:203",
@@ -183,14 +183,14 @@
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2438:16",
-            "targetVariableName": "Color/Brand C/Coolblue/60",
+            "targetVariableName": "Color/Brand C/Coolblue/400",
             "targetVariableSetId": "VariableCollectionId:1:200",
             "targetVariableSetName": "Core (Primitives)"
           },
           "com.figma.isOverride": true,
           "com.figma.modeValues": {
             "Brand A": {
-              "$ref": "Color/Brand C/Coolblue/60"
+              "$ref": "Color/Brand C/Coolblue/400"
             },
             "Brand B": {
               "$ref": "Color/Brand B/Green/400"
@@ -204,7 +204,7 @@
       "Primary Dark": {
         "$type": "color",
         "$value": {
-          "$ref": "Color/Brand C/Blue/10"
+          "$ref": "Color/Brand C/Blue/900"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:2007:377",
@@ -216,14 +216,14 @@
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2438:2",
-            "targetVariableName": "Color/Brand C/Blue/10",
+            "targetVariableName": "Color/Brand C/Blue/900",
             "targetVariableSetId": "VariableCollectionId:1:200",
             "targetVariableSetName": "Core (Primitives)"
           },
           "com.figma.isOverride": true,
           "com.figma.modeValues": {
             "Brand A": {
-              "$ref": "Color/Brand C/Blue/10"
+              "$ref": "Color/Brand C/Blue/900"
             },
             "Brand B": {
               "$ref": "Color/Brand B/Purple/800"
@@ -237,7 +237,7 @@
       "Accent Dark": {
         "$type": "color",
         "$value": {
-          "$ref": "Color/Brand C/Coolblue/10"
+          "$ref": "Color/Brand C/Coolblue/900"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:2007:378",
@@ -249,14 +249,14 @@
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2438:11",
-            "targetVariableName": "Color/Brand C/Coolblue/10",
+            "targetVariableName": "Color/Brand C/Coolblue/900",
             "targetVariableSetId": "VariableCollectionId:1:200",
             "targetVariableSetName": "Core (Primitives)"
           },
           "com.figma.isOverride": true,
           "com.figma.modeValues": {
             "Brand A": {
-              "$ref": "Color/Brand C/Coolblue/10"
+              "$ref": "Color/Brand C/Coolblue/900"
             },
             "Brand B": {
               "$ref": "Color/Brand B/Green/800"


### PR DESCRIPTION
…fix ordering

- Rename all Brand C palette stops: 10->100, 20->200, ... 90->900, 100->1000
- Reverse value order to match Brand A/B convention (100=light, 900/1000=dark)
- Remove duplicate Blue/100 and Coolblue/100 variables (same value as /10)
- Update Theme  paths to point to correct new stops
- Figma variables updated in sync