### PR TITLE
feat(input): add date/time, number, password types and validation states

### DIFF
--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -286,6 +286,8 @@
     if (previewState === "active") classes.push("is-active");
     if (previewState === "focus") classes.push("is-focus-visible");
     if (previewState === "disabled") classes.push("is-disabled");
+    if (previewState === "readonly") classes.push("is-readonly");
+    if (previewState === "invalid") classes.push("is-invalid");
     if (props.className) classes.push(String(props.className));
 
     element.className = classes.join(" ");
@@ -293,6 +295,7 @@
     element.placeholder = placeholder;
     element.value = value;
     element.disabled = previewState === "disabled" || Boolean(props.disabled);
+    element.readOnly = previewState === "readonly";
 
     const attrs = [
       `class="${quoteAttr(element.className)}"`,

--- a/site/components/input-playground.md
+++ b/site/components/input-playground.md
@@ -32,6 +32,9 @@ playground:
         - password
         - tel
         - url
+        - date
+        - time
+        - number
     - kind: text
       name: placeholder
       label: Placeholder
@@ -53,6 +56,8 @@ playground:
         - active
         - focus
         - disabled
+        - readonly
+        - invalid
 ---
 
 {% from "macros/playground.njk" import playground as uiPlayground with context %}

--- a/src/ui/patterns/input.css
+++ b/src/ui/patterns/input.css
@@ -73,4 +73,82 @@
     background: var(--input-container-background-disabled);
     border-color: var(--input-border-color-disabled);
   }
+
+  /* Date/time type inputs — picker indicator styling */
+
+  .input[type="date"],
+  .input[type="time"],
+  .input[type="datetime-local"] {
+    cursor: pointer;
+  }
+
+  .input[type="date"]::-webkit-calendar-picker-indicator,
+  .input[type="time"]::-webkit-calendar-picker-indicator,
+  .input[type="datetime-local"]::-webkit-calendar-picker-indicator {
+    cursor: pointer;
+    opacity: 0.7;
+  }
+
+  .input[type="date"]:hover::-webkit-calendar-picker-indicator,
+  .input[type="time"]:hover::-webkit-calendar-picker-indicator,
+  .input[type="datetime-local"]:hover::-webkit-calendar-picker-indicator {
+    opacity: 1;
+  }
+
+  .input[type="date"]:disabled::-webkit-calendar-picker-indicator,
+  .input[type="time"]:disabled::-webkit-calendar-picker-indicator,
+  .input[type="datetime-local"]:disabled::-webkit-calendar-picker-indicator {
+    opacity: 0.4;
+  }
+
+  /* Number type — spinner styling */
+
+  .input[type="number"]::-webkit-inner-spin-button,
+  .input[type="number"]::-webkit-outer-spin-button {
+    opacity: 0.7;
+    cursor: pointer;
+  }
+
+  .input[type="number"]:hover::-webkit-inner-spin-button,
+  .input[type="number"]:hover::-webkit-outer-spin-button {
+    opacity: 1;
+  }
+
+  .input[type="number"]:disabled::-webkit-inner-spin-button,
+  .input[type="number"]:disabled::-webkit-outer-spin-button {
+    opacity: 0.4;
+  }
+
+  /* Password type — reveal button styling */
+
+  .input[type="password"]::-ms-reveal,
+  .input[type="password"]::-webkit-credentials-auto-fill-button {
+    cursor: pointer;
+  }
+
+  /* Readonly state */
+
+  .input:read-only,
+  .input[readonly],
+  .input.is-readonly {
+    cursor: default;
+    background: var(--input-container-background-default);
+    border-style: dashed;
+  }
+
+  /* Validation states */
+  .input.is-invalid,
+  .input[aria-invalid="true"],
+  .input:user-invalid {
+    border-color: var(--input-border-color-invalid);
+  }
+
+  .input.is-invalid:focus-visible,
+  .input[aria-invalid="true"]:focus-visible,
+  .input:user-invalid:focus-visible,
+  .input.is-invalid.is-focus-visible,
+  .input[aria-invalid="true"].is-focus-visible {
+    border-color: var(--input-border-color-invalid);
+    box-shadow: 0 0 0 var(--shadow-focus, 0) var(--input-border-color-invalid);
+  }
 }


### PR DESCRIPTION
## Summary

Extends the Input component with type-specific styling and validation states.

## What Changed

- **Date/time/datetime-local**: picker indicator opacity + cursor
- **Number**: spinner button styling
- **Password**: reveal button cursor
- **Readonly**: dashed border, default cursor, focusable
- **Validation**: `is-invalid`, `aria-invalid`, `:user-invalid` with danger border
- **Playground**: type dropdown adds date/time/number, state adds invalid/readonly

## Notes

- No new tokens needed — uses existing `--input-border-color-invalid`
- `:user-invalid` fires after user interaction (not on page load)
- Readonly uses dashed border to distinguish from disabled (solid + grey)