### PR TITLE
feat(docs): redesign color & typography pages, Brand A B&W theme

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -64,7 +64,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addCollection("foundationsDocs", (collectionApi) => {
     return collectionApi
       .getFilteredByGlob("site/foundations/**/*.md")
-      .filter((entry) => entry.data.permalink !== "/foundations/" && !entry.data.excludeFromNav)
+      .filter((entry) => entry.data.permalink !== "/foundations/" && entry.data.permalink !== "/foundations/design-tokens/" && !entry.data.excludeFromNav)
       .sort((a, b) => {
         const aOrder = Number(a.data.order || 999);
         const bOrder = Number(b.data.order || 999);

--- a/figma/exports/Themes (Brands).tokens.json
+++ b/figma/exports/Themes (Brands).tokens.json
@@ -63,7 +63,7 @@
                 "$ref": "Color/Brand B/Red/600"
               },
               "Brand A": {
-                "$ref": "Color/Neutral/700"
+                "$ref": "Color/Neutral/900"
               }
             }
           }

--- a/figma/exports/Themes (Brands).tokens.json
+++ b/figma/exports/Themes (Brands).tokens.json
@@ -30,7 +30,7 @@
                 "$ref": "Color/Brand B/Green/600"
               },
               "Brand A": {
-                "$ref": "Color/Brand A/Green/600"
+                "$ref": "Color/Neutral/800"
               }
             }
           }
@@ -63,7 +63,7 @@
                 "$ref": "Color/Brand B/Red/600"
               },
               "Brand A": {
-                "$ref": "Color/Brand A/Red/600"
+                "$ref": "Color/Neutral/700"
               }
             }
           }
@@ -96,7 +96,7 @@
                 "$ref": "Color/Brand B/Purple/700"
               },
               "Brand A": {
-                "$ref": "Color/Brand A/Green/700"
+                "$ref": "Color/Neutral/900"
               }
             }
           }
@@ -129,7 +129,7 @@
                 "$ref": "Color/Brand B/Purple/900"
               },
               "Brand A": {
-                "$ref": "Color/Brand A/Green/900"
+                "$ref": "Color/Neutral/1000"
               }
             }
           }
@@ -163,7 +163,7 @@
               "$ref": "Color/Brand B/Purple/600"
             },
             "Brand A": {
-              "$ref": "Color/Brand A/Sand/700"
+              "$ref": "Color/Neutral/1000"
             }
           }
         }
@@ -196,7 +196,7 @@
               "$ref": "Color/Brand B/Green/400"
             },
             "Brand A": {
-              "$ref": "Color/Brand A/Green/400"
+              "$ref": "Color/Neutral/600"
             }
           }
         }
@@ -229,7 +229,7 @@
               "$ref": "Color/Brand B/Purple/800"
             },
             "Brand A": {
-              "$ref": "Color/Brand A/Sand/900"
+              "$ref": "Color/Neutral/1000"
             }
           }
         }
@@ -262,7 +262,7 @@
               "$ref": "Color/Brand B/Green/800"
             },
             "Brand A": {
-              "$ref": "Color/Brand A/Green/600"
+              "$ref": "Color/Neutral/800"
             }
           }
         }

--- a/site/_data/colorDocs.js
+++ b/site/_data/colorDocs.js
@@ -10,95 +10,215 @@ function normalizeTokens(tokens) {
       cssVar: String(token.cssVar),
       name: String(token.name || token.cssVar.replace(/^--/, "")),
       value: token.value ?? "",
+      type: String(token.type || ""),
+      path: String(token.path || ""),
       scopeBucket: String(token.scopeBucket || ""),
       scopeId: String(token.scopeId || ""),
     }));
 }
 
