### PR TITLE
fix(schemas): replace figma.enum() with figma.boolean() for boolean p…

### DIFF
--- a/schemas/web-accordion.figma.ts
+++ b/schemas/web-accordion.figma.ts
@@ -5,12 +5,7 @@ figma.connect(
   "https://www.figma.com/design/uqMsy8fV1fPbQdAzgwlmBA/UI-Foundations?node-id=2535-283&m=dev",
   {
     props: {
-      open: figma.enum("Open", {
-        True: "open",
-        False: undefined,
-        true: "open",
-        false: undefined,
-      }),
+      open: figma.boolean("Open", { true: "open", false: undefined }),
       title: figma.string("Title"),
     },
     example: ({ open, title }: AccordionItemProps) =>

--- a/schemas/web-button-group.figma.ts
+++ b/schemas/web-button-group.figma.ts
@@ -9,12 +9,7 @@ figma.connect(
         Horizontal: "horizontal",
         Vertical: "vertical",
       }),
-      attached: figma.enum("Attached", {
-        True: "true",
-        False: "false",
-        true: "true",
-        false: "false",
-      }),
+      attached: figma.boolean("Attached", { true: "true", false: "false" }),
     },
     example: ({ orientation, attached }: ButtonGroupProps) => html`<div
       class="button-group"

--- a/schemas/web-checkbox.figma.ts
+++ b/schemas/web-checkbox.figma.ts
@@ -16,12 +16,7 @@ figma.connect(
           Default: undefined,
           Hover: "is-hover",
         }),
-        figma.enum("Disabled", {
-          False: undefined,
-          True: "is-disabled",
-          false: undefined,
-          true: "is-disabled",
-        }),
+        figma.boolean("Disabled", { true: "is-disabled", false: undefined }),
       ]),
       checked: figma.enum("Checked", {
         Unchecked: "false",
@@ -62,12 +57,7 @@ figma.connect(
     props: {
       wrapperClassName: figma.className([
         "checkbox-field",
-        figma.enum("Is Disabled", {
-          False: undefined,
-          True: "is-disabled",
-          false: undefined,
-          true: "is-disabled",
-        }),
+        figma.boolean("Is Disabled", { true: "is-disabled", false: undefined }),
       ]),
       className: figma.className([
         "checkbox",
@@ -75,12 +65,7 @@ figma.connect(
           Default: undefined,
           Hover: "is-hover",
         }),
-        figma.enum("Is Disabled", {
-          False: undefined,
-          True: "is-disabled",
-          false: undefined,
-          true: "is-disabled",
-        }),
+        figma.boolean("Is Disabled", { true: "is-disabled", false: undefined }),
         "is-checked",
       ]),
       checked: figma.enum("Is Disabled", {

--- a/schemas/web-input.figma.ts
+++ b/schemas/web-input.figma.ts
@@ -14,12 +14,7 @@ figma.connect(
           Readonly: undefined,
           Placeholder: undefined,
         }),
-        figma.enum("Disabled", {
-          False: undefined,
-          True: "is-disabled",
-          false: undefined,
-          true: "is-disabled",
-        }),
+        figma.boolean("Disabled", { true: "is-disabled", false: undefined }),
       ]),
       disabled: figma.boolean("Disabled"),
       type: figma.enum("Type", {

--- a/schemas/web-label.figma.ts
+++ b/schemas/web-label.figma.ts
@@ -7,12 +7,7 @@ figma.connect(
     props: {
       className: figma.className([
         "label-content",
-        figma.enum("Has Text", {
-          True: undefined,
-          False: "is-icon-only",
-          true: undefined,
-          false: "is-icon-only",
-        }),
+        figma.boolean("Has Text", { true: undefined, false: "is-icon-only" }),
       ]),
       text: figma.string("Text"),
     },

--- a/schemas/web-radio.figma.ts
+++ b/schemas/web-radio.figma.ts
@@ -11,12 +11,7 @@ figma.connect(
           Default: undefined,
           Hover: "is-hover",
         }),
-        figma.enum("Disabled", {
-          False: undefined,
-          True: "is-disabled",
-          false: undefined,
-          true: "is-disabled",
-        }),
+        figma.boolean("Disabled", { true: "is-disabled", false: undefined }),
       ]),
       checked: figma.enum("Checked", {
         Unchecked: "false",
@@ -44,21 +39,11 @@ figma.connect(
     props: {
       wrapperClassName: figma.className([
         "radio-field",
-        figma.enum("Is Disabled", {
-          False: undefined,
-          True: "is-disabled",
-          false: undefined,
-          true: "is-disabled",
-        }),
+        figma.boolean("Is Disabled", { true: "is-disabled", false: undefined }),
       ]),
       className: figma.className([
         "radio",
-        figma.enum("Is Disabled", {
-          False: undefined,
-          True: "is-disabled",
-          false: undefined,
-          true: "is-disabled",
-        }),
+        figma.boolean("Is Disabled", { true: "is-disabled", false: undefined }),
         "is-checked",
       ]),
       checked: figma.enum("Is Disabled", {

--- a/schemas/web-select.figma.ts
+++ b/schemas/web-select.figma.ts
@@ -13,12 +13,7 @@ figma.connect(
           Active: "is-active",
           Placeholder: "is-placeholder",
         }),
-        figma.enum("Disabled", {
-          False: undefined,
-          True: "is-disabled",
-          false: undefined,
-          true: "is-disabled",
-        }),
+        figma.boolean("Disabled", { true: "is-disabled", false: undefined }),
       ]),
       disabled: figma.boolean("Disabled"),
       placeholder: figma.enum("State", {

--- a/schemas/web-switch.figma.ts
+++ b/schemas/web-switch.figma.ts
@@ -15,12 +15,7 @@ figma.connect(
           Default: undefined,
           Hover: "is-hover",
         }),
-        figma.enum("Disabled", {
-          False: undefined,
-          True: "is-disabled",
-          false: undefined,
-          true: "is-disabled",
-        }),
+        figma.boolean("Disabled", { true: "is-disabled", false: undefined }),
       ]),
       checked: figma.enum("Checked", {
         Unchecked: "false",
@@ -54,21 +49,11 @@ figma.connect(
     props: {
       wrapperClassName: figma.className([
         "switch-field",
-        figma.enum("Is Disabled", {
-          False: undefined,
-          True: "is-disabled",
-          false: undefined,
-          true: "is-disabled",
-        }),
+        figma.boolean("Is Disabled", { true: "is-disabled", false: undefined }),
       ]),
       className: figma.className([
         "switch",
-        figma.enum("Is Disabled", {
-          False: undefined,
-          True: "is-disabled",
-          false: undefined,
-          true: "is-disabled",
-        }),
+        figma.boolean("Is Disabled", { true: "is-disabled", false: undefined }),
         "is-checked",
       ]),
       checked: figma.enum("Is Disabled", {

--- a/schemas/web-tab.figma.ts
+++ b/schemas/web-tab.figma.ts
@@ -8,12 +8,7 @@ figma.connect(
       className: figma.className([
         "tab",
       ]),
-      selected: figma.enum("Selected", {
-        True: "true",
-        False: "false",
-        true: "true",
-        false: "false",
-      }),
+      selected: figma.boolean("Selected", { true: "true", false: "false" }),
       label: figma.string("Label"),
     },
     example: ({ className, selected, label }: TabProps) =>

--- a/schemas/web-textarea.figma.ts
+++ b/schemas/web-textarea.figma.ts
@@ -12,12 +12,7 @@ figma.connect(
           Hover: "is-hover",
           Focus: "is-focus-visible",
         }),
-        figma.enum("Disabled", {
-          True: "is-disabled",
-          False: undefined,
-          true: "is-disabled",
-          false: undefined,
-        }),
+        figma.boolean("Disabled", { true: "is-disabled", false: undefined }),
       ]),
       disabled: figma.boolean("Disabled"),
       placeholder: figma.string("Placeholder"),


### PR DESCRIPTION
…rops

All boolean variant properties (Disabled, Is Disabled, Open, Attached, Selected, Has Text) were incorrectly using figma.enum() with redundant True/true/False/false mappings. Replaced with figma.boolean() which is the correct API for boolean component properties.

Affected schemas:
- web-checkbox (Disabled, Is Disabled)
- web-radio (Disabled, Is Disabled)
- web-switch (Disabled, Is Disabled)
- web-input (Disabled)
- web-textarea (Disabled)
- web-select (Disabled)
- web-accordion (Open)
- web-button-group (Attached)
- web-tab (Selected)
- web-label (Has Text)