### PR TITLE
fix: add token-driven focus ring to button variants

### DIFF
--- a/src/ui/patterns/button.css
+++ b/src/ui/patterns/button.css
@@ -64,6 +64,8 @@
     background: var(--button-solid-container-background-focus);
     border-color: var(--button-solid-border-color-focus);
     color: var(--button-solid-text-color-default);
+    outline: none;
+    box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
   .button.outline {
@@ -103,6 +105,8 @@
     background: var(--button-outline-container-background-focus);
     border-color: var(--button-outline-border-color-focus);
     color: var(--button-outline-text-color-default);
+    outline: none;
+    box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
   .button.ghost {
@@ -142,6 +146,8 @@
     background: var(--button-ghost-container-background-focus);
     border-color: var(--button-ghost-border-color-focus);
     color: var(--button-ghost-text-color-default);
+    outline: none;
+    box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
   .button:disabled,


### PR DESCRIPTION
## Summary

Button was the only interactive component missing the standard focus ring pattern. All other components (input, checkbox, radio, switch, select, textarea, tabs, accordion, link) use:

```css
outline: none;
box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
```

This adds the same two declarations to all three button variants (solid, outline, ghost).

## What changed

- `src/ui/patterns/button.css` — added `outline: none` and `box-shadow` using `--shadow-focus` / `--color-focus` tokens to the `:focus-visible` rules for solid, outline, and ghost variants.

## Tokens used

- `--shadow-focus` (core primitive, `.5rem`)
- `--color-focus` (appearance mode, resolves to brand primary per mode)

Both are existing codeSyntax.WEB-derived tokens. No new variables introduced.

## Checks

- `npm run ci:check` passes (lint, unit tests, build, smoke, tokens, assets, rules, docs)

## Risks

- Low. Purely additive CSS declarations. No breaking change to markup or existing token contracts. Focus ring was previously browser-default (inconsistent blue outline); now it matches the system pattern.