-function sortByName(tokens) {
-  return [...tokens].sort((a, b) =>
-    a.name.localeCompare(b.name, undefined, { numeric: true }),
+/**
+ * Extract hex from an rgb(...) or direct hex value string.
+ */
+function extractHex(value) {
+  if (!value) return "";
+  const str = String(value).trim();
+  if (str.startsWith("#")) return str.toUpperCase();
+  const rgbMatch = str.match(
+    /rgb\(\s*(\d+)\s+(\d+)\s+(\d+)\s*(?:\/\s*[\d.]+)?\s*\)/,
   );
+  if (rgbMatch) {
+    const r = parseInt(rgbMatch[1], 10);
+    const g = parseInt(rgbMatch[2], 10);
+    const b = parseInt(rgbMatch[3], 10);
+    return (
+      "#" +
+      [r, g, b].map((c) => c.toString(16).padStart(2, "0")).join("").toUpperCase()
+    );
+  }
+  return str;
 }
 
-function pickByScope(tokens, bucket, id) {
-  return tokens.filter(
-    (token) => token.scopeBucket === bucket && token.scopeId === id,
-  );
+/**
+ * Compute relative luminance from hex color.
+ */
+function luminance(hex) {
+  const h = hex.replace("#", "");
+  const r = parseInt(h.slice(0, 2), 16) / 255;
+  const g = parseInt(h.slice(2, 4), 16) / 255;
+  const b = parseInt(h.slice(4, 6), 16) / 255;
+  const toLinear = (c) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+  return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
 }
 
-function pickByPrefixes(tokens, prefixes) {
-  return tokens.filter((token) =>
-    prefixes.some((prefix) => token.cssVar.startsWith(prefix)),
+/**
+ * Contrast ratio against white (#FFFFFF).
+ */
+function contrastVsWhite(hex) {
+  if (!hex || hex.length < 7) return "";
+  const lum = luminance(hex);
+  const whiteLum = 1;
+  const ratio = (whiteLum + 0.05) / (lum + 0.05);
+  return ratio.toFixed(2);
+}
+
+/**
+ * Group color primitives by family (e.g. "Brand A / Green", "Neutral").
+ */
+function groupByFamily(tokens) {
+  const families = new Map();
+
+  for (const token of tokens) {
+    if (token.type !== "color") continue;
+    if (!token.path.startsWith("Color/")) continue;
+
+    // Skip alpha/overlay/transparent tokens — handled separately
+    const pathAfterColor = token.path.slice(6); // remove "Color/"
+    if (pathAfterColor.startsWith("Transparent")) continue;
+
+    // Parse family and step from path like "Brand A/Green/100" or "Neutral/400"
+    const parts = pathAfterColor.split("/");
+    let family;
+    let step;
+
+    if (parts.length === 3) {
+      // e.g. ["Brand A", "Green", "100"]
+      family = parts[0] + " / " + parts[1];
+      step = parts[2];
+    } else if (parts.length === 2) {
+      // e.g. ["Neutral", "400"] or ["Neutral", "Alpha"]
+      if (/^\d+$/.test(parts[1])) {
+        family = parts[0];
+        step = parts[1];
+      } else {
+        // Sub-family like "Neutral/Alpha"
+        family = parts[0] + " / " + parts[1];
+        step = "";
+      }
+    } else if (parts.length === 4) {
+      // e.g. ["Neutral", "Alpha", "Inverse", "100"]
+      family = parts.slice(0, -1).join(" / ");
+      step = parts[parts.length - 1];
+    } else {
+      continue;
+    }
+
+    if (!step || !/^\d+$/.test(step)) continue;
+
+    if (!families.has(family)) {
+      families.set(family, []);
+    }
+
+    const hex = extractHex(token.value);
+
+    families.get(family).push({
+      step: parseInt(step, 10),
+      cssVar: token.cssVar,
+      name: token.name,
+      hex,
+      contrast: contrastVsWhite(hex),
+      value: token.value,
+    });
+  }
+
+  // Sort steps within each family
+  for (const [, steps] of families) {
+    steps.sort((a, b) => a.step - b.step);
+  }
+
+  return families;
+}
+
+/**
+ * Group semantic color tokens by category (text, fill, border, overlay).
+ */
+function groupSemanticByCategory(tokens, bucket, id) {
+  const scoped = tokens.filter(
+    (t) => t.scopeBucket === bucket && t.scopeId === id,
   );
+
+  const categories = {
+    text: [],
+    fill: [],
+    border: [],
+    overlay: [],
+  };
+
+  for (const token of scoped) {
+    if (token.cssVar.startsWith("--color-text-")) categories.text.push(token);
+    else if (token.cssVar.startsWith("--color-fill-")) categories.fill.push(token);
+    else if (token.cssVar.startsWith("--color-border-")) categories.border.push(token);
+    else if (token.cssVar.startsWith("--color-overlay-")) categories.overlay.push(token);
+  }
+
+  return Object.entries(categories)
+    .filter(([, items]) => items.length > 0)
+    .map(([category, items]) => ({
+      category,
+      tokens: items.sort((a, b) => a.name.localeCompare(b.name)),
+    }));
 }
 
 module.exports = () => {
   const tokens = normalizeTokens(loadTokensFromYaml());
-  const semanticPrefixes = [
-    "--color-text-",
-    "--color-fill-",
-    "--color-border-",
-    "--color-overlay-",
+
+  // Primitive color palettes (core)
+  const coreTokens = tokens.filter(
+    (t) => t.scopeBucket === "global" && t.scopeId === "core-primitives",
+  );
+  const paletteFamilies = groupByFamily(coreTokens);
+
+  // Organize into sections
+  const palettes = [];
+  const familyOrder = [
+    "Neutral",
+    "Neutral / Alpha",
+    "Neutral / Alpha Inverse",
   ];
 
-  const groups = [
-    {
-      id: "brand-a",
-      title: "Brand A",
-      description: "Filtered from tokens.yaml (scope brand:a).",
-      tokens: sortByName(
-        pickByPrefixes(pickByScope(tokens, "brand", "a"), ["--brand-color-"]),
-      ),
-    },
-    {
-      id: "brand-b",
-      title: "Brand B",
-      description: "Filtered from tokens.yaml (scope brand:b).",
-      tokens: sortByName(
-        pickByPrefixes(pickByScope(tokens, "brand", "b"), ["--brand-color-"]),
-      ),
-    },
-    {
-      id: "brand-c",
-      title: "Brand C",
-      description: "Filtered from tokens.yaml (scope brand:c).",
-      tokens: sortByName(
-        pickByPrefixes(pickByScope(tokens, "brand", "c"), ["--brand-color-"]),
-      ),
-    },
-    {
-      id: "light-semantic",
-      title: "Light Semantic Mapping",
-      description: "Filtered from tokens.yaml (scope mode:light).",
-      tokens: sortByName(
-        pickByPrefixes(pickByScope(tokens, "mode", "light"), semanticPrefixes),
-      ),
-    },
-    {
-      id: "dark-semantic",
-      title: "Dark Semantic Mapping",
-      description: "Filtered from tokens.yaml (scope mode:dark).",
-      tokens: sortByName(
-        pickByPrefixes(pickByScope(tokens, "mode", "dark"), semanticPrefixes),
-      ),
-    },
-    {
-      id: "core-neutral-overlay",
-      title: "Core Neutrals & Overlay",
-      description: "Filtered from tokens.yaml (scope global:core-primitives).",
-      tokens: sortByName(
-        pickByPrefixes(pickByScope(tokens, "global", "core-primitives"), [
-          "--color-transparent",
-          "--color-neutral-",
-          "--color-neutral-alpha-",
-        ]),
-      ),
-    },
-  ].filter((group) => group.tokens.length > 0);
+  // Add neutrals first
+  for (const name of familyOrder) {
+    if (paletteFamilies.has(name)) {
+      palettes.push({ family: name, steps: paletteFamilies.get(name) });
+      paletteFamilies.delete(name);
+    }
+  }
+
+  // Remaining families sorted alphabetically
+  const remaining = [...paletteFamilies.entries()].sort((a, b) =>
+    a[0].localeCompare(b[0]),
+  );
+  for (const [name, steps] of remaining) {
+    palettes.push({ family: name, steps });
+  }
+
+  // Brand tokens (semantic brand aliases)
+  const brandGroups = ["a", "b", "c"]
+    .map((id) => {
+      const brandTokens = tokens.filter(
+        (t) =>
+          t.scopeBucket === "brand" &&
+          t.scopeId === id &&
+          t.cssVar.startsWith("--brand-color-"),
+      );
+      if (brandTokens.length === 0) return null;
+      return {
+        id,
+        title: "Brand " + id.toUpperCase(),
+        tokens: brandTokens.sort((a, b) => a.name.localeCompare(b.name)),
+      };
+    })
+    .filter(Boolean);
+
+  // Semantic mapping (light/dark)
+  const lightSemantic = groupSemanticByCategory(tokens, "mode", "light");
+  const darkSemantic = groupSemanticByCategory(tokens, "mode", "dark");
 
   return {
-    groups,
+    palettes,
+    brandGroups,
+    lightSemantic,
+    darkSemantic,
     sourceDir: TOKENS_YAML_RELATIVE_PATH,
   };
 };

--- a/site/_data/typographyDocs.js
+++ b/site/_data/typographyDocs.js
@@ -1,0 +1,128 @@
+const {
+  TOKENS_YAML_RELATIVE_PATH,
+  loadTokensFromYaml,
+} = require("../lib/tokens-yaml");
+
+module.exports = () => {
+  const tokens = loadTokensFromYaml().filter(
+    (t) => t.cssVar && t.cssVar.startsWith("--"),
+  );
+
+  // Font families
+  const families = tokens
+    .filter((t) => t.cssVar.startsWith("--font-family-"))
+    .map((t) => ({
+      cssVar: t.cssVar,
+      name: t.cssVar.replace("--font-family-", ""),
+      value: String(t.value || ""),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  // Font sizes (core scale)
+  const sizes = tokens
+    .filter(
+      (t) =>
+        t.cssVar.startsWith("--font-size-") &&
+        !t.cssVar.includes("badge") &&
+        !t.cssVar.includes("button") &&
+        !t.cssVar.includes("input") &&
+        !t.cssVar.includes("link") &&
+        !t.cssVar.includes("select") &&
+        !t.cssVar.includes("textarea"),
+    )
+    .map((t) => ({
+      cssVar: t.cssVar,
+      name: t.cssVar.replace("--", ""),
+      value: String(t.value || ""),
+    }))
+    .sort((a, b) => {
+      const order = ["xs", "sm", "md", "lg", "xl", "xxl", "xxxl"];
+      const aKey = a.name.replace("font-size-", "");
+      const bKey = b.name.replace("font-size-", "");
+      return order.indexOf(aKey) - order.indexOf(bKey);
+    });
+
+  // Font weights
+  const weights = tokens
+    .filter(
+      (t) =>
+        t.cssVar.startsWith("--font-weight-") &&
+        /--font-weight-\d+$/.test(t.cssVar),
+    )
+    .map((t) => ({
+      cssVar: t.cssVar,
+      name: t.cssVar.replace("--", ""),
+      value: String(t.value || ""),
+    }))
+    .sort((a, b) => Number(a.value) - Number(b.value));
+
+  // Line heights
+  const lineHeights = tokens
+    .filter(
+      (t) =>
+        t.cssVar.startsWith("--line-height-") &&
+        !t.cssVar.includes("badge") &&
+        !t.cssVar.includes("button") &&
+        !t.cssVar.includes("input") &&
+        !t.cssVar.includes("link") &&
+        !t.cssVar.includes("select") &&
+        !t.cssVar.includes("textarea"),
+    )
+    .map((t) => ({
+      cssVar: t.cssVar,
+      name: t.cssVar.replace("--", ""),
+      value: String(t.value || ""),
+    }))
+    .sort((a, b) => {
+      const order = ["xs", "sm", "md", "lg", "xl", "xxl", "xxxl"];
+      const aKey = a.name.replace("line-height-", "");
+      const bKey = b.name.replace("line-height-", "");
+      return order.indexOf(aKey) - order.indexOf(bKey);
+    });
+
+  // Brand font tokens
+  const brandFonts = tokens
+    .filter(
+      (t) =>
+        t.cssVar.startsWith("--brand-font-") &&
+        t.scopeBucket === "brand",
+    )
+    .map((t) => ({
+      cssVar: t.cssVar,
+      name: t.cssVar.replace("--", ""),
+      value: String(t.value || ""),
+      brand: t.scopeId || "",
+    }));
+
+  // Heading scale tokens
+  const headingScale = [
+    { class: "heading-xxxl", label: "XXXL", element: "h1" },
+    { class: "heading-xxl", label: "XXL", element: "h2" },
+    { class: "heading-xl", label: "XL", element: "h3" },
+    { class: "heading-lg", label: "LG", element: "h4" },
+    { class: "heading-md", label: "MD", element: "h5" },
+    { class: "heading-sm", label: "SM", element: "h6" },
+  ];
+
+  // Text scale
+  const textScale = [
+    { class: "text-xxxl", label: "XXXL" },
+    { class: "text-xxl", label: "XXL" },
+    { class: "text-xl", label: "XL" },
+    { class: "text-lg", label: "LG" },
+    { class: "text-md", label: "MD" },
+    { class: "text-sm", label: "SM" },
+    { class: "text-xs", label: "XS" },
+  ];
+
+  return {
+    families,
+    sizes,
+    weights,
+    lineHeights,
+    brandFonts,
+    headingScale,
+    textScale,
+    sourceDir: TOKENS_YAML_RELATIVE_PATH,
+  };
+};

--- a/site/_includes/layouts/docs.njk
+++ b/site/_includes/layouts/docs.njk
@@ -99,16 +99,10 @@
                 {% endfor %}
               </ul>
               <details class="docs-nav-subgroup"{% if page.url.indexOf("/primitives/") == 0 or page.url == "/foundations/design-tokens/" %} open{% endif %}>
-                <summary class="docs-nav-group-toggle">Design Tokens</summary>
+                <summary class="docs-nav-subgroup-toggle">
+                  <a href="/foundations/design-tokens/"{% if page.url == "/foundations/design-tokens/" %} aria-current="page"{% endif %}>Design Tokens</a>
+                </summary>
                 <ul>
-                  <li>
-                    <a
-                      href="/foundations/design-tokens/"
-                      {% if page.url == "/foundations/design-tokens/" %}aria-current="page"{% endif %}
-                    >
-                      Overview
-                    </a>
-                  </li>
                   {% for entry in collections.primitivesDocs %}
                   <li>
                     <a

--- a/site/_includes/layouts/docs.njk
+++ b/site/_includes/layouts/docs.njk
@@ -99,8 +99,11 @@
                 {% endfor %}
               </ul>
               <details class="docs-nav-subgroup"{% if page.url.indexOf("/primitives/") == 0 or page.url == "/foundations/design-tokens/" %} open{% endif %}>
-                <summary class="docs-nav-subgroup-toggle">
-                  <a href="/foundations/design-tokens/"{% if page.url == "/foundations/design-tokens/" %} aria-current="page"{% endif %}>Design Tokens</a>
+                <summary>
+                  <a
+                    href="/foundations/design-tokens/"
+                    {% if page.url == "/foundations/design-tokens/" %}aria-current="page"{% endif %}
+                  >Design Tokens</a>
                 </summary>
                 <ul>
                   {% for entry in collections.primitivesDocs %}

--- a/site/_includes/layouts/docs.njk
+++ b/site/_includes/layouts/docs.njk
@@ -101,9 +101,9 @@
             </details>
           </nav>
 
-          <nav class="docs-nav-group" aria-label="Primitives">
+          <nav class="docs-nav-group" aria-label="Core Tokens">
             <details{% if page.url.indexOf("/primitives/") == 0 %} open{% endif %}>
-              <summary class="docs-nav-group-toggle">Primitives</summary>
+              <summary class="docs-nav-group-toggle">Core Tokens</summary>
               <ul>
                 {% for entry in collections.primitivesDocs %}
                 <li>

--- a/site/_includes/layouts/docs.njk
+++ b/site/_includes/layouts/docs.njk
@@ -97,27 +97,24 @@
                   </a>
                 </li>
                 {% endfor %}
+                <li>
+                  <details class="docs-nav-subgroup"{% if page.url.indexOf("/primitives/") == 0 or page.url == "/foundations/design-tokens/" %} open{% endif %}>
+                    <summary><a href="/foundations/design-tokens/"{% if page.url == "/foundations/design-tokens/" %} aria-current="page"{% endif %}>Design Tokens</a></summary>
+                    <ul>
+                      {% for entry in collections.primitivesDocs %}
+                      <li>
+                        <a
+                          href="{{ entry.url }}"
+                          {% if entry.url == page.url %}aria-current="page"{% endif %}
+                        >
+                          {{ entry.data.navTitle or entry.data.title }}
+                        </a>
+                      </li>
+                      {% endfor %}
+                    </ul>
+                  </details>
+                </li>
               </ul>
-              <details class="docs-nav-subgroup"{% if page.url.indexOf("/primitives/") == 0 or page.url == "/foundations/design-tokens/" %} open{% endif %}>
-                <summary>
-                  <a
-                    href="/foundations/design-tokens/"
-                    {% if page.url == "/foundations/design-tokens/" %}aria-current="page"{% endif %}
-                  >Design Tokens</a>
-                </summary>
-                <ul>
-                  {% for entry in collections.primitivesDocs %}
-                  <li>
-                    <a
-                      href="{{ entry.url }}"
-                      {% if entry.url == page.url %}aria-current="page"{% endif %}
-                    >
-                      {{ entry.data.navTitle or entry.data.title }}
-                    </a>
-                  </li>
-                  {% endfor %}
-                </ul>
-              </details>
             </details>
           </nav>
 

--- a/site/_includes/layouts/docs.njk
+++ b/site/_includes/layouts/docs.njk
@@ -84,7 +84,7 @@
 
         <nav class="docs-nav" aria-label="Documentation navigation">
           <nav class="docs-nav-group" aria-label="Foundations">
-            <details{% if page.url.indexOf("/foundations/") == 0 %} open{% endif %}>
+            <details{% if page.url.indexOf("/foundations/") == 0 or page.url.indexOf("/primitives/") == 0 %} open{% endif %}>
               <summary class="docs-nav-group-toggle">Foundations</summary>
               <ul>
                 {% for entry in collections.foundationsDocs %}
@@ -98,24 +98,29 @@
                 </li>
                 {% endfor %}
               </ul>
-            </details>
-          </nav>
-
-          <nav class="docs-nav-group" aria-label="Core Tokens">
-            <details{% if page.url.indexOf("/primitives/") == 0 %} open{% endif %}>
-              <summary class="docs-nav-group-toggle">Core Tokens</summary>
-              <ul>
-                {% for entry in collections.primitivesDocs %}
-                <li>
-                  <a
-                    href="{{ entry.url }}"
-                    {% if entry.url == page.url %}aria-current="page"{% endif %}
-                  >
-                    {{ entry.data.navTitle or entry.data.title }}
-                  </a>
-                </li>
-                {% endfor %}
-              </ul>
+              <details class="docs-nav-subgroup"{% if page.url.indexOf("/primitives/") == 0 or page.url == "/foundations/design-tokens/" %} open{% endif %}>
+                <summary class="docs-nav-group-toggle">Design Tokens</summary>
+                <ul>
+                  <li>
+                    <a
+                      href="/foundations/design-tokens/"
+                      {% if page.url == "/foundations/design-tokens/" %}aria-current="page"{% endif %}
+                    >
+                      Overview
+                    </a>
+                  </li>
+                  {% for entry in collections.primitivesDocs %}
+                  <li>
+                    <a
+                      href="{{ entry.url }}"
+                      {% if entry.url == page.url %}aria-current="page"{% endif %}
+                    >
+                      {{ entry.data.navTitle or entry.data.title }}
+                    </a>
+                  </li>
+                  {% endfor %}
+                </ul>
+              </details>
             </details>
           </nav>
 

--- a/site/assets/docs.css
+++ b/site/assets/docs.css
@@ -2094,3 +2094,421 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
 .docs-footer a:hover {
   color: var(--docs-text-0, #1a2233);
 }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   Color Palette Page — Spectrum-inspired layout
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.palette-nav {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0;
+  padding: 3px;
+  border-radius: 999px;
+  border: 1px solid var(--docs-border);
+  background: var(--docs-surface-1);
+  box-shadow: var(--docs-shadow-sm);
+  margin-bottom: 2rem;
+}
+
+.palette-nav a {
+  display: inline-block;
+  padding: 6px 14px;
+  border-radius: 999px;
+  text-decoration: none;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--docs-text-1);
+  transition: all 120ms ease;
+}
+
+.palette-nav a:hover {
+  background: var(--docs-surface-2);
+  color: var(--docs-text-0);
+}
+
+.section-description {
+  margin: 0 0 1.5rem;
+  color: var(--docs-text-1);
+  font-size: 0.92rem;
+  max-width: 72ch;
+}
+
+/* ─── Color family block ─── */
+.color-family {
+  margin-bottom: 2.5rem;
+}
+
+.color-family h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+/* ─── Horizontal color ramp bar ─── */
+.color-ramp {
+  display: flex;
+  border-radius: 10px;
+  overflow: hidden;
+  height: 48px;
+  border: 1px solid var(--docs-border);
+  box-shadow: var(--docs-shadow-sm);
+  margin-bottom: 1rem;
+}
+
+.color-ramp__step {
+  flex: 1;
+  min-width: 0;
+  transition: flex 180ms ease;
+}
+
+.color-ramp__step:hover {
+  flex: 2;
+}
+
+/* ─── Token data table ─── */
+.color-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--docs-border);
+  border-radius: 12px;
+  background: var(--docs-surface-1);
+  box-shadow: var(--docs-shadow-sm);
+}
+
+.color-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 0.84rem;
+}
+
+.color-table th {
+  text-align: left;
+  padding: 8px 12px;
+  font-size: 0.69rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 800;
+  color: var(--docs-text-1);
+  background: var(--docs-surface-2);
+  border-bottom: 1px solid var(--docs-border);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.color-table .th-hint {
+  font-weight: 600;
+  opacity: 0.7;
+}
+
+.color-table td {
+  padding: 7px 12px;
+  border-bottom: 1px solid var(--docs-border);
+  vertical-align: middle;
+}
+
+.color-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.color-table tbody tr:hover td {
+  background: rgba(37, 99, 235, 0.03);
+}
+
+/* Preview dot */
+.color-table__preview {
+  width: 40px;
+  padding-right: 0;
+}
+
+.color-dot {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  vertical-align: middle;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+}
+
+/* Columns */
+.color-table__name {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.color-table__token code {
+  font-size: 0.78rem;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--docs-surface-2);
+  word-break: break-all;
+}
+
+.color-table__contrast {
+  font-family: var(--docs-code-font);
+  font-size: 0.78rem;
+  color: var(--docs-text-1);
+  white-space: nowrap;
+}
+
+.color-table__hex code {
+  font-size: 0.78rem;
+  color: var(--docs-text-1);
+}
+
+/* ─── Brand sections toggle ─── */
+.brand-section[hidden] {
+  display: none;
+}
+
+/* ─── Responsive ─── */
+@media (max-width: 980px) {
+  .color-ramp {
+    height: 36px;
+  }
+
+  .color-table {
+    font-size: 0.78rem;
+    min-width: 580px;
+  }
+
+  .palette-nav {
+    flex-wrap: wrap;
+  }
+}
+
+/* ─── TOC sidebar nested sublist for color families ─── */
+.docs-toc-sidebar-sublist {
+  list-style: none;
+  margin: 4px 0 4px 12px;
+  padding: 0;
+  display: grid;
+  gap: 1px;
+  border-inline-start: 1px solid var(--docs-border);
+  padding-inline-start: 8px;
+}
+
+.docs-toc-sidebar-sublist a {
+  display: block;
+  padding: 3px 6px;
+  border-radius: 4px;
+  text-decoration: none;
+  color: var(--docs-text-1);
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.4;
+  transition: color 120ms ease, background 120ms ease;
+}
+
+.docs-toc-sidebar-sublist a:hover {
+  color: var(--docs-text-0);
+  background: var(--docs-surface-2);
+}
+
+.docs-toc-sidebar-sublist a.is-active {
+  color: var(--docs-accent);
+  background: rgba(37, 99, 235, 0.06);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   Typography Page — Spectrum-inspired layout
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* ─── Typeface specimens ─── */
+.type-specimens {
+  display: grid;
+  gap: 16px;
+}
+
+.type-specimen {
+  border-radius: 14px;
+  border: 1px solid var(--docs-border);
+  background: var(--docs-surface-1);
+  box-shadow: var(--docs-shadow-sm);
+  overflow: hidden;
+}
+
+.type-specimen__sample {
+  padding: 32px 24px 24px;
+  background: var(--docs-surface-2);
+  border-bottom: 1px solid var(--docs-border);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.type-specimen__sample * {
+  font-family: inherit;
+}
+
+.type-specimen__large {
+  font-size: 4rem;
+  font-weight: 400;
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+
+.type-specimen__alphabet {
+  font-size: 0.92rem;
+  line-height: 1.6;
+  color: var(--docs-text-1);
+  letter-spacing: 0.02em;
+  word-break: break-all;
+}
+
+.type-specimen__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 24px;
+}
+
+.type-specimen__name {
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+.type-specimen__token {
+  font-size: 0.78rem;
+  padding: 3px 8px;
+  border-radius: 6px;
+  background: var(--docs-surface-2);
+  color: var(--docs-text-1);
+}
+
+/* ─── Type scale tables (heading + text) ─── */
+.type-scale-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--docs-border);
+  border-radius: 14px;
+  background: var(--docs-surface-1);
+  box-shadow: var(--docs-shadow-sm);
+}
+
+.type-scale-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.type-scale-table th {
+  text-align: left;
+  padding: 10px 16px;
+  font-size: 0.69rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 800;
+  color: var(--docs-text-1);
+  background: var(--docs-surface-2);
+  border-bottom: 1px solid var(--docs-border);
+}
+
+.type-scale-table td {
+  padding: 16px;
+  border-bottom: 1px solid var(--docs-border);
+  vertical-align: middle;
+}
+
+.type-scale-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.type-scale-table tbody tr:hover td {
+  background: rgba(37, 99, 235, 0.02);
+}
+
+.type-scale-table__size {
+  width: 80px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--docs-text-1);
+  white-space: nowrap;
+}
+
+.type-scale-table__class {
+  width: 240px;
+  white-space: nowrap;
+}
+
+.type-scale-table__class code {
+  font-size: 0.78rem;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--docs-surface-2);
+}
+
+.type-scale-table__sample {
+  color: var(--docs-text-0);
+}
+
+.type-scale-table__sample .heading-xxxl,
+.type-scale-table__sample .heading-xxl,
+.type-scale-table__sample .heading-xl,
+.type-scale-table__sample .heading-lg,
+.type-scale-table__sample .heading-md,
+.type-scale-table__sample .heading-sm {
+  margin: 0;
+  color: inherit;
+}
+
+/* ─── Token tables (sizes, weights, line-heights) ─── */
+.type-token-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--docs-border);
+  border-radius: 14px;
+  background: var(--docs-surface-1);
+  box-shadow: var(--docs-shadow-sm);
+}
+
+.type-token-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.type-token-table th {
+  text-align: left;
+  padding: 10px 16px;
+  font-size: 0.69rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 800;
+  color: var(--docs-text-1);
+  background: var(--docs-surface-2);
+  border-bottom: 1px solid var(--docs-border);
+}
+
+.type-token-table td {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--docs-border);
+  vertical-align: middle;
+}
+
+.type-token-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.type-token-table tbody tr:hover td {
+  background: rgba(37, 99, 235, 0.02);
+}
+
+.type-token-table td code {
+  font-size: 0.78rem;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--docs-surface-2);
+}
+
+.type-token-table__value {
+  font-family: var(--docs-code-font);
+  font-size: 0.82rem;
+  color: var(--docs-text-1);
+  white-space: nowrap;
+}
+
+.type-token-table__preview {
+  color: var(--docs-text-0);
+}

--- a/site/assets/docs.css
+++ b/site/assets/docs.css
@@ -2515,62 +2515,48 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
 
 /* ─── Nested nav sub-group (Design Tokens inside Foundations) ─── */
 .docs-nav-subgroup {
-  margin: 4px 0 4px 8px;
-  padding-inline-start: 10px;
-  border-inline-start: 1px solid var(--docs-border);
+  margin: 0;
+  border: 0;
 }
 
-.docs-nav-subgroup > .docs-nav-subgroup-toggle {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 6px 4px;
-  font-size: 0.69rem;
-  letter-spacing: 0.11em;
-  text-transform: uppercase;
-  font-weight: 800;
+.docs-nav-subgroup > summary {
+  display: block;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  text-decoration: none;
   color: var(--docs-text-1);
+  font-size: 0.9rem;
+  font-weight: 600;
   cursor: pointer;
   list-style: none;
-  user-select: none;
+  transition: all 120ms ease;
 }
 
-.docs-nav-subgroup > .docs-nav-subgroup-toggle::-webkit-details-marker {
+.docs-nav-subgroup > summary::-webkit-details-marker {
   display: none;
 }
 
-.docs-nav-subgroup > .docs-nav-subgroup-toggle::before {
-  content: "";
-  display: inline-block;
-  width: 0.5em;
-  height: 0.5em;
-  border-inline-end: 2px solid currentColor;
-  border-block-end: 2px solid currentColor;
-  transform: rotate(-45deg);
-  transition: transform 150ms ease;
-  flex-shrink: 0;
+.docs-nav-subgroup > summary:hover {
+  border-color: var(--docs-border);
+  background: #fff;
+  color: var(--docs-text-0);
 }
 
-.docs-nav-subgroup[open] > .docs-nav-subgroup-toggle::before {
-  transform: rotate(45deg);
-}
-
-.docs-nav-subgroup > .docs-nav-subgroup-toggle a {
+.docs-nav-subgroup > summary a {
   text-decoration: none;
   color: inherit;
+  pointer-events: auto;
 }
 
-.docs-nav-subgroup > .docs-nav-subgroup-toggle a:hover {
+.docs-nav-subgroup > summary a[aria-current="page"] {
   color: var(--docs-text-0);
-}
-
-.docs-nav-subgroup > .docs-nav-subgroup-toggle a[aria-current="page"] {
-  color: var(--docs-text-0);
+  font-weight: 700;
 }
 
 .docs-nav-subgroup ul {
   list-style: none;
-  margin: 4px 0 8px;
+  margin: 2px 0 2px 12px;
   padding: 0;
   display: grid;
   gap: 2px;

--- a/site/assets/docs.css
+++ b/site/assets/docs.css
@@ -2520,9 +2520,52 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
   border-inline-start: 1px solid var(--docs-border);
 }
 
-.docs-nav-subgroup > .docs-nav-group-toggle {
-  font-size: 0.65rem;
-  padding: 4px 4px;
+.docs-nav-subgroup > .docs-nav-subgroup-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 4px;
+  font-size: 0.69rem;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  font-weight: 800;
+  color: var(--docs-text-1);
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+
+.docs-nav-subgroup > .docs-nav-subgroup-toggle::-webkit-details-marker {
+  display: none;
+}
+
+.docs-nav-subgroup > .docs-nav-subgroup-toggle::before {
+  content: "";
+  display: inline-block;
+  width: 0.5em;
+  height: 0.5em;
+  border-inline-end: 2px solid currentColor;
+  border-block-end: 2px solid currentColor;
+  transform: rotate(-45deg);
+  transition: transform 150ms ease;
+  flex-shrink: 0;
+}
+
+.docs-nav-subgroup[open] > .docs-nav-subgroup-toggle::before {
+  transform: rotate(45deg);
+}
+
+.docs-nav-subgroup > .docs-nav-subgroup-toggle a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.docs-nav-subgroup > .docs-nav-subgroup-toggle a:hover {
+  color: var(--docs-text-0);
+}
+
+.docs-nav-subgroup > .docs-nav-subgroup-toggle a[aria-current="page"] {
+  color: var(--docs-text-0);
 }
 
 .docs-nav-subgroup ul {

--- a/site/assets/docs.css
+++ b/site/assets/docs.css
@@ -2512,3 +2512,49 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
 .type-token-table__preview {
   color: var(--docs-text-0);
 }
+
+/* ─── Nested nav sub-group (Design Tokens inside Foundations) ─── */
+.docs-nav-subgroup {
+  margin: 4px 0 4px 8px;
+  padding-inline-start: 10px;
+  border-inline-start: 1px solid var(--docs-border);
+}
+
+.docs-nav-subgroup > .docs-nav-group-toggle {
+  font-size: 0.65rem;
+  padding: 4px 4px;
+}
+
+.docs-nav-subgroup ul {
+  list-style: none;
+  margin: 4px 0 8px;
+  padding: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.docs-nav-subgroup a {
+  display: block;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  text-decoration: none;
+  color: var(--docs-text-1);
+  font-size: 0.85rem;
+  font-weight: 600;
+  transition: all 120ms ease;
+}
+
+.docs-nav-subgroup a:hover {
+  border-color: var(--docs-border);
+  background: #fff;
+  color: var(--docs-text-0);
+}
+
+.docs-nav-subgroup a[aria-current="page"] {
+  border-color: var(--docs-border-strong);
+  background: #fff;
+  color: var(--docs-text-0);
+  box-shadow: var(--docs-shadow-sm);
+  font-weight: 700;
+}

--- a/site/assets/docs.css
+++ b/site/assets/docs.css
@@ -2516,6 +2516,7 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
 /* ─── Nested nav sub-group (Design Tokens inside Foundations) ─── */
 .docs-nav-subgroup {
   margin: 0;
+  padding: 0;
   border: 0;
 }
 
@@ -2530,23 +2531,15 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
   font-weight: 600;
   cursor: pointer;
   list-style: none;
-  transition: all 120ms ease;
 }
 
 .docs-nav-subgroup > summary::-webkit-details-marker {
   display: none;
 }
 
-.docs-nav-subgroup > summary:hover {
-  border-color: var(--docs-border);
-  background: #fff;
-  color: var(--docs-text-0);
-}
-
 .docs-nav-subgroup > summary a {
   text-decoration: none;
   color: inherit;
-  pointer-events: auto;
 }
 
 .docs-nav-subgroup > summary a[aria-current="page"] {
@@ -2556,7 +2549,7 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
 
 .docs-nav-subgroup ul {
   list-style: none;
-  margin: 2px 0 2px 12px;
+  margin: 2px 0 0 12px;
   padding: 0;
   display: grid;
   gap: 2px;

--- a/site/assets/docs.css
+++ b/site/assets/docs.css
@@ -2525,16 +2525,22 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
   padding: 8px 10px;
   border-radius: 10px;
   border: 1px solid transparent;
-  text-decoration: none;
   color: var(--docs-text-1);
   font-size: 0.9rem;
   font-weight: 600;
   cursor: pointer;
   list-style: none;
+  transition: all 120ms ease;
 }
 
 .docs-nav-subgroup > summary::-webkit-details-marker {
   display: none;
+}
+
+.docs-nav-subgroup > summary:hover {
+  border-color: var(--docs-border);
+  background: #fff;
+  color: var(--docs-text-0);
 }
 
 .docs-nav-subgroup > summary a {

--- a/site/primitives/color-tokens.md
+++ b/site/primitives/color-tokens.md
@@ -1,7 +1,7 @@
 ---
 layout: layouts/docs.njk
-title: Color Tokens
-description: Brand, neutral, and overlay tokens including mode and brand switching.
+title: Color Palette
+description: The complete color system — primitives, brand palettes, and semantic mappings.
 navTitle: Color
 order: 10
 permalink: /primitives/color/
@@ -9,8 +9,65 @@ permalink: /primitives/color/
 
 {% import "macros/ui.njk" as ui %}
 
-{% if colorDocs.groups and colorDocs.groups.length %}
-<p class="page-intro">This page is generated automatically from <code>{{ colorDocs.sourceDir }}</code>.</p>
+<p class="page-intro">
+  All color primitives available in the system, organized by family. Each row shows the full ramp from lightest to darkest.
+  Generated from <code>{{ colorDocs.sourceDir }}</code>.
+</p>
+
+{% if colorDocs.palettes and colorDocs.palettes.length %}
+
+<nav class="palette-nav" aria-label="Color sections">
+  <a href="#primitives">Primitives</a>
+  <a href="#brands">Brands</a>
+  <a href="#semantic-light">Semantic (Light)</a>
+  <a href="#semantic-dark">Semantic (Dark)</a>
+</nav>
+
+<!-- ═══════════════════════════════════════════════════
+     PRIMITIVES
+     ═══════════════════════════════════════════════════ -->
+
+<section id="primitives">
+<h2 id="primitives-heading">Color Primitives</h2>
+<p class="section-description">Raw color values from the Core layer. These are referenced by semantic and brand tokens — never used directly in components.</p>
+
+{% for palette in colorDocs.palettes %}
+<div class="color-family" id="family-{{ palette.family | slug }}">
+  <h3 id="palette-{{ palette.family | slug }}">{{ palette.family }}</h3>
+  <div class="color-ramp">{% for step in palette.steps %}<div class="color-ramp__step" style="background: {{ step.hex }};" title="{{ step.name }} — {{ step.hex }}"></div>{% endfor %}</div>
+  <div class="color-table-wrap">
+    <table class="color-table">
+      <thead>
+        <tr>
+          <th class="color-table__preview"></th>
+          <th>Name</th>
+          <th>Token</th>
+          <th>Contrast <span class="th-hint">:1</span></th>
+          <th>Hex</th>
+        </tr>
+      </thead>
+      <tbody>{% for step in palette.steps %}
+        <tr>
+          <td class="color-table__preview"><span class="color-dot" style="background: {{ step.hex }};"></span></td>
+          <td class="color-table__name">{{ palette.family }} {{ step.step }}</td>
+          <td class="color-table__token"><code>{{ step.cssVar }}</code></td>
+          <td class="color-table__contrast">{{ step.contrast }}</td>
+          <td class="color-table__hex"><code>{{ step.hex }}</code></td>
+        </tr>{% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endfor %}
+</section>
+
+<!-- ═══════════════════════════════════════════════════
+     BRANDS
+     ═══════════════════════════════════════════════════ -->
+
+<section id="brands">
+<h2 id="brands-heading">Brand Color Mapping</h2>
+<p class="section-description">Each brand maps the same semantic keys to different primitives. Switch brands to compare.</p>
 
 <div class="docs-header" style="margin-bottom: 1.5rem;">
   <span class="docs-hero-switch" data-hero-group="brand">
@@ -20,19 +77,103 @@ permalink: /primitives/color/
   </span>
 </div>
 
-<section class="palette">
-{% for group in colorDocs.groups %}
-<div class="palette-group" id="group-{{ group.id }}"{% if group.id == "brand-a" %} data-brand-scope="a"{% elif group.id == "brand-b" %} data-brand-scope="b"{% elif group.id == "brand-c" %} data-brand-scope="c"{% endif %}>
-<h2>{{ group.title }}</h2>
-{% if group.description %}<p class="palette-note">{{ group.description }}</p>{% endif %}
-<div class="swatch-grid">
-{% for token in group.tokens %}
-{{ ui.colorChip(token) }}
-{% endfor %}
-</div>
+{% for brand in colorDocs.brandGroups %}
+<div class="brand-section" data-brand-scope="{{ brand.id }}" {% if brand.id != "a" %}hidden{% endif %}>
+  <h3>{{ brand.title }}</h3>
+  <div class="color-table-wrap">
+    <table class="color-table">
+      <thead>
+        <tr>
+          <th class="color-table__preview"></th>
+          <th>Role</th>
+          <th>Token</th>
+          <th>Resolved Value</th>
+        </tr>
+      </thead>
+      <tbody>{% for token in brand.tokens %}
+        <tr>
+          <td class="color-table__preview"><span class="color-dot" style="background: var({{ token.cssVar }});"></span></td>
+          <td class="color-table__name">{{ token.name | replace("brand-color-", "") }}</td>
+          <td class="color-table__token"><code>{{ token.cssVar }}</code></td>
+          <td class="color-table__hex"><code>{{ token.value }}</code></td>
+        </tr>{% endfor %}
+      </tbody>
+    </table>
+  </div>
 </div>
 {% endfor %}
 </section>
+
+<!-- ═══════════════════════════════════════════════════
+     SEMANTIC LIGHT
+     ═══════════════════════════════════════════════════ -->
+
+<section id="semantic-light">
+<h2 id="semantic-light-heading">Semantic Mapping — Light</h2>
+<p class="section-description">Intent-based tokens for the light appearance mode. These resolve to primitives and adapt per brand.</p>
+
+{% for group in colorDocs.lightSemantic %}
+<div class="color-family">
+  <h3>{{ group.category | capitalize }}</h3>
+  <div class="color-table-wrap">
+    <table class="color-table">
+      <thead>
+        <tr>
+          <th class="color-table__preview"></th>
+          <th>Name</th>
+          <th>Token</th>
+          <th>Value</th>
+        </tr>
+      </thead>
+      <tbody>{% for token in group.tokens %}
+        <tr>
+          <td class="color-table__preview"><span class="color-dot" style="background: var({{ token.cssVar }});"></span></td>
+          <td class="color-table__name">{{ token.name | replace("color-", "") }}</td>
+          <td class="color-table__token"><code>{{ token.cssVar }}</code></td>
+          <td class="color-table__hex"><code>{{ token.value }}</code></td>
+        </tr>{% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endfor %}
+</section>
+
+<!-- ═══════════════════════════════════════════════════
+     SEMANTIC DARK
+     ═══════════════════════════════════════════════════ -->
+
+<section id="semantic-dark">
+<h2 id="semantic-dark-heading">Semantic Mapping — Dark</h2>
+<p class="section-description">Intent-based tokens for the dark appearance mode.</p>
+
+{% for group in colorDocs.darkSemantic %}
+<div class="color-family">
+  <h3>{{ group.category | capitalize }}</h3>
+  <div class="color-table-wrap">
+    <table class="color-table">
+      <thead>
+        <tr>
+          <th class="color-table__preview"></th>
+          <th>Name</th>
+          <th>Token</th>
+          <th>Value</th>
+        </tr>
+      </thead>
+      <tbody>{% for token in group.tokens %}
+        <tr>
+          <td class="color-table__preview"><span class="color-dot" style="background: var({{ token.cssVar }});"></span></td>
+          <td class="color-table__name">{{ token.name | replace("color-", "") }}</td>
+          <td class="color-table__token"><code>{{ token.cssVar }}</code></td>
+          <td class="color-table__hex"><code>{{ token.value }}</code></td>
+        </tr>{% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endfor %}
+</section>
+
 {% else %}
 <p>No color tokens found in <code>{{ colorDocs.sourceDir }}</code>.</p>
 <p>Run <code>npm run tokens:generate</code> first.</p>
@@ -43,13 +184,95 @@ permalink: /primitives/color/
   var btns = document.querySelectorAll(".docs-brand-switch");
   if (!btns.length) return;
   var root = document.documentElement;
+  var sections = document.querySelectorAll("[data-brand-scope]");
   btns.forEach(function (btn) {
     btn.addEventListener("click", function () {
       root.dataset.brand = btn.dataset.switchBrand;
       btns.forEach(function (b) {
         b.setAttribute("aria-pressed", b === btn ? "true" : "false");
       });
+      sections.forEach(function (sec) {
+        sec.hidden = sec.dataset.brandScope !== btn.dataset.switchBrand;
+      });
     });
   });
+})();
+
+// Enhanced TOC with nested color families
+(function () {
+  // Remove the auto-generated TOC (from layout script) if present
+  var existing = document.querySelector(".docs-toc-sidebar");
+  if (existing) existing.remove();
+
+  var main = document.querySelector(".docs-main");
+  if (!main) return;
+
+  var aside = document.createElement("aside");
+  aside.className = "docs-toc-sidebar";
+  aside.setAttribute("aria-label", "On this page");
+
+  var title = document.createElement("p");
+  title.className = "docs-toc-sidebar-title";
+  title.textContent = "On this page";
+  aside.appendChild(title);
+
+  var ul = document.createElement("ul");
+  ul.className = "docs-toc-sidebar-list";
+
+  // Build TOC: h2[id] as top-level, h3[id] inside #primitives as nested
+  var h2s = document.querySelectorAll(".docs-content h2[id]");
+  h2s.forEach(function (h2) {
+    var li = document.createElement("li");
+    var a = document.createElement("a");
+    a.href = "#" + h2.id;
+    a.textContent = h2.textContent;
+    a.dataset.tocTarget = h2.id;
+    li.appendChild(a);
+
+    // If this is the primitives heading, add nested palette links
+    if (h2.id === "primitives-heading") {
+      var subUl = document.createElement("ul");
+      subUl.className = "docs-toc-sidebar-sublist";
+      var families = document.querySelectorAll("#primitives h3[id]");
+      families.forEach(function (h3) {
+        var subLi = document.createElement("li");
+        var subA = document.createElement("a");
+        subA.href = "#" + h3.id;
+        subA.textContent = h3.textContent;
+        subA.dataset.tocTarget = h3.id;
+        subLi.appendChild(subA);
+        subUl.appendChild(subLi);
+      });
+      li.appendChild(subUl);
+    }
+
+    ul.appendChild(li);
+  });
+
+  aside.appendChild(ul);
+  main.appendChild(aside);
+
+  // Scroll spy for all links
+  var allLinks = ul.querySelectorAll("a[data-toc-target]");
+  var allTargets = [];
+  allLinks.forEach(function (l) {
+    var target = document.getElementById(l.dataset.tocTarget);
+    if (target) allTargets.push(target);
+  });
+
+  var observer = new IntersectionObserver(
+    function (entries) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          allLinks.forEach(function (l) { l.classList.remove("is-active"); });
+          var active = ul.querySelector('[data-toc-target="' + entry.target.id + '"]');
+          if (active) active.classList.add("is-active");
+        }
+      });
+    },
+    { rootMargin: "-80px 0px -60% 0px", threshold: 0 }
+  );
+
+  allTargets.forEach(function (t) { observer.observe(t); });
 })();
 </script>

--- a/site/primitives/color-tokens.md
+++ b/site/primitives/color-tokens.md
@@ -16,13 +16,6 @@ permalink: /primitives/color/
 
 {% if colorDocs.palettes and colorDocs.palettes.length %}
 
-<nav class="palette-nav" aria-label="Color sections">
-  <a href="#primitives">Primitives</a>
-  <a href="#brands">Brands</a>
-  <a href="#semantic-light">Semantic (Light)</a>
-  <a href="#semantic-dark">Semantic (Dark)</a>
-</nav>
-
 <!-- ═══════════════════════════════════════════════════
      PRIMITIVES
      ═══════════════════════════════════════════════════ -->
@@ -198,81 +191,53 @@ permalink: /primitives/color/
   });
 })();
 
-// Enhanced TOC with nested color families
+// Enhanced TOC: add nested color families to the layout-generated TOC
 (function () {
-  // Remove the auto-generated TOC (from layout script) if present
-  var existing = document.querySelector(".docs-toc-sidebar");
-  if (existing) existing.remove();
+  // Wait for the layout script to build the TOC first
+  setTimeout(function () {
+    var toc = document.querySelector(".docs-toc-sidebar-list");
+    if (!toc) return;
 
-  var main = document.querySelector(".docs-main");
-  if (!main) return;
+    // Find the "Color Primitives" entry and append nested palette links
+    var links = toc.querySelectorAll("a");
+    var primitivesLi = null;
+    links.forEach(function (a) {
+      if (a.dataset.tocTarget === "primitives-heading") primitivesLi = a.parentElement;
+    });
+    if (!primitivesLi) return;
 
-  var aside = document.createElement("aside");
-  aside.className = "docs-toc-sidebar";
-  aside.setAttribute("aria-label", "On this page");
+    var subUl = document.createElement("ul");
+    subUl.className = "docs-toc-sidebar-sublist";
+    var families = document.querySelectorAll("#primitives h3[id]");
+    families.forEach(function (h3) {
+      var subLi = document.createElement("li");
+      var subA = document.createElement("a");
+      subA.href = "#" + h3.id;
+      subA.textContent = h3.textContent;
+      subA.dataset.tocTarget = h3.id;
+      subLi.appendChild(subA);
+      subUl.appendChild(subLi);
+    });
+    primitivesLi.appendChild(subUl);
 
-  var title = document.createElement("p");
-  title.className = "docs-toc-sidebar-title";
-  title.textContent = "On this page";
-  aside.appendChild(title);
-
-  var ul = document.createElement("ul");
-  ul.className = "docs-toc-sidebar-list";
-
-  // Build TOC: h2[id] as top-level, h3[id] inside #primitives as nested
-  var h2s = document.querySelectorAll(".docs-content h2[id]");
-  h2s.forEach(function (h2) {
-    var li = document.createElement("li");
-    var a = document.createElement("a");
-    a.href = "#" + h2.id;
-    a.textContent = h2.textContent;
-    a.dataset.tocTarget = h2.id;
-    li.appendChild(a);
-
-    // If this is the primitives heading, add nested palette links
-    if (h2.id === "primitives-heading") {
-      var subUl = document.createElement("ul");
-      subUl.className = "docs-toc-sidebar-sublist";
-      var families = document.querySelectorAll("#primitives h3[id]");
-      families.forEach(function (h3) {
-        var subLi = document.createElement("li");
-        var subA = document.createElement("a");
-        subA.href = "#" + h3.id;
-        subA.textContent = h3.textContent;
-        subA.dataset.tocTarget = h3.id;
-        subLi.appendChild(subA);
-        subUl.appendChild(subLi);
-      });
-      li.appendChild(subUl);
-    }
-
-    ul.appendChild(li);
-  });
-
-  aside.appendChild(ul);
-  main.appendChild(aside);
-
-  // Scroll spy for all links
-  var allLinks = ul.querySelectorAll("a[data-toc-target]");
-  var allTargets = [];
-  allLinks.forEach(function (l) {
-    var target = document.getElementById(l.dataset.tocTarget);
-    if (target) allTargets.push(target);
-  });
-
-  var observer = new IntersectionObserver(
-    function (entries) {
-      entries.forEach(function (entry) {
-        if (entry.isIntersecting) {
-          allLinks.forEach(function (l) { l.classList.remove("is-active"); });
-          var active = ul.querySelector('[data-toc-target="' + entry.target.id + '"]');
-          if (active) active.classList.add("is-active");
-        }
-      });
-    },
-    { rootMargin: "-80px 0px -60% 0px", threshold: 0 }
-  );
-
-  allTargets.forEach(function (t) { observer.observe(t); });
+    // Extend scroll spy to include nested links
+    var newLinks = subUl.querySelectorAll("a[data-toc-target]");
+    var allTocLinks = toc.querySelectorAll("a[data-toc-target]");
+    var observer = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            allTocLinks.forEach(function (l) { l.classList.remove("is-active"); });
+            newLinks.forEach(function (l) { l.classList.remove("is-active"); });
+            var active = toc.querySelector('[data-toc-target="' + entry.target.id + '"]');
+            if (!active) active = subUl.querySelector('[data-toc-target="' + entry.target.id + '"]');
+            if (active) active.classList.add("is-active");
+          }
+        });
+      },
+      { rootMargin: "-80px 0px -60% 0px", threshold: 0 }
+    );
+    families.forEach(function (h3) { observer.observe(h3); });
+  }, 0);
 })();
 </script>

