### PR TITLE
docs: distinguish Patterns from Components

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -98,7 +98,7 @@ module.exports = function (eleventyConfig) {
         title: page.data.title,
         description: page.data.description || "",
         url: page.url,
-        type: "component",
+        type: "pattern",
       });
     }
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -64,6 +64,21 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addCollection("foundationsDocs", (collectionApi) => {
     return collectionApi
       .getFilteredByGlob("site/foundations/**/*.md")
+      .filter((entry) => entry.data.permalink !== "/foundations/" && !entry.data.excludeFromNav)
+      .sort((a, b) => {
+        const aOrder = Number(a.data.order || 999);
+        const bOrder = Number(b.data.order || 999);
+        if (aOrder !== bOrder) return aOrder - bOrder;
+        return String(a.data.title || "").localeCompare(
+          String(b.data.title || ""),
+        );
+      });
+  });
+
+  eleventyConfig.addCollection("primitivesDocs", (collectionApi) => {
+    return collectionApi
+      .getFilteredByGlob("site/primitives/**/*.md")
+      .filter((entry) => entry.data.permalink !== "/primitives/")
       .sort((a, b) => {
         const aOrder = Number(a.data.order || 999);
         const bOrder = Number(b.data.order || 999);

--- a/.kiro/steering/README.md
+++ b/.kiro/steering/README.md
@@ -13,7 +13,7 @@ These are included in every prompt automatically:
 
 ## Task → Steering Map
 
-### Creating a component
+### Creating a pattern
 
 1. `workflows/component-creation.md`
 2. `components/component-patterns.md`

--- a/.kiro/steering/foundations/design-system-context.md
+++ b/.kiro/steering/foundations/design-system-context.md
@@ -147,8 +147,8 @@ instances, and bind variables.
 
 ## Key Rules (from `docs/agentic/assistant-behavior-rules.md`)
 
-- Rule 8: New components require all 10 integration surfaces
-- Rule 9: Every component gets its own tokens — never reuse another component's
+- Rule 8: New patterns require all 10 integration surfaces
+- Rule 9: Every pattern gets its own tokens — never reuse another pattern's
 - Rule 10: Token `$ref` aliases must point to existing tokens
 - Rule 11: CSS class = bare name (`.slider` not `.ui-slider`), `@layer components`, logical properties
 - Rule 12: React = named `export function`, `React.createElement`, no JSX, no CSS imports

--- a/.kiro/steering/foundations/design-system-context.md
+++ b/.kiro/steering/foundations/design-system-context.md
@@ -50,11 +50,33 @@ Figma exports are the source. Generated files in `dist/` are never edited direct
 | Token exports | `figma/exports/*.tokens.json` |
 | Brand overrides | `dist/tokens/css/themes-brands.tokens.*.css` |
 
-## Current Components
+## Current Patterns
 
-Label, Button (solid/outline/ghost), ButtonGroup, Input, Icon, Checkbox, Radio, Switch, Link, Badge, Divider, Textarea, Avatar, Accordion, Tabs, Tooltip, Select, Form (bordered/none), Form Group
+Patterns are CSS-only, stateless UI building blocks. No JavaScript required.
 
-Planned (not yet implemented): Slider
+Label, Button (solid/outline/ghost), Input, Icon, Checkbox, Radio, Switch,
+Link, Badge, Divider, Textarea, Avatar, Accordion, Tabs, Tooltip, Select,
+Form (bordered/none), Form Group
+
+## Components (planned)
+
+Components are functional units that add state, interactivity, or orchestration
+logic via JavaScript. They build on top of patterns.
+
+Planned: Calendar, DatePicker, ComboBox, Dialog, Table
+
+Components will live in `src/components/` (not yet created).
+
+## Pattern vs. Component
+
+| | Pattern | Component |
+|---|---|---|
+| CSS | ✓ | ✓ (uses patterns) |
+| JavaScript | – | ✓ |
+| State | – | ✓ |
+| Location | `src/ui/patterns/` | `src/components/` |
+| Token layer | `@layer components` | `@layer components` |
+| Example | `.button`, `.input` | `<Calendar>` |
 
 ## Environment Variables
 
@@ -67,22 +89,23 @@ Copy `.env.example` to `.env` for local use. Scripts that need `FIGMA_TOKEN`
 will fail with auth errors if it is missing. `NPM_TOKEN` is only needed for
 `npm publish`.
 
-## Component Promotion Workflow
+## Pattern Promotion Workflow
 
 When building examples, pages, or compositions that use UI patterns not yet in
-the component list above, follow this workflow:
+the pattern list above, follow this workflow:
 
 1. **Detect** — After finishing the requested work, review the markup for any
    repeated UI pattern (badge, list, card, tooltip, etc.) that is not an
-   existing system component.
-2. **Report** — At the end of your response, list each missing component with:
+   existing system pattern.
+2. **Report** — At the end of your response, list each missing pattern with:
    - Name and short purpose (e.g. "Badge — small status pill label").
    - Why it passes the utility test (reusable across multiple contexts).
+   - Whether it is a Pattern (CSS-only) or Component (needs JS/state).
    - Which of the 10 integration surfaces are needed (Rule 8).
-3. **Provide a follow-up prompt** — For each missing component, write a
+3. **Provide a follow-up prompt** — For each missing pattern, write a
    ready-to-copy prompt the user can paste in a new conversation to scaffold
-   that component. The prompt should include the component name, variants,
-   token naming, and a reference to the example where it was first used.
+   that pattern. The prompt should include the name, variants, token naming,
+   and a reference to the example where it was first used.
 4. **Do NOT auto-create** — Never scaffold all 10 surfaces in the same session
    unless the user explicitly asks. Keep the current task focused and
    token-efficient.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -39,12 +39,12 @@ Themes are orthogonal:
 - `data-brand`
 - `data-mode`
 
-Brand and appearance must not be hardcoded into components.
+Brand and appearance must not be hardcoded into patterns.
 
 ## Color Rules
 
 Use semantic tokens for UI decisions.
-Do not use raw hex values in components unless explicitly documented.
+Do not use raw hex values in patterns unless explicitly documented.
 
 ## Typography Rules
 
@@ -56,9 +56,9 @@ Do not infer font stacks, line heights, or weights from screenshots.
 Prefer semantic spacing intent where available.
 Avoid arbitrary pixel values.
 
-## Component Rules
+## Pattern Rules
 
-Components must:
+Patterns must:
 
 - use existing tokens
 - support theming
@@ -79,5 +79,5 @@ Before creating UI:
 1. Read this file.
 2. Read `AGENTS.md`.
 3. Inspect token exports.
-4. Reuse existing tokens/components.
+4. Reuse existing tokens/patterns.
 5. Validate with available scripts.

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -102,7 +102,7 @@ No:
 
 ---
 
-## Component Implementation
+## Pattern Implementation
 
 HTML patterns:
 
@@ -142,7 +142,7 @@ React (optional):
 
 ---
 
-## Component Workflow
+## Pattern Workflow
 
 1. Update Figma token exports
 2. Run: npm run build\:all

--- a/README.md
+++ b/README.md
@@ -84,19 +84,16 @@ work with the system reliably.
 
 ### Layering
 
-```
- ╔═══════════════════════════════════╗
- ║  CORE       Raw values            ║
- ╠═══════════════════════════════════╣
- ║  SEMANTIC   Intent-based aliases  ║
- ╠═══════════════════════════════════╣
- ║  COMPONENT  Scoped per component  ║
- ╠═══════════════════════════════════╣
- ║  THEME      Brand + Mode overlay  ║
- ╚═══════════════════════════════════╝
+Token layers from foundation to surface:
+
+``` 
+   ╱─ THEME        Brand + Mode
+  ╱── COMPONENT    Scoped tokens
+ ╱─── SEMANTIC     Intent aliases
+╱──── CORE         Raw values
 ```
 
-Components reference only Semantic or Core. Never raw values.
+Patterns consume Semantic or Core tokens. Never raw values.
 
 ### Component Integration
 
@@ -152,7 +149,7 @@ npm install ui-foundations
 @import "ui-foundations/ui.css";
 ```
 
-### Use Components (plain HTML)
+### Use Patterns (plain HTML)
 
 ```html
 <button class="button">Label</button>
@@ -183,7 +180,9 @@ to see it in action.
 
 ---
 
-## Components
+## Patterns
+
+CSS-only, stateless UI building blocks. No JavaScript required.
 
 ```
  ┌──────────┬──────────┬──────────┬──────────┐
@@ -195,12 +194,25 @@ to see it in action.
  ├──────────┼──────────┼──────────┼──────────┤
  │ Label    │ TextArea │ Icon     │ Select   │
  ├──────────┼──────────┼──────────┼──────────┤
- │ Form     │          │          │          │
+ │ Form     │ FormGroup│          │          │
  └──────────┴──────────┴──────────┴──────────┘
 ```
 
-Each component uses semantic tokens (or its own token layer for complex variants)
-and supports theming out of the box.
+Each pattern uses semantic tokens and supports theming out of the box.
+
+## Components (coming next)
+
+Functional units that add state and interactivity on top of patterns.
+
+```
+ ┌──────────┬──────────┬──────────┐
+ │ Calendar │ DatePckr │ ComboBox │
+ ├──────────┼──────────┼──────────┤
+ │ Dialog   │ Table    │   ...    │
+ └──────────┴──────────┴──────────┘
+```
+
+Components will live in `src/components/` and require JavaScript.
 
 ---
 
@@ -382,7 +394,8 @@ npm run release:publish
 
 ## Roadmap
 
-- **Web Components** — replace React wrappers with framework-agnostic custom elements (light DOM, no shadow DOM) so the library is truly platform-independent.
+- **Calendar Component** — first functional component with state, date logic, and keyboard navigation. Built on top of existing patterns.
+- **Web Components** — replace React wrappers with framework-agnostic custom elements (light DOM, no shadow DOM) so patterns are truly platform-independent (#104).
 
 ---
 

--- a/docs/agentic/assistant-behavior-rules.md
+++ b/docs/agentic/assistant-behavior-rules.md
@@ -8,40 +8,40 @@ type: agent-guide
 
 1. Always follow foundation rules in `/docs/foundations` as the source of truth.
 2. Keep the 4-layer architecture: Core → Color Modes → Semantics → Components.
-3. Components may only reference Semantics/Core tokens; no raw values in components.
+3. Patterns may only reference Semantics/Core tokens; no raw values in patterns.
 4. Typography tokens never include color; text color lives in `Color.Text.*`.
 5. Responsive thresholds:
    - Viewport breakpoints in `Core.Breakpoint.*`
    - Container query thresholds in `Core.Container.*`
-6. Use variant-first naming: `Component.variant.part.property.state`.
-7. Before creating a new component, run a boundary check:
-   - Prefer composition inside an existing component family when behavior is mainly layout/wrapping/grouping.
-   - Create a standalone component only if it introduces distinct semantics, API surface, or lifecycle.
-   - This decision is independent from token work: new tokens alone are not sufficient reason for a standalone component.
+6. Use variant-first naming: `Pattern.variant.part.property.state`.
+7. Before creating a new pattern, run a boundary check:
+   - Prefer composition inside an existing pattern family when behavior is mainly layout/wrapping/grouping.
+   - Create a standalone pattern only if it introduces distinct semantics, API surface, or lifecycle.
+   - This decision is independent from token work: new tokens alone are not sufficient reason for a standalone pattern.
    - Apply the Snowflake check: local one-off solutions stay local; shared utility can enter the system.
    - Source of truth: `docs/foundations/foundation-009-component-boundaries-and-utility.md`.
-8. When creating a new component, always complete all integration surfaces:
-   - CSS pattern in `src/ui/patterns/<component>.css`
+8. When creating a new pattern, always complete all integration surfaces:
+   - CSS pattern in `src/ui/patterns/<pattern>.css`
    - Import in `src/ui/index.css`
-   - React wrapper in `src/react/<component>.js`
+   - React wrapper in `src/react/<pattern>.js`
    - Export in `src/react/index.js`
    - Nunjucks macro in `site/_includes/macros/ui.njk` (source of truth; `dist/macros/ui.njk` is copied during build)
    - Playground renderer in `site/assets/playground/renderers.js` — register the render function and add it to the `renderers` map
-   - Playground page in `site/components/<component>-playground.md` with `renderer: <component>` matching the key in the renderers map
-   - Docs page in `site/components/<component>.md`
-   - Code Connect file in `schemas/web-<component>.figma.ts`
-   - Component card in `site/components/index.md`
+   - Playground page in `site/components/<pattern>-playground.md` with `renderer: <pattern>` matching the key in the renderers map
+   - Docs page in `site/components/<pattern>.md`
+   - Code Connect file in `schemas/web-<pattern>.figma.ts`
+   - Pattern card in `site/components/index.md`
    Missing any of these (especially the playground renderer) will cause broken pages.
-9. Every new component must have its own Component-layer tokens. Never reuse tokens from another component (e.g. do not use `--input-checkbox-*` for a radio).
+9. Every new pattern must have its own Component-layer tokens. Never reuse tokens from another pattern (e.g. do not use `--input-checkbox-*` for a radio).
    - Check `dist/tokens/css/components-ui.tokens.css` for existing tokens.
-   - If the component has no tokens in Figma yet, propose new ones following the naming pattern `--<component>-<part>-<property>-<state>` and add them to `components-ui.tokens.css`, referencing only Semantic or Core tokens.
-   - This keeps components independently themeable and avoids hidden coupling.
+   - If the pattern has no tokens in Figma yet, propose new ones following the naming pattern `--<pattern>-<part>-<property>-<state>` and add them to `components-ui.tokens.css`, referencing only Semantic or Core tokens.
+   - This keeps patterns independently themeable and avoids hidden coupling.
 10. Token alias references must point to tokens that actually exist in the system.
     - Before adding a `$ref`, verify the target exists in `dist/tokens/css/` (Core, Modes, Semantics).
     - Run `npm run tokens:generate` and check for "missing alias targets" warnings.
     - Never invent Semantic/Core token names (e.g. `Color/Fill/Muted`, `Size/Spacing/50`) — use only what the system provides.
     - If a needed Semantic token does not exist, flag it for creation in Figma first.
-11. CSS class naming must follow the project convention: bare component name (e.g. `.slider`, `.radio`, `.checkbox`).
+11. CSS class naming must follow the project convention: bare pattern name (e.g. `.slider`, `.radio`, `.checkbox`).
     - Never prefix with `.ui-` or other namespaces.
     - CSS patterns must be wrapped in `@layer components { }`.
 12. React wrappers must follow the existing pattern:
@@ -49,7 +49,7 @@ type: agent-guide
     - No CSS imports inside React files
     - Use `React.createElement`, not JSX
     - Class array pattern: `const classes = ["component"]; if (className) classes.push(className);`
-13. Docs-only UI (code-tabs, mode toggles) must use docs-specific CSS, not component tokens.
+13. Docs-only UI (code-tabs, mode toggles) must use docs-specific CSS, not pattern tokens.
     - The `.code-tabs-bar` and `.docs-header` button groups are styled in `site/assets/docs.css` with hardcoded docs colors.
     - They must not inherit brand theming from `data-brand`.
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -146,8 +146,10 @@ function runStage(cmd, args, onLine) {
 // ─── Eleventy Page Categories ────────────────
 
 function categorize(path) {
+  if (path.startsWith('patterns/') && path.includes('-playground')) return 'Playgrounds';
+  if (path.startsWith('patterns/')) return 'Patterns';
   if (path.startsWith('components/') && path.includes('-playground')) return 'Playgrounds';
-  if (path.startsWith('components/')) return 'Components';
+  if (path.startsWith('components/')) return 'Patterns';
   if (path.startsWith('foundations/')) return 'Foundations';
   if (path.startsWith('examples/')) return 'Examples';
   return 'System';
@@ -171,7 +173,7 @@ const metrics = {
   assets: 0,
   buildTime: 0,
   serverUrl: null,
-  categories: { Foundations: 0, Components: 0, Playgrounds: 0, Examples: 0, System: 0 },
+  categories: { Foundations: 0, Patterns: 0, Playgrounds: 0, Examples: 0, System: 0 },
 };
 
 const buildStart = Date.now();
@@ -312,7 +314,7 @@ function printDocsSection() {
   out(`${c.green}${section('DOCS', 'OK')}${c.reset}`);
   const rows = [];
   if (cats.Foundations > 0) rows.push(['Foundations', cats.Foundations]);
-  if (cats.Components > 0) rows.push(['Components', cats.Components]);
+  if (cats.Patterns > 0) rows.push(['Patterns', cats.Patterns]);
   if (cats.Playgrounds > 0) rows.push(['Playgrounds', cats.Playgrounds]);
   if (cats.Examples > 0) rows.push(['Examples', cats.Examples]);
   if (cats.System > 0) rows.push(['System', cats.System]);

--- a/site/_includes/layouts/docs.njk
+++ b/site/_includes/layouts/docs.njk
@@ -195,14 +195,8 @@
           {% endif %}
           {% set isComponentsOverview = page.url == "/patterns/" or page.url == "/patterns" %}
           {% set isComponentDoc = page.url and page.url.indexOf("/patterns/") == 0 and not isPlayground and not isComponentsOverview %}
-          {% set hasFigmaConnection = figmaConnections and figmaConnections.byName and figmaConnections.byName[page.fileSlug] %}
-          {% set figmaComponentUrl = figmaConnections and figmaConnections.urlsByName and figmaConnections.urlsByName[page.fileSlug] %}
-          {% set showDraftPrefix = isComponentDoc and not hasFigmaConnection %}
           {% if title and not compactTitleInBreadcrumb %}
-          <h1>
-            {% if showDraftPrefix %}<span class="docs-draft-stamp">!Draft</span>{% endif %}
-            {{ title }}
-          </h1>
+          <h1>{{ title }}</h1>
           {% endif %}
           {% if description and not isPlayground %}<p class="page-intro">{{ description }}</p>{% endif %}
           {{ content | safe }}

--- a/site/_includes/layouts/docs.njk
+++ b/site/_includes/layouts/docs.njk
@@ -101,6 +101,24 @@
             </details>
           </nav>
 
+          <nav class="docs-nav-group" aria-label="Primitives">
+            <details{% if page.url.indexOf("/primitives/") == 0 %} open{% endif %}>
+              <summary class="docs-nav-group-toggle">Primitives</summary>
+              <ul>
+                {% for entry in collections.primitivesDocs %}
+                <li>
+                  <a
+                    href="{{ entry.url }}"
+                    {% if entry.url == page.url %}aria-current="page"{% endif %}
+                  >
+                    {{ entry.data.navTitle or entry.data.title }}
+                  </a>
+                </li>
+                {% endfor %}
+              </ul>
+            </details>
+          </nav>
+
           <nav class="docs-nav-group" aria-label="Patterns">
             <details{% if page.url.indexOf("/patterns/") == 0 or page.url == "/patterns/" %} open{% endif %}>
               <summary class="docs-nav-group-toggle">Patterns</summary>

--- a/site/_includes/layouts/docs.njk
+++ b/site/_includes/layouts/docs.njk
@@ -50,7 +50,7 @@
     {% endif %}
 
     {# Task 2.4: JSON-LD structured data for component pages #}
-    {% if page.url.indexOf("/components/") == 0 and not isPlayground and page.url != "/components/" %}
+    {% if page.url.indexOf("/patterns/") == 0 and not isPlayground and page.url != "/patterns/" %}
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -78,7 +78,7 @@
         <a class="docs-logo" href="/">UI Foundations</a>
 
         <div class="docs-search" role="combobox" aria-expanded="false" aria-haspopup="listbox" aria-owns="docs-search-results">
-          <input type="search" class="docs-search-input" placeholder="Search tokens & components" aria-label="Search documentation" aria-autocomplete="list" aria-controls="docs-search-results" autocomplete="off" />
+          <input type="search" class="docs-search-input" placeholder="Search tokens & patterns" aria-label="Search documentation" aria-autocomplete="list" aria-controls="docs-search-results" autocomplete="off" />
           <ul id="docs-search-results" class="docs-search-results" role="listbox" hidden></ul>
         </div>
 
@@ -101,9 +101,9 @@
             </details>
           </nav>
 
-          <nav class="docs-nav-group" aria-label="Components">
-            <details{% if page.url.indexOf("/components/") == 0 or page.url == "/components/" %} open{% endif %}>
-              <summary class="docs-nav-group-toggle">Components</summary>
+          <nav class="docs-nav-group" aria-label="Patterns">
+            <details{% if page.url.indexOf("/patterns/") == 0 or page.url == "/patterns/" %} open{% endif %}>
+              <summary class="docs-nav-group-toggle">Patterns</summary>
               <ul>
                 {% for entry in collections.componentsDocs %}
                 <li>
@@ -193,8 +193,8 @@
             </ol>
           </nav>
           {% endif %}
-          {% set isComponentsOverview = page.url == "/components/" or page.url == "/components" %}
-          {% set isComponentDoc = page.url and page.url.indexOf("/components/") == 0 and not isPlayground and not isComponentsOverview %}
+          {% set isComponentsOverview = page.url == "/patterns/" or page.url == "/patterns" %}
+          {% set isComponentDoc = page.url and page.url.indexOf("/patterns/") == 0 and not isPlayground and not isComponentsOverview %}
           {% set hasFigmaConnection = figmaConnections and figmaConnections.byName and figmaConnections.byName[page.fileSlug] %}
           {% set figmaComponentUrl = figmaConnections and figmaConnections.urlsByName and figmaConnections.urlsByName[page.fileSlug] %}
           {% set showDraftPrefix = isComponentDoc and not hasFigmaConnection %}

--- a/site/assets/docs.css
+++ b/site/assets/docs.css
@@ -165,11 +165,14 @@ details[open] > .docs-nav-group-toggle::before {
   color: var(--docs-text-0);
 }
 
-.docs-nav-section a[aria-current="page"] {
+.docs-nav-section a[aria-current="page"],
+.docs-nav-group a[aria-current="page"],
+.docs-nav-top a[aria-current="page"] {
   border-color: var(--docs-border-strong);
   background: #fff;
   color: var(--docs-text-0);
   box-shadow: var(--docs-shadow-sm);
+  font-weight: 700;
 }
 
 .docs-main {
@@ -198,18 +201,6 @@ details[open] > .docs-nav-group-toggle::before {
   letter-spacing: -0.015em;
 }
 
-.docs-draft-stamp {
-  display: inline-flex;
-  align-items: center;
-  border: 1px solid rgba(255, 110, 77, 0.35);
-  border-radius: 999px;
-  padding: 3px 11px;
-  font-size: 0.7em;
-  font-weight: 800;
-  line-height: 1.2;
-  background: #fff2ee;
-  color: #b93e26;
-}
 
 .docs-breadcrumb {
   margin: 0 0 14px;

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -681,6 +681,30 @@
     return { element: wrapper, code: codeLines.join("\n") };
   };
 
+  // ─── Divider ──────────────────────────────────
+
+  const renderVanillaDivider = ({ props }) => {
+    const variant = String(props.variant || "default");
+    const orientation = String(props.orientation || "horizontal");
+
+    const element = document.createElement("hr");
+    element.className = "divider";
+    if (variant === "subtle") element.classList.add("subtle");
+    if (orientation === "vertical") {
+      element.setAttribute("aria-orientation", "vertical");
+      element.style.display = "inline-block";
+      element.style.blockSize = "3rem";
+    }
+
+    const classes = ["divider"];
+    if (variant === "subtle") classes.push("subtle");
+    const attrs = [];
+    if (orientation === "vertical") attrs.push('aria-orientation="vertical"');
+    const code = `<hr class="${classes.join(" ")}"${attrs.length ? " " + attrs.join(" ") : ""} />`;
+
+    return { element, code };
+  };
+
   const renderVanillaForm = ({ props }) => {
     const borderless = asBoolean(props.borderless);
     const labelPosition = String(props.labelPosition || "top");
@@ -958,6 +982,7 @@
       button: renderVanillaButton,
       "button-group": renderVanillaButtonGroup,
       checkbox: renderVanillaCheckbox,
+      divider: renderVanillaDivider,
       icon: renderVanillaIcon,
       input: renderVanillaInput,
       label: renderVanillaLabel,

--- a/site/components/accordion-playground.md
+++ b/site/components/accordion-playground.md
@@ -4,7 +4,7 @@ title: Accordion Playground
 description: Interactive preview for the Accordion component.
 navTitle: Accordion Playground
 order: 19
-permalink: /components/accordion-playground/
+permalink: /patterns/accordion-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:

--- a/site/components/accordion-playground.md
+++ b/site/components/accordion-playground.md
@@ -8,10 +8,10 @@ permalink: /patterns/accordion-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:
-  - label: Components
-    url: /components/
+  - label: Patterns
+    url: /patterns/
   - label: Accordion
-    url: /components/accordion/
+    url: /patterns/accordion/
   - label: Playground
 playground:
   id: accordion-playground

--- a/site/components/accordion.md
+++ b/site/components/accordion.md
@@ -38,7 +38,6 @@ playgroundLabel: Open Accordion Playground
     </div>
   </div>
   <div class="docs-hero-meta">
-    <span class="docs-status" data-status="draft">Draft</span>
     {% if playgroundUrl %}
     <a class="docs-page-link docs-page-link--playground" href="{{ playgroundUrl }}">{{ playgroundLabel or "Open Playground" }}</a>
     {% endif %}

--- a/site/components/accordion.md
+++ b/site/components/accordion.md
@@ -4,8 +4,8 @@ title: Accordion
 description: Expandable/collapsible content sections using native details/summary elements. Keyboard accessible by default.
 navTitle: Accordion
 order: 19
-permalink: /components/accordion/
-playgroundUrl: /components/accordion-playground/
+permalink: /patterns/accordion/
+playgroundUrl: /patterns/accordion-playground/
 playgroundLabel: Open Accordion Playground
 ---
 {% import "macros/ui.njk" as ui %}

--- a/site/components/avatar-playground.md
+++ b/site/components/avatar-playground.md
@@ -8,10 +8,10 @@ permalink: /patterns/avatar-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:
-  - label: Components
-    url: /components/
+  - label: Patterns
+    url: /patterns/
   - label: Avatar
-    url: /components/avatar/
+    url: /patterns/avatar/
   - label: Playground
 playground:
   id: avatar-playground

--- a/site/components/avatar-playground.md
+++ b/site/components/avatar-playground.md
@@ -4,7 +4,7 @@ title: Avatar Playground
 description: Interactive preview for the Avatar component.
 navTitle: Avatar Playground
 order: 18
-permalink: /components/avatar-playground/
+permalink: /patterns/avatar-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:

--- a/site/components/avatar.md
+++ b/site/components/avatar.md
@@ -4,8 +4,8 @@ title: Avatar
 description: Thumbnail representation of a user or entity. Supports images and initials fallback with multiple sizes.
 navTitle: Avatar
 order: 18
-permalink: /components/avatar/
-playgroundUrl: /components/avatar-playground/
+permalink: /patterns/avatar/
+playgroundUrl: /patterns/avatar-playground/
 playgroundLabel: Open Avatar Playground
 ---
 {% import "macros/ui.njk" as ui %}

--- a/site/components/avatar.md
+++ b/site/components/avatar.md
@@ -32,7 +32,6 @@ playgroundLabel: Open Avatar Playground
     </div>
   </div>
   <div class="docs-hero-meta">
-    <span class="docs-status" data-status="draft">Draft</span>
     {% if playgroundUrl %}
     <a class="docs-page-link docs-page-link--playground" href="{{ playgroundUrl }}">{{ playgroundLabel or "Open Playground" }}</a>
     {% endif %}

--- a/site/components/badge-playground.md
+++ b/site/components/badge-playground.md
@@ -8,10 +8,10 @@ permalink: /patterns/badge-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:
-  - label: Components
-    url: /components/
+  - label: Patterns
+    url: /patterns/
   - label: Badge
-    url: /components/badge/
+    url: /patterns/badge/
   - label: Playground
 playground:
   id: badge-playground

--- a/site/components/badge-playground.md
+++ b/site/components/badge-playground.md
@@ -4,7 +4,7 @@ title: Badge Playground
 description: Interactive vanilla preview for the Badge component.
 navTitle: Badge Playground
 order: 16
-permalink: /components/badge-playground/
+permalink: /patterns/badge-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:

--- a/site/components/badge.md
+++ b/site/components/badge.md
@@ -4,8 +4,8 @@ title: Badge
 description: Badges are small pill-shaped labels for status, counts, or highlights. Non-interactive, they adapt across brands and modes.
 navTitle: Badge
 order: 15
-permalink: /components/badge/
-playgroundUrl: /components/badge-playground/
+permalink: /patterns/badge/
+playgroundUrl: /patterns/badge-playground/
 playgroundLabel: Open Badge Playground
 ---
 {% import "macros/ui.njk" as ui %}

--- a/site/components/badge.md
+++ b/site/components/badge.md
@@ -30,7 +30,6 @@ playgroundLabel: Open Badge Playground
     </div>
   </div>
   <div class="docs-hero-meta">
-    <span class="docs-status" data-status="draft">Draft</span>
     {% if playgroundUrl %}
     <a class="docs-page-link docs-page-link--playground" href="{{ playgroundUrl }}">{{ playgroundLabel or "Open Playground" }}</a>
     {% endif %}

--- a/site/components/button-group-playground.md
+++ b/site/components/button-group-playground.md
@@ -8,10 +8,10 @@ permalink: /patterns/button-group-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:
-  - label: Components
-    url: /components/
+  - label: Patterns
+    url: /patterns/
   - label: Button
-    url: /components/button/
+    url: /patterns/button/
   - label: Group Playground
 playground:
   id: button-group-playground

--- a/site/components/button-group-playground.md
+++ b/site/components/button-group-playground.md
@@ -4,7 +4,7 @@ title: Button Group Playground
 description: Interactive grouped button layouts for attached rows and toggle states.
 navTitle: Button Group Playground
 order: 21
-permalink: /components/button-group-playground/
+permalink: /patterns/button-group-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:

--- a/site/components/button-playground.md
+++ b/site/components/button-playground.md
@@ -8,10 +8,10 @@ permalink: /patterns/button-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:
-  - label: Components
-    url: /components/
+  - label: Patterns
+    url: /patterns/
   - label: Button
-    url: /components/button/
+    url: /patterns/button/
   - label: Playground
 playground:
   id: button-playground

--- a/site/components/button-playground.md
+++ b/site/components/button-playground.md
@@ -4,7 +4,7 @@ title: Button Playground
 description: Interactive vanilla example with live button props.
 navTitle: Button Playground
 order: 20
-permalink: /components/button-playground/
+permalink: /patterns/button-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:

--- a/site/components/button.md
+++ b/site/components/button.md
@@ -235,7 +235,7 @@ Use `ButtonGroup` to keep related actions visually and semantically grouped.
   {% endcall %}
 </div>
 
-[Open Button Group Playground](/components/button-group-playground/)
+[Open Button Group Playground](/patterns/button-group-playground/)
 
 <div class="docs-guideline">
   <div class="docs-guideline-item" data-type="do">

--- a/site/components/button.md
+++ b/site/components/button.md
@@ -4,8 +4,8 @@ title: Button
 description: Buttons allow users to perform an action or navigate to another page. They have multiple variants for various needs and are ideal for calling attention to where a user needs to act.
 navTitle: Button
 order: 10
-permalink: /components/button/
-playgroundUrl: /components/button-playground/
+permalink: /patterns/button/
+playgroundUrl: /patterns/button-playground/
 playgroundLabel: Open Button Playground
 ---
 

--- a/site/components/checkbox-playground.md
+++ b/site/components/checkbox-playground.md
@@ -8,10 +8,10 @@ permalink: /patterns/checkbox-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:
-  - label: Components
-    url: /components/
+  - label: Patterns
+    url: /patterns/
   - label: Checkbox
-    url: /components/checkbox/
+    url: /patterns/checkbox/
   - label: Playground
 playground:
   id: checkbox-playground

--- a/site/components/checkbox-playground.md
+++ b/site/components/checkbox-playground.md
@@ -4,7 +4,7 @@ title: Checkbox Playground
 description: Interactive vanilla preview for checkbox states and form behavior.
 navTitle: Checkbox Playground
 order: 46
-permalink: /components/checkbox-playground/
+permalink: /patterns/checkbox-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:

--- a/site/components/checkbox.md
+++ b/site/components/checkbox.md
@@ -4,8 +4,8 @@ title: Checkbox
 description: Checkboxes allow users to select one or more options from a list, or toggle a single binary choice. They support checked, unchecked, and indeterminate states.
 navTitle: Checkbox
 order: 45
-permalink: /components/checkbox/
-playgroundUrl: /components/checkbox-playground/
+permalink: /patterns/checkbox/
+playgroundUrl: /patterns/checkbox-playground/
 playgroundLabel: Open Checkbox Playground
 ---
 

--- a/site/components/divider-playground.md
+++ b/site/components/divider-playground.md
@@ -1,0 +1,43 @@
+---
+layout: layouts/docs.njk
+title: Divider Playground
+description: Interactive vanilla preview for the Divider pattern.
+navTitle: Divider Playground
+order: 17
+permalink: /patterns/divider-playground/
+templateEngineOverride: njk
+isPlayground: true
+breadcrumb:
+  - label: Patterns
+    url: /patterns/
+  - label: Divider
+    url: /patterns/divider/
+  - label: Playground
+playground:
+  id: divider-playground
+  queryPrefix: divider
+  runtime: vanilla
+  renderer: divider
+  tokenCssPath: src/ui/patterns/divider.css
+  controls:
+    - kind: select
+      name: variant
+      label: Variant
+      query: true
+      default: default
+      options:
+        - default
+        - subtle
+    - kind: select
+      name: orientation
+      label: Orientation
+      query: true
+      default: horizontal
+      options:
+        - horizontal
+        - vertical
+---
+
+{% from "macros/playground.njk" import playground as uiPlayground with context %}
+
+{{ uiPlayground(playground) }}

--- a/site/components/divider.md
+++ b/site/components/divider.md
@@ -5,6 +5,8 @@ description: Dividers are visual separators that create clear boundaries between
 navTitle: Divider
 order: 16
 permalink: /patterns/divider/
+playgroundUrl: /patterns/divider-playground/
+playgroundLabel: Open Divider Playground
 ---
 {% import "macros/ui.njk" as ui %}
 

--- a/site/components/divider.md
+++ b/site/components/divider.md
@@ -31,7 +31,6 @@ playgroundLabel: Open Divider Playground
     </div>
   </div>
   <div class="docs-hero-meta">
-    <span class="docs-status" data-status="draft">Draft</span>
     {% if figmaConnections and figmaConnections.urlsByName and figmaConnections.urlsByName[page.fileSlug] %}
     <a class="docs-page-link" href="{{ figmaConnections.urlsByName[page.fileSlug] }}" target="_blank" rel="noopener noreferrer">Open in Figma</a>
     {% endif %}

--- a/site/components/divider.md
+++ b/site/components/divider.md
@@ -31,6 +31,9 @@ playgroundLabel: Open Divider Playground
     </div>
   </div>
   <div class="docs-hero-meta">
+    {% if playgroundUrl %}
+    <a class="docs-page-link docs-page-link--playground" href="{{ playgroundUrl }}">{{ playgroundLabel or "Open Playground" }}</a>
+    {% endif %}
     {% if figmaConnections and figmaConnections.urlsByName and figmaConnections.urlsByName[page.fileSlug] %}
     <a class="docs-page-link" href="{{ figmaConnections.urlsByName[page.fileSlug] }}" target="_blank" rel="noopener noreferrer">Open in Figma</a>
     {% endif %}

--- a/site/components/divider.md
+++ b/site/components/divider.md
@@ -4,7 +4,7 @@ title: Divider
 description: Dividers are visual separators that create clear boundaries between content sections. They use semantic HTML and adapt across brands and modes.
 navTitle: Divider
 order: 16
-permalink: /components/divider/
+permalink: /patterns/divider/
 ---
 {% import "macros/ui.njk" as ui %}
 

--- a/site/components/form-playground.md
+++ b/site/components/form-playground.md
@@ -8,10 +8,10 @@ permalink: /patterns/form-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:
-  - label: Components
-    url: /components/
+  - label: Patterns
+    url: /patterns/
   - label: Form
-    url: /components/form/
+    url: /patterns/form/
   - label: Playground
 playground:
   id: form-playground

--- a/site/components/form-playground.md
+++ b/site/components/form-playground.md
@@ -4,7 +4,7 @@ title: Form Playground
 description: Interactive preview for form layout, grouping, and validation patterns.
 navTitle: Form Playground
 order: 71
-permalink: /components/form-playground/
+permalink: /patterns/form-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:

--- a/site/components/form.md
+++ b/site/components/form.md
@@ -4,8 +4,8 @@ title: Form
 description: Form provides layout structure for grouping fields, labels, helper text, and actions into a cohesive form experience.
 navTitle: Form
 order: 70
-permalink: /components/form/
-playgroundUrl: /components/form-playground/
+permalink: /patterns/form/
+playgroundUrl: /patterns/form-playground/
 playgroundLabel: Open Form Playground
 ---
 

--- a/site/components/icon-playground.md
+++ b/site/components/icon-playground.md
@@ -8,10 +8,10 @@ permalink: /patterns/icon-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:
-  - label: Components
-    url: /components/
+  - label: Patterns
+    url: /patterns/
   - label: Icon
-    url: /components/icon/
+    url: /patterns/icon/
   - label: Playground
 playground:
   id: icon-playground

--- a/site/components/icon-playground.md
+++ b/site/components/icon-playground.md
@@ -4,7 +4,7 @@ title: Icon Playground
 description: Interactive vanilla preview for decorative and accessible icon usage.
 navTitle: Icon Playground
 order: 21
-permalink: /components/icon-playground/
+permalink: /patterns/icon-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:

--- a/site/components/icon.md
+++ b/site/components/icon.md
@@ -4,8 +4,8 @@ title: Icon
 description: Icons communicate meaning through simple, recognizable symbols. They reinforce labels, indicate actions, and provide visual cues that reduce cognitive load.
 navTitle: Icon
 order: 20
-permalink: /components/icon/
-playgroundUrl: /components/icon-playground/
+permalink: /patterns/icon/
+playgroundUrl: /patterns/icon-playground/
 playgroundLabel: Open Icon Playground
 ---
 {% import "macros/ui.njk" as ui %}

--- a/site/components/index.md
+++ b/site/components/index.md
@@ -1,10 +1,10 @@
 ---
 layout: layouts/docs.njk
-title: Components
-description: Interactive building blocks of the design system.
+title: Patterns
+description: CSS-only building blocks of the design system.
 navTitle: Overview
 order: 1
-permalink: /components/
+permalink: /patterns/
 ---
 
 {% import "macros/ui.njk" as ui %}

--- a/site/components/index.md
+++ b/site/components/index.md
@@ -23,7 +23,7 @@ permalink: /patterns/
   </div>
   <div class="docs-hero-preview-stage">
     <div class="docs-component-grid">
-  <a class="docs-component-card" href="/components/button/">
+  <a class="docs-component-card" href="/patterns/button/">
     <div class="docs-component-card-preview">
       {{ ui.button("Action") }}
       {{ ui.button("Secondary", "outline") }}
@@ -33,7 +33,7 @@ permalink: /patterns/
       <p>Solid, outline, and ghost variants for primary, secondary, and tertiary actions.</p>
     </div>
   </a>
-  <a class="docs-component-card" href="/components/icon/">
+  <a class="docs-component-card" href="/patterns/icon/">
     <div class="docs-component-card-preview">
       <span class="icon" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
       <span class="icon" style="--icon-src: url('/assets/icons/star.svg');" aria-hidden="true"></span>
@@ -45,7 +45,7 @@ permalink: /patterns/
       <p>SVG icons via CSS mask, inheriting color and size from the parent.</p>
     </div>
   </a>
-  <a class="docs-component-card" href="/components/badge/">
+  <a class="docs-component-card" href="/patterns/badge/">
     <div class="docs-component-card-preview">
       {{ ui.badge("Default") }}
       {{ ui.badge("Brand", variant="brand") }}
@@ -56,7 +56,7 @@ permalink: /patterns/
       <p>Pill-shaped labels for status, counts, or highlights.</p>
     </div>
   </a>
-  <a class="docs-component-card" href="/components/label/">
+  <a class="docs-component-card" href="/patterns/label/">
     <div class="docs-component-card-preview">
       <span class="label-content">
         <span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
@@ -68,7 +68,7 @@ permalink: /patterns/
       <p>Text and icon primitives for components and form fields.</p>
     </div>
   </a>
-  <a class="docs-component-card" href="/components/input/">
+  <a class="docs-component-card" href="/patterns/input/">
     <div class="docs-component-card-preview">
       {{ ui.input(type="text", placeholder="Email address") }}
     </div>
@@ -77,7 +77,7 @@ permalink: /patterns/
       <p>Text input with token-driven states for data entry.</p>
     </div>
   </a>
-  <a class="docs-component-card" href="/components/checkbox/">
+  <a class="docs-component-card" href="/patterns/checkbox/">
     <div class="docs-component-card-preview">
       {{ ui.checkbox("Option A", true) }}
       {{ ui.checkbox("Option B") }}
@@ -87,7 +87,7 @@ permalink: /patterns/
       <p>Binary selection with checked, unchecked, and indeterminate states.</p>
     </div>
   </a>
-  <a class="docs-component-card" href="/components/radio/">
+  <a class="docs-component-card" href="/patterns/radio/">
     <div class="docs-component-card-preview">
       {{ ui.radio("Option A", true, false, "default", "", "", "", "ov-radio", "a") }}
       {{ ui.radio("Option B", false, false, "default", "", "", "", "ov-radio", "b") }}
@@ -97,7 +97,7 @@ permalink: /patterns/
       <p>Mutually exclusive choices within a group.</p>
     </div>
   </a>
-  <a class="docs-component-card" href="/components/switch/">
+  <a class="docs-component-card" href="/patterns/switch/">
     <div class="docs-component-card-preview">
       {{ ui.switch("Notifications", true) }}
     </div>
@@ -106,7 +106,7 @@ permalink: /patterns/
       <p>Binary toggle for immediate on/off settings.</p>
     </div>
   </a>
-  <a class="docs-component-card" href="/components/link/">
+  <a class="docs-component-card" href="/patterns/link/">
     <div class="docs-component-card-preview">
       <span class="link">Learn more</span>
     </div>
@@ -115,7 +115,7 @@ permalink: /patterns/
       <p>Inline and standalone navigation with token-driven states.</p>
     </div>
   </a>
-  <a class="docs-component-card" href="/components/select/">
+  <a class="docs-component-card" href="/patterns/select/">
     <div class="docs-component-card-preview">
       {{ ui.select(options=[{value: "opt1", label: "Option 1"}, {value: "opt2", label: "Option 2"}], placeholder="Choose an option") }}
     </div>

--- a/site/components/input-playground.md
+++ b/site/components/input-playground.md
@@ -4,7 +4,7 @@ title: Input Playground
 description: Interactive vanilla preview for input states and field properties.
 navTitle: Input Playground
 order: 41
-permalink: /components/input-playground/
+permalink: /patterns/input-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:

--- a/site/components/input-playground.md
+++ b/site/components/input-playground.md
@@ -8,10 +8,10 @@ permalink: /patterns/input-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:
-  - label: Components
-    url: /components/
+  - label: Patterns
+    url: /patterns/
   - label: Input
-    url: /components/input/
+    url: /patterns/input/
   - label: Playground
 playground:
   id: input-playground

--- a/site/components/input.md
+++ b/site/components/input.md
@@ -4,8 +4,8 @@ title: Input
 description: Text inputs allow users to enter freeform text. They support multiple types, placeholder text, and validation states for structured data entry.
 navTitle: Input
 order: 40
-permalink: /components/input/
-playgroundUrl: /components/input-playground/
+permalink: /patterns/input/
+playgroundUrl: /patterns/input-playground/
 playgroundLabel: Open Input Playground
 ---
 

--- a/site/components/label-playground.md
+++ b/site/components/label-playground.md
@@ -8,10 +8,10 @@ permalink: /patterns/label-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:
-  - label: Components
-    url: /components/
+  - label: Patterns
+    url: /patterns/
   - label: Label
-    url: /components/label/
+    url: /patterns/label/
   - label: Playground
 playground:
   id: label-playground

--- a/site/components/label-playground.md
+++ b/site/components/label-playground.md
@@ -4,7 +4,7 @@ title: Label Playground
 description: Interactive vanilla preview for LabelContent and FieldLabel patterns.
 navTitle: Label Playground
 order: 31
-permalink: /components/label-playground/
+permalink: /patterns/label-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:

--- a/site/components/label.md
+++ b/site/components/label.md
@@ -4,8 +4,8 @@ title: Label
 description: Text and icon label primitives for components and form fields.
 navTitle: Label
 order: 30
-permalink: /components/label/
-playgroundUrl: /components/label-playground/
+permalink: /patterns/label/
+playgroundUrl: /patterns/label-playground/
 playgroundLabel: Open Label Playground
 ---
 {% import "macros/ui.njk" as ui %}

--- a/site/components/link-playground.md
+++ b/site/components/link-playground.md
@@ -8,10 +8,10 @@ permalink: /patterns/link-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:
-  - label: Components
-    url: /components/
+  - label: Patterns
+    url: /patterns/
   - label: Link
-    url: /components/link/
+    url: /patterns/link/
   - label: Playground
 playground:
   id: link-playground

--- a/site/components/link-playground.md
+++ b/site/components/link-playground.md
@@ -4,7 +4,7 @@ title: Link Playground
 description: Interactive vanilla preview for the Link component.
 navTitle: Link Playground
 order: 61
-permalink: /components/link-playground/
+permalink: /patterns/link-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:

--- a/site/components/link.md
+++ b/site/components/link.md
@@ -10,7 +10,7 @@ playgroundLabel: Open Link Playground
 templateEngineOverride: njk
 breadcrumb:
   - label: Components
-    url: /components/
+    url: /patterns/
   - label: Link
 ---
 

--- a/site/components/link.md
+++ b/site/components/link.md
@@ -4,8 +4,8 @@ title: Link
 description: Inline navigation element for text-level links with optional icon slots, visited state, and accessible disabled handling.
 navTitle: Link
 order: 60
-permalink: /components/link/
-playgroundUrl: /components/link-playground/
+permalink: /patterns/link/
+playgroundUrl: /patterns/link-playground/
 playgroundLabel: Open Link Playground
 templateEngineOverride: njk
 breadcrumb:

--- a/site/components/radio-playground.md
+++ b/site/components/radio-playground.md
@@ -4,7 +4,7 @@ title: Radio Playground
 description: Interactive vanilla preview for radio states and form behavior.
 navTitle: Radio Playground
 order: 56
-permalink: /components/radio-playground/
+permalink: /patterns/radio-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:

--- a/site/components/radio-playground.md
+++ b/site/components/radio-playground.md
@@ -8,10 +8,10 @@ permalink: /patterns/radio-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:
-  - label: Components
-    url: /components/
+  - label: Patterns
+    url: /patterns/
   - label: Radio
-    url: /components/radio/
+    url: /patterns/radio/
   - label: Playground
 playground:
   id: radio-playground

--- a/site/components/radio.md
+++ b/site/components/radio.md
@@ -4,8 +4,8 @@ title: Radio
 description: Selection control for mutually exclusive choices within a group.
 navTitle: Radio
 order: 55
-permalink: /components/radio/
-playgroundUrl: /components/radio-playground/
+permalink: /patterns/radio/
+playgroundUrl: /patterns/radio-playground/
 playgroundLabel: Open Radio Playground
 ---
 

--- a/site/components/select-playground.md
+++ b/site/components/select-playground.md
@@ -4,7 +4,7 @@ title: Select Playground
 description: Interactive vanilla preview for select states and field properties.
 navTitle: Select Playground
 order: 46
-permalink: /components/select-playground/
+permalink: /patterns/select-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:

--- a/site/components/select-playground.md
+++ b/site/components/select-playground.md
@@ -8,10 +8,10 @@ permalink: /patterns/select-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:
-  - label: Components
-    url: /components/
+  - label: Patterns
+    url: /patterns/
   - label: Select
-    url: /components/select/
+    url: /patterns/select/
   - label: Playground
 playground:
   id: select-playground

--- a/site/components/select.md
+++ b/site/components/select.md
@@ -4,8 +4,8 @@ title: Select
 description: Dropdown selection component for choosing a single option from a list. Supports placeholder text, option groups, disabled states, and keyboard navigation.
 navTitle: Select
 order: 45
-permalink: /components/select/
-playgroundUrl: /components/select-playground/
+permalink: /patterns/select/
+playgroundUrl: /patterns/select-playground/
 playgroundLabel: Open Select Playground
 ---
 

--- a/site/components/switch-playground.md
+++ b/site/components/switch-playground.md
@@ -4,7 +4,7 @@ title: Switch Playground
 description: Interactive vanilla preview for switch states and checked behavior.
 navTitle: Switch Playground
 order: 48
-permalink: /components/switch-playground/
+permalink: /patterns/switch-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:

--- a/site/components/switch-playground.md
+++ b/site/components/switch-playground.md
@@ -8,10 +8,10 @@ permalink: /patterns/switch-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:
-  - label: Components
-    url: /components/
+  - label: Patterns
+    url: /patterns/
   - label: Switch
-    url: /components/switch/
+    url: /patterns/switch/
   - label: Playground
 playground:
   id: switch-playground

--- a/site/components/switch.md
+++ b/site/components/switch.md
@@ -29,7 +29,6 @@ playgroundLabel: Open Switch Playground
     </div>
   </div>
   <div class="docs-hero-meta">
-    <span class="docs-status" data-status="draft">Draft</span>
     {% if playgroundUrl %}
     <a class="docs-page-link docs-page-link--playground" href="{{ playgroundUrl }}">{{ playgroundLabel or "Open Playground" }}</a>
     {% endif %}

--- a/site/components/switch.md
+++ b/site/components/switch.md
@@ -4,8 +4,8 @@ title: Switch
 description: Switches toggle a single setting on or off with immediate effect. Use them for binary choices that take effect without a submit action.
 navTitle: Switch
 order: 47
-permalink: /components/switch/
-playgroundUrl: /components/switch-playground/
+permalink: /patterns/switch/
+playgroundUrl: /patterns/switch-playground/
 playgroundLabel: Open Switch Playground
 ---
 

--- a/site/components/tabs-playground.md
+++ b/site/components/tabs-playground.md
@@ -8,10 +8,10 @@ permalink: /patterns/tabs-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:
-  - label: Components
-    url: /components/
+  - label: Patterns
+    url: /patterns/
   - label: Tabs
-    url: /components/tabs/
+    url: /patterns/tabs/
   - label: Playground
 playground:
   id: tabs-playground

--- a/site/components/tabs-playground.md
+++ b/site/components/tabs-playground.md
@@ -4,7 +4,7 @@ title: Tabs Playground
 description: Interactive preview for the Tabs component.
 navTitle: Tabs Playground
 order: 20
-permalink: /components/tabs-playground/
+permalink: /patterns/tabs-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:

--- a/site/components/tabs.md
+++ b/site/components/tabs.md
@@ -35,7 +35,6 @@ playgroundLabel: Open Tabs Playground
     </div>
   </div>
   <div class="docs-hero-meta">
-    <span class="docs-status" data-status="draft">Draft</span>
     {% if playgroundUrl %}
     <a class="docs-page-link docs-page-link--playground" href="{{ playgroundUrl }}">{{ playgroundLabel or "Open Playground" }}</a>
     {% endif %}

--- a/site/components/tabs.md
+++ b/site/components/tabs.md
@@ -4,8 +4,8 @@ title: Tabs
 description: Tabbed navigation for switching between related content panels. Keyboard accessible with ARIA tablist pattern.
 navTitle: Tabs
 order: 20
-permalink: /components/tabs/
-playgroundUrl: /components/tabs-playground/
+permalink: /patterns/tabs/
+playgroundUrl: /patterns/tabs-playground/
 playgroundLabel: Open Tabs Playground
 ---
 {% import "macros/ui.njk" as ui %}

--- a/site/components/textarea-playground.md
+++ b/site/components/textarea-playground.md
@@ -4,7 +4,7 @@ title: TextArea Playground
 description: Interactive preview for the TextArea component.
 navTitle: TextArea Playground
 order: 17
-permalink: /components/textarea-playground/
+permalink: /patterns/textarea-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:

--- a/site/components/textarea-playground.md
+++ b/site/components/textarea-playground.md
@@ -8,10 +8,10 @@ permalink: /patterns/textarea-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:
-  - label: Components
-    url: /components/
+  - label: Patterns
+    url: /patterns/
   - label: TextArea
-    url: /components/textarea/
+    url: /patterns/textarea/
   - label: Playground
 playground:
   id: textarea-playground

--- a/site/components/textarea.md
+++ b/site/components/textarea.md
@@ -4,8 +4,8 @@ title: TextArea
 description: Multi-line text input for longer form content. Uses native textarea element with token-based styling.
 navTitle: TextArea
 order: 17
-permalink: /components/textarea/
-playgroundUrl: /components/textarea-playground/
+permalink: /patterns/textarea/
+playgroundUrl: /patterns/textarea-playground/
 playgroundLabel: Open TextArea Playground
 ---
 {% import "macros/ui.njk" as ui %}

--- a/site/components/textarea.md
+++ b/site/components/textarea.md
@@ -28,7 +28,6 @@ playgroundLabel: Open TextArea Playground
     </div>
   </div>
   <div class="docs-hero-meta">
-    <span class="docs-status" data-status="draft">Draft</span>
     {% if playgroundUrl %}
     <a class="docs-page-link docs-page-link--playground" href="{{ playgroundUrl }}">{{ playgroundLabel or "Open Playground" }}</a>
     {% endif %}

--- a/site/components/tooltip-playground.md
+++ b/site/components/tooltip-playground.md
@@ -8,10 +8,10 @@ permalink: /patterns/tooltip-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:
-  - label: Components
-    url: /components/
+  - label: Patterns
+    url: /patterns/
   - label: Tooltip
-    url: /components/tooltip/
+    url: /patterns/tooltip/
   - label: Playground
 playground:
   id: tooltip-playground

--- a/site/components/tooltip-playground.md
+++ b/site/components/tooltip-playground.md
@@ -4,7 +4,7 @@ title: Tooltip Playground
 description: Interactive preview for the Tooltip component.
 navTitle: Tooltip Playground
 order: 21
-permalink: /components/tooltip-playground/
+permalink: /patterns/tooltip-playground/
 templateEngineOverride: njk
 isPlayground: true
 breadcrumb:

--- a/site/components/tooltip.md
+++ b/site/components/tooltip.md
@@ -30,7 +30,6 @@ playgroundLabel: Open Tooltip Playground
     </div>
   </div>
   <div class="docs-hero-meta">
-    <span class="docs-status" data-status="draft">Draft</span>
     {% if playgroundUrl %}
     <a class="docs-page-link docs-page-link--playground" href="{{ playgroundUrl }}">{{ playgroundLabel or "Open Playground" }}</a>
     {% endif %}

--- a/site/components/tooltip.md
+++ b/site/components/tooltip.md
@@ -4,8 +4,8 @@ title: Tooltip
 description: Contextual help text that appears on hover or focus. Non-interactive, positioned relative to a trigger element.
 navTitle: Tooltip
 order: 21
-permalink: /components/tooltip/
-playgroundUrl: /components/tooltip-playground/
+permalink: /patterns/tooltip/
+playgroundUrl: /patterns/tooltip-playground/
 playgroundLabel: Open Tooltip Playground
 ---
 {% import "macros/ui.njk" as ui %}

--- a/site/examples/index.md
+++ b/site/examples/index.md
@@ -44,8 +44,8 @@ Every new component needs all 10 surfaces:
 4. React export — `src/react/index.js`
 5. Nunjucks macro — `site/_includes/macros/ui.njk`
 6. Playground renderer — `site/assets/playground/renderers.js`
-7. Playground page — `site/components/<component>-playground.md`
-8. Docs page — `site/components/<component>.md`
+7. Playground page — `site/patterns/<component>-playground.md`
+8. Docs page — `site/patterns/<component>.md`
 9. Code Connect — `schemas/web-<component>.figma.ts`
 10. Code generator — `site/assets/playground/code-generators.js`
 

--- a/site/foundations/all-tokens.md
+++ b/site/foundations/all-tokens.md
@@ -4,8 +4,9 @@ title: All Tokens
 description: Tabular overview of all tokens from the central YAML export.
 navTitle: All Tokens
 order: 12
-permalink: /foundations/all-tokens/
+permalink: /foundations/design-tokens/all/
 templateEngineOverride: njk
+excludeFromNav: true
 ---
 
 {% if tokensTable.rows and tokensTable.rows.length %}

--- a/site/foundations/design-tokens.md
+++ b/site/foundations/design-tokens.md
@@ -71,3 +71,7 @@ active token values without changing component markup.
 - Never mix token layers in a single declaration.
 - Never hardcode hex, rgb, or hsl values in component CSS.
 - Always use `var(--...)` for every visual property.
+
+## Reference
+
+- [All Tokens](/foundations/design-tokens/all/) — complete tabular index of all generated tokens

--- a/site/index.md
+++ b/site/index.md
@@ -57,7 +57,7 @@ permalink: /
       <h2>Tokens</h2>
       <p>Colors, typography, spacing, and other visual foundations.</p>
     </a>
-    <a class="docs-card" href="/components/">
+    <a class="docs-card" href="/patterns/">
       <h2>Components</h2>
       <p>Interactive components with API docs, playgrounds, and usage guidelines.</p>
     </a>

--- a/site/primitives/color-tokens.md
+++ b/site/primitives/color-tokens.md
@@ -4,7 +4,7 @@ title: Color Tokens
 description: Brand, neutral, and overlay tokens including mode and brand switching.
 navTitle: Color
 order: 10
-permalink: /foundations/color/
+permalink: /primitives/color/
 ---
 
 {% import "macros/ui.njk" as ui %}

--- a/site/primitives/index.md
+++ b/site/primitives/index.md
@@ -1,0 +1,13 @@
+---
+layout: layouts/docs.njk
+title: Primitives
+description: Core token values that define the visual language — colors, typography, spacing.
+navTitle: Overview
+order: 1
+permalink: /primitives/
+---
+
+Primitives are the raw building blocks of the design system. They define the concrete values that everything else references.
+
+- [Color Tokens](/primitives/color/) — palettes, modes, semantic color aliases
+- [Typography Tokens](/primitives/typography/) — font families, sizes, weights, line heights

--- a/site/primitives/typography-tokens.md
+++ b/site/primitives/typography-tokens.md
@@ -4,7 +4,7 @@ title: Typography Tokens
 description: Display of heading and text scales including token values.
 navTitle: Typography
 order: 11
-permalink: /foundations/typography/
+permalink: /primitives/typography/
 ---
 
 <section class="typography">

--- a/site/robots.njk
+++ b/site/robots.njk
@@ -5,7 +5,7 @@ eleventyExcludeFromCollections: true
 User-agent: *
 Allow: /
 Disallow: /assets/
-Disallow: /components/*-playground/
+Disallow: /patterns/*-playground/
 {% if site.baseUrl %}
 Sitemap: {{ site.baseUrl }}/sitemap.xml
 {% endif %}

--- a/tests/docs-search.test.mjs
+++ b/tests/docs-search.test.mjs
@@ -12,7 +12,7 @@ const { filterIndex, navigateIndex } = require("../site/assets/search-utils.js")
 
 test("filterIndex: empty query returns empty array", () => {
   const index = [
-    { title: "Button", description: "Primary action", url: "/button/", type: "component" },
+    { title: "Button", description: "Primary action", url: "/button/", type: "pattern" },
   ];
   assert.deepEqual(filterIndex("", index), []);
 });
@@ -27,17 +27,17 @@ test("filterIndex: whitespace-only query returns empty array", () => {
 
 test("filterIndex: no-match query returns empty array", () => {
   const index = [
-    { title: "Button", description: "Primary action", url: "/button/", type: "component" },
-    { title: "Input", description: "Text field", url: "/input/", type: "component" },
+    { title: "Button", description: "Primary action", url: "/button/", type: "pattern" },
+    { title: "Input", description: "Text field", url: "/input/", type: "pattern" },
   ];
   assert.deepEqual(filterIndex("zzzzz", index), []);
 });
 
 test("filterIndex: matches on title (case-insensitive)", () => {
   const index = [
-    { title: "Button", description: "Primary action", url: "/button/", type: "component" },
-    { title: "Input", description: "Text field", url: "/input/", type: "component" },
-    { title: "Badge", description: "Status pill", url: "/badge/", type: "component" },
+    { title: "Button", description: "Primary action", url: "/button/", type: "pattern" },
+    { title: "Input", description: "Text field", url: "/input/", type: "pattern" },
+    { title: "Badge", description: "Status pill", url: "/badge/", type: "pattern" },
   ];
   const results = filterIndex("but", index);
   assert.equal(results.length, 1);
@@ -46,8 +46,8 @@ test("filterIndex: matches on title (case-insensitive)", () => {
 
 test("filterIndex: matches on description (case-insensitive)", () => {
   const index = [
-    { title: "Button", description: "Primary action", url: "/button/", type: "component" },
-    { title: "Input", description: "Text field", url: "/input/", type: "component" },
+    { title: "Button", description: "Primary action", url: "/button/", type: "pattern" },
+    { title: "Input", description: "Text field", url: "/input/", type: "pattern" },
   ];
   const results = filterIndex("TEXT", index);
   assert.equal(results.length, 1);
@@ -57,21 +57,21 @@ test("filterIndex: matches on description (case-insensitive)", () => {
 test("filterIndex: returns multiple matches", () => {
   const index = [
     { title: "Color tokens", description: "All colors", url: "/color/", type: "token" },
-    { title: "Button", description: "Colorful action", url: "/button/", type: "component" },
-    { title: "Icon", description: "SVG icons", url: "/icon/", type: "component" },
+    { title: "Button", description: "Colorful action", url: "/button/", type: "pattern" },
+    { title: "Icon", description: "SVG icons", url: "/icon/", type: "pattern" },
   ];
   const results = filterIndex("color", index);
   assert.equal(results.length, 2);
 });
 
 test("filterIndex: preserves entry structure", () => {
-  const entry = { title: "Tabs", description: "Tab navigation", url: "/tabs/", type: "component" };
+  const entry = { title: "Tabs", description: "Tab navigation", url: "/tabs/", type: "pattern" };
   const results = filterIndex("tab", [entry]);
   assert.equal(results.length, 1);
   assert.equal(results[0].title, "Tabs");
   assert.equal(results[0].description, "Tab navigation");
   assert.equal(results[0].url, "/tabs/");
-  assert.equal(results[0].type, "component");
+  assert.equal(results[0].type, "pattern");
 });
 
 test("navigateIndex: ArrowDown increments (clamped at end)", () => {
@@ -120,9 +120,9 @@ test("search index collection: includes foundation pages with title", () => {
 
 test("search index collection: excludes playground pages", () => {
   const pages = [
-    { data: { title: "Button", isPlayground: false }, url: "/components/button/" },
-    { data: { title: "Button Playground", isPlayground: true }, url: "/components/button-playground/" },
-    { data: { title: "Checkbox", isPlayground: undefined }, url: "/components/checkbox/" },
+    { data: { title: "Button", isPlayground: false }, url: "/patterns/button/" },
+    { data: { title: "Button Playground", isPlayground: true }, url: "/patterns/button-playground/" },
+    { data: { title: "Checkbox", isPlayground: undefined }, url: "/patterns/checkbox/" },
   ];
 
   const entries = pages
@@ -131,7 +131,7 @@ test("search index collection: excludes playground pages", () => {
       title: p.data.title,
       description: p.data.description || "",
       url: p.url,
-      type: "component",
+      type: "pattern",
     }));
 
   assert.equal(entries.length, 2);
@@ -147,7 +147,7 @@ const searchEntryArb = fc.record({
   title: fc.string({ minLength: 1, maxLength: 50 }),
   description: fc.string({ maxLength: 100 }),
   url: fc.webUrl(),
-  type: fc.constantFrom("token", "component"),
+  type: fc.constantFrom("token", "pattern"),
 });
 
 test("PBT Property 3: filterIndex returns only case-insensitive substring matches", () => {


### PR DESCRIPTION
Introduces clear terminology:

**Patterns** — CSS-only, stateless building blocks (Button, Input, Badge, Form, etc.)
Located in `src/ui/patterns/`. No JS required.

**Components** — functional units with state and interactivity (Calendar, DatePicker, etc.)
Will live in `src/components/`. Require JavaScript. Not yet implemented.

### Changes
- README: separate Patterns and Components (coming next) sections
- Steering: updated pattern list, promotion workflow, added comparison table
- Roadmap: Calendar as first component, Web Components for pattern layer

No code changes — terminology/docs only.