### PR TITLE
Dim leading zeros in build log

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -40,7 +40,7 @@ const useColor = isTTY && !noColor && !isCI;
 const c = useColor ? {
   reset: '\x1b[0m',
   bold: '\x1b[1m',
-  dim: '\x1b[2m',
+  dim: '\x1b[2;90m',
   green: '\x1b[32m',
   red: '\x1b[31m',
   yellow: '\x1b[33m',
@@ -325,7 +325,7 @@ function printDocsSection() {
 function printServerSection() {
   out(sep);
   out(`${c.green}${section('DEV SERVER', 'RUN')}${c.reset}`);
-  out(row('URL', metrics.serverUrl, false));
+  out(row('URL', `${c.green}${metrics.serverUrl}${c.reset}`, false));
   out(row('Watch', 'ACTIVE', true));
   out(sep);
   out(`${c.green}ONLINE \u00B7 SERVER \u00B7 WATCH${c.reset}`);

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -51,11 +51,26 @@ const c = useColor ? {
 
 const W = 40;
 
+/** Zero-pad to 4 digits, dim the leading zeros. */
+function padNum(n) {
+  const s = String(n);
+  const zeros = Math.max(0, 4 - s.length);
+  if (zeros === 0) return s;
+  return `${c.dim}${'0'.repeat(zeros)}${c.reset}${s}`;
+}
+
+/** Visible length (strips ANSI for gap calculation). */
+function visLen(s) {
+  return s.replace(/\x1b\[[0-9;]*m/g, '').length;
+}
+
 function row(label, value, last) {
   const conn = last ? '\u2514' : '\u251C';
-  const val = typeof value === 'number' ? String(value).padStart(4, '0') : String(value);
+  const val = typeof value === 'number' || /^\d+$/.test(String(value))
+    ? padNum(Number(value))
+    : String(value);
   const left = `${conn} ${label}`;
-  const gap = W - left.length - val.length;
+  const gap = W - left.length - visLen(val);
   return gap > 0 ? `${left}${' '.repeat(gap)}${val}` : `${left} ${val}`;
 }
 


### PR DESCRIPTION
Leading zeros in metric values (e.g. `0289`) are rendered with ANSI dim to reduce visual noise while keeping 4-digit column alignment.