--- a/site/primitives/typography-tokens.md
+++ b/site/primitives/typography-tokens.md
@@ -1,47 +1,234 @@
 ---
 layout: layouts/docs.njk
-title: Typography Tokens
-description: Display of heading and text scales including token values.
+title: Typography
+description: Typefaces, type scale, weights, and line heights — the complete typography system.
 navTitle: Typography
 order: 11
 permalink: /primitives/typography/
 ---
 
-<section class="typography">
-  <div class="type-grid">
-    <div class="type-card">
-      <p class="type-meta">h1 (default)</p>
-      <h1>Journeys are measured in stories.</h1>
-    </div>
-    <div class="type-card">
-      <p class="type-meta">Heading class (xl)</p>
-      <p class="heading-xl">Journeys are measured in stories.</p>
-    </div>
-    <div class="type-card">
-      <p class="type-meta">Body (md)</p>
-      <p class="body text-md">
-        Clear schedules, gentle spacing, and readable copy for every screen.
-      </p>
-    </div>
-    <div class="type-card">
-      <p class="type-meta">Code</p>
-      <p class="type-sample"><code>const ticketId = "ZX-418";</code></p>
-    </div>
-  </div>
+<p class="page-intro">
+  Typography brings consistency across experiences and platforms. All type tokens are defined in the Core layer and referenced by component tokens.
+  Generated from <code>{{ typographyDocs.sourceDir }}</code>.
+</p>
 
