### PR TITLE
fix: correct focus ring to use blur instead of spread

### DIFF
--- a/src/ui/patterns/accordion.css
+++ b/src/ui/patterns/accordion.css
@@ -59,7 +59,7 @@
   .accordion-item > summary:focus-visible,
   .accordion-item > summary.is-focus-visible {
     outline: none;
-    box-shadow: inset 0 0 0 var(--shadow-focus) var(--color-focus);
+    box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
   .accordion-item__content {

--- a/src/ui/patterns/checkbox.css
+++ b/src/ui/patterns/checkbox.css
@@ -132,7 +132,7 @@
   .checkbox.is-focus-visible {
     border-color: var(--checkbox-border-color-focus);
     outline: none;
-    box-shadow: 0 0 0 var(--shadow-focus, 0) var(--color-focus, transparent);
+    box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
   .checkbox:disabled,

--- a/src/ui/patterns/input.css
+++ b/src/ui/patterns/input.css
@@ -62,7 +62,7 @@
     background: var(--input-container-background-focus);
     border-color: var(--input-border-color-focus);
     outline: none;
-    box-shadow: 0 0 0 var(--shadow-focus, 0) var(--color-focus, transparent);
+    box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
   .input:disabled,
@@ -149,6 +149,6 @@
   .input.is-invalid.is-focus-visible,
   .input[aria-invalid="true"].is-focus-visible {
     border-color: var(--input-border-color-invalid);
-    box-shadow: 0 0 0 var(--shadow-focus, 0) var(--input-border-color-invalid);
+    box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--input-border-color-invalid);
   }
 }

--- a/src/ui/patterns/radio.css
+++ b/src/ui/patterns/radio.css
@@ -95,7 +95,7 @@
   .radio.is-focus-visible {
     border-color: var(--radio-border-color-focus);
     outline: none;
-    box-shadow: 0 0 0 var(--shadow-focus, 0) var(--color-focus, transparent);
+    box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
   .radio:disabled,

--- a/src/ui/patterns/select.css
+++ b/src/ui/patterns/select.css
@@ -74,7 +74,7 @@
     background: var(--select-container-background-focus);
     border-color: var(--select-border-color-focus);
     outline: none;
-    box-shadow: 0 0 0 var(--shadow-focus, 0) var(--color-focus, transparent);
+    box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
   .select:disabled,
@@ -101,6 +101,6 @@
   .select.is-invalid.is-focus-visible,
   .select[aria-invalid="true"].is-focus-visible {
     border-color: var(--select-border-color-invalid);
-    box-shadow: 0 0 0 var(--shadow-focus, 0) var(--select-border-color-invalid);
+    box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--select-border-color-invalid);
   }
 }

--- a/src/ui/patterns/switch.css
+++ b/src/ui/patterns/switch.css
@@ -127,7 +127,7 @@
   .switch.is-focus-visible {
     border-color: var(--switch-track-border-color-active);
     outline: none;
-    box-shadow: 0 0 0 var(--shadow-focus, 0) var(--color-focus, transparent);
+    box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
   .switch:disabled,

--- a/src/ui/patterns/tabs.css
+++ b/src/ui/patterns/tabs.css
@@ -51,7 +51,7 @@
   .tab:focus-visible,
   .tab.is-focus-visible {
     outline: none;
-    box-shadow: inset 0 0 0 var(--shadow-focus) var(--color-focus);
+    box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
   .tab:disabled,

--- a/src/ui/patterns/textarea.css
+++ b/src/ui/patterns/textarea.css
@@ -29,7 +29,7 @@
   .textarea.is-focus-visible {
     border-color: var(--textarea-border-color-focus);
     outline: none;
-    box-shadow: 0 0 0 var(--shadow-focus, 0) var(--color-focus, transparent);
+    box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
   .textarea:disabled,


### PR DESCRIPTION
The focus ring box-shadow was using spread (solid ring) instead of blur (soft glow).

**Before:** `box-shadow: 0 0 0 var(--shadow-focus) var(--color-focus)` → solid 8px ring
**After:** `box-shadow: 0 0 var(--shadow-focus) 0 var(--color-focus)` → soft 8px glow

Matches the Figma drop shadow effect: `0px 0px 8px 0px color`.

Affected: input, select, textarea, checkbox, radio, switch