-  <div class="type-scale">
-    <div class="type-scale-row"><span class="type-scale-label">heading-xxxl</span><span class="type-scale-sample heading-xxxl">Sample</span></div>
-    <div class="type-scale-row"><span class="type-scale-label">heading-xxl</span><span class="type-scale-sample heading-xxl">Sample</span></div>
-    <div class="type-scale-row"><span class="type-scale-label">heading-xl</span><span class="type-scale-sample heading-xl">Sample</span></div>
-    <div class="type-scale-row"><span class="type-scale-label">heading-lg</span><span class="type-scale-sample heading-lg">Sample</span></div>
-    <div class="type-scale-row"><span class="type-scale-label">heading-md</span><span class="type-scale-sample heading-md">Sample</span></div>
-    <div class="type-scale-row"><span class="type-scale-label">heading-sm</span><span class="type-scale-sample heading-sm">Sample</span></div>
-    <div class="type-scale-row"><span class="type-scale-label">text-xs</span><span class="type-scale-sample text-xs">Sample</span></div>
-    <div class="type-scale-row"><span class="type-scale-label">text-sm</span><span class="type-scale-sample text-sm">Sample</span></div>
-    <div class="type-scale-row"><span class="type-scale-label">text-md</span><span class="type-scale-sample text-md">Sample</span></div>
-    <div class="type-scale-row"><span class="type-scale-label">text-lg</span><span class="type-scale-sample text-lg">Sample</span></div>
-    <div class="type-scale-row"><span class="type-scale-label">text-xl</span><span class="type-scale-sample text-xl">Sample</span></div>
-    <div class="type-scale-row"><span class="type-scale-label">text-xxl</span><span class="type-scale-sample text-xxl">Sample</span></div>
-    <div class="type-scale-row"><span class="type-scale-label">text-xxxl</span><span class="type-scale-sample text-xxxl">Sample</span></div>
+<!-- TYPEFACES -->
+
+<section id="typefaces">
+<h2 id="typefaces-heading">Typefaces</h2>
+<p class="section-description">Three typeface families — sans-serif for UI, serif for editorial content, monospace for code.</p>
+
+<div class="type-specimens">{% for family in typographyDocs.families %}
+  <div class="type-specimen">
+    <div class="type-specimen__sample" style="font-family: var({{ family.cssVar }});">
+      <span class="type-specimen__large">Aa</span>
+      <span class="type-specimen__alphabet">ABCDEFGHIJKLMNOPQRSTUVWXYZ</span>
+      <span class="type-specimen__alphabet">abcdefghijklmnopqrstuvwxyz 0123456789</span>
+    </div>
+    <div class="type-specimen__meta">
+      <span class="type-specimen__name">{{ family.value }}</span>
+      <code class="type-specimen__token">{{ family.cssVar }}</code>
+    </div>
+  </div>{% endfor %}
+</div>
+</section>
+
+<!-- HEADING SCALE -->
+
+<section id="heading-scale">
+<h2 id="heading-scale-heading">Heading Scale</h2>
+<p class="section-description">Headings create typographic hierarchy. Each size maps to an HTML element and a utility class.</p>
+
+<div class="type-scale-table-wrap">
+  <table class="type-scale-table">
+    <thead>
+      <tr>
+        <th>Size</th>
+        <th>Class / Element</th>
+        <th>Sample</th>
+      </tr>
+    </thead>
+    <tbody>{% for item in typographyDocs.headingScale %}
+      <tr>
+        <td class="type-scale-table__size">{{ item.label }}</td>
+        <td class="type-scale-table__class"><code>.{{ item.class }}</code> / <code>&lt;{{ item.element }}&gt;</code></td>
+        <td class="type-scale-table__sample"><span class="{{ item.class }}">The quick brown fox</span></td>
+      </tr>{% endfor %}
+    </tbody>
+  </table>
+</div>
+</section>
+
+<!-- TEXT SCALE -->
+
+<section id="text-scale">
+<h2 id="text-scale-heading">Text Scale</h2>
+<p class="section-description">Body text sizes for running copy, labels, and captions.</p>
+
+<div class="type-scale-table-wrap">
+  <table class="type-scale-table">
+    <thead>
+      <tr>
+        <th>Size</th>
+        <th>Class</th>
+        <th>Sample</th>
+      </tr>
+    </thead>
+    <tbody>{% for item in typographyDocs.textScale %}
+      <tr>
+        <td class="type-scale-table__size">{{ item.label }}</td>
+        <td class="type-scale-table__class"><code>.{{ item.class }}</code></td>
+        <td class="type-scale-table__sample"><span class="{{ item.class }}">Clear schedules, gentle spacing, and readable copy for every screen.</span></td>
+      </tr>{% endfor %}
+    </tbody>
+  </table>
+</div>
+</section>
+
+<!-- FONT SIZES -->
+
+<section id="font-sizes">
+<h2 id="font-sizes-heading">Font Sizes</h2>
+<p class="section-description">All available size tokens. Each step follows a consistent scale ratio.</p>
+
+<div class="type-token-table-wrap">
+  <table class="type-token-table">
+    <thead>
+      <tr>
+        <th>Token</th>
+        <th>Value</th>
+        <th>Preview</th>
+      </tr>
+    </thead>
+    <tbody>{% for size in typographyDocs.sizes %}
+      <tr>
+        <td><code>{{ size.cssVar }}</code></td>
+        <td class="type-token-table__value">{{ size.value }}</td>
+        <td class="type-token-table__preview"><span style="font-size: var({{ size.cssVar }}); line-height: 1.2;">Ag</span></td>
+      </tr>{% endfor %}
+    </tbody>
+  </table>
+</div>
+</section>
+
+<!-- FONT WEIGHTS -->
+
+<section id="font-weights">
+<h2 id="font-weights-heading">Font Weights</h2>
+<p class="section-description">Numeric weight tokens available in the system.</p>
+
+<div class="type-token-table-wrap">
+  <table class="type-token-table">
+    <thead>
+      <tr>
+        <th>Token</th>
+        <th>Value</th>
+        <th>Preview</th>
+      </tr>
+    </thead>
+    <tbody>{% for weight in typographyDocs.weights %}
+      <tr>
+        <td><code>{{ weight.cssVar }}</code></td>
+        <td class="type-token-table__value">{{ weight.value }}</td>
+        <td class="type-token-table__preview"><span style="font-weight: var({{ weight.cssVar }});">The quick brown fox</span></td>
+      </tr>{% endfor %}
+    </tbody>
+  </table>
+</div>
+</section>
+
+<!-- LINE HEIGHT -->
+
+<section id="line-height">
+<h2 id="line-height-heading">Line Height</h2>
+<p class="section-description">Line height tokens ensure readable vertical rhythm across all text sizes.</p>
+
+<div class="type-token-table-wrap">
+  <table class="type-token-table">
+    <thead>
+      <tr>
+        <th>Token</th>
+        <th>Value</th>
+        <th>Preview</th>
+      </tr>
+    </thead>
+    <tbody>{% for lh in typographyDocs.lineHeights %}
+      <tr>
+        <td><code>{{ lh.cssVar }}</code></td>
+        <td class="type-token-table__value">{{ lh.value }}</td>
+        <td class="type-token-table__preview"><span style="line-height: var({{ lh.cssVar }}); display: inline-block; border-left: 2px solid var(--docs-accent); padding-left: 8px;">Line height<br>demonstration</span></td>
+      </tr>{% endfor %}
+    </tbody>
+  </table>
+</div>
+</section>
+
+<!-- USAGE GUIDELINES -->
+
+<section id="usage">
+<h2 id="usage-heading">Usage Guidelines</h2>
+
+<div class="docs-guideline">
+  <div class="docs-guideline-item" data-type="do">
+    <div class="docs-guideline-preview">
+      <span class="heading-lg">Use defined type tokens</span>
+    </div>
+    <div class="docs-guideline-body">
+      <p class="docs-guideline-label">Do</p>
+      <p>Always use font-size tokens from the scale. Custom pixel values break consistency.</p>
+    </div>
   </div>
+  <div class="docs-guideline-item" data-type="dont">
+    <div class="docs-guideline-preview">
+      <span style="font-size: 17px;">Avoid arbitrary sizes</span>
+    </div>
+    <div class="docs-guideline-body">
+      <p class="docs-guideline-label">Don't</p>
+      <p>Don't use arbitrary px or rem values that aren't in the token scale.</p>
+    </div>
+  </div>
+</div>
+
+<div class="docs-guideline">
+  <div class="docs-guideline-item" data-type="do">
+    <div class="docs-guideline-preview">
+      <span style="max-width: 45ch; display: block;">Paragraphs of text should be roughly 50–80 characters wide for comfortable reading.</span>
+    </div>
+    <div class="docs-guideline-body">
+      <p class="docs-guideline-label">Do</p>
+      <p>Keep line lengths between 50 and 80 characters for body text.</p>
+    </div>
+  </div>
+  <div class="docs-guideline-item" data-type="dont">
+    <div class="docs-guideline-preview">
+      <span style="max-width: 20ch; display: block;">Text too narrow is hard to read and wastes space.</span>
+    </div>
+    <div class="docs-guideline-body">
+      <p class="docs-guideline-label">Don't</p>
+      <p>Don't let paragraph widths get too thin or too wide.</p>
+    </div>
+  </div>
+</div>
+
+<div class="docs-guideline">
+  <div class="docs-guideline-item" data-type="do">
+    <div class="docs-guideline-preview">
+      <span class="heading-md" style="font-family: var(--font-family-sans);">Use brand font tokens</span>
+    </div>
+    <div class="docs-guideline-body">
+      <p class="docs-guideline-label">Do</p>
+      <p>Reference <code>--brand-font-base</code> and <code>--brand-font-lead</code> so fonts adapt per brand.</p>
+    </div>
+  </div>
+  <div class="docs-guideline-item" data-type="dont">
+    <div class="docs-guideline-preview">
+      <span style="font-family: Arial;">Don't hardcode font names</span>
+    </div>
+    <div class="docs-guideline-body">
+      <p class="docs-guideline-label">Don't</p>
+      <p>Never hardcode font-family values like <code>"Inter"</code> or <code>"Arial"</code> directly.</p>
+    </div>
+  </div>
+</div>
+
 </section>

--- a/src/ui/patterns/badge.css
+++ b/src/ui/patterns/badge.css
@@ -46,4 +46,10 @@
   .badge > .icon {
     flex: 0 0 auto;
   }
+
+  /* ── Ensure children inherit color over base :where(span) rule ── */
+
+  .badge > * {
+    color: inherit;
+  }
 }


### PR DESCRIPTION
## Summary

- **Color page**: Spectrum-style horizontal ramp bars + data tables with contrast ratios, grouped by color family, nested TOC sidebar
- **Typography page**: typeface specimens, heading/text scale tables, font size/weight/line-height token tables, usage guidelines (do/dont)
- **Brand A theme**: switched to black & white (Neutral palette only), synced in Figma
- **Badge contrast fix**: `.badge > * { color: inherit }` to override base layer `:where(span)` rule
- **Nav restructure**: Design Tokens nested under Foundations, no more Primitives/Principles confusion

## Changes

- `figma/exports/Themes (Brands).tokens.json` — Brand A refs → Neutral palette
- `site/_data/colorDocs.js` — rewritten for palette families with hex/contrast
- `site/_data/typographyDocs.js` — new data file for type tokens
- `site/primitives/color-tokens.md` — Spectrum-style layout
- `site/primitives/typography-tokens.md` — Spectrum-style layout
- `site/assets/docs.css` — palette ramps, type specimens, nav subgroup styles
- `site/_includes/layouts/docs.njk` — nav restructure
- `.eleventy.js` — exclude Design Tokens from foundationsDocs
- `src/ui/patterns/badge.css` — color inherit fix

## Verified

- `npm run ci:check` passes (lint, tests, build, tokens, docs)
- Figma variables updated to match code