### PR TITLE
feat(keytips): improve keyboard navigation

### DIFF
--- a/site/_includes/layouts/docs.njk
+++ b/site/_includes/layouts/docs.njk
@@ -79,7 +79,7 @@
         <a class="docs-logo" href="/">UI Foundations</a>
 
         <div class="docs-search" role="combobox" aria-expanded="false" aria-haspopup="listbox" aria-owns="docs-search-results">
-          <input type="search" class="docs-search-input" placeholder="Search tokens & patterns" aria-label="Search documentation" aria-autocomplete="list" aria-controls="docs-search-results" autocomplete="off" />
+          <input type="search" class="docs-search-input" placeholder="Search tokens & patterns" aria-label="Search documentation" aria-autocomplete="list" aria-controls="docs-search-results" aria-keyshortcuts="Alt+Space" autocomplete="off" />
           <ul id="docs-search-results" class="docs-search-results" role="listbox" hidden></ul>
         </div>
 

--- a/site/assets/docs-keytips.js
+++ b/site/assets/docs-keytips.js
@@ -97,8 +97,19 @@
         this._altDownTime = Date.now();
         this._altCombo = false;
       }
-      // Prevent default to suppress menu bar activation on Windows/Linux
-      // but only when we might use this as a key-tip trigger
+      // Prevent default to suppress menu bar activation on Windows/Linux.
+      // Safe: only fires on standalone Alt keydown, not combos.
+      e.preventDefault();
+      return;
+    }
+
+    // Alt+Space: focus the search input immediately.
+    // On macOS Alt+Space may produce a non-breaking space (code "Space" but key is \u00A0).
+    if (e.altKey && (e.code === "Space" || e.key === " ")) {
+      e.preventDefault();
+      e.stopPropagation();
+      this._altCombo = true;
+      this._focusSearch();
       return;
     }
 
@@ -155,6 +166,14 @@
     if (this._active) {
       this._deactivate();
     }
+  };
+
+  NavigationKeyTips.prototype._focusSearch = function () {
+    var input = document.querySelector(".docs-search-input");
+    if (!input) return;
+    this._deactivate();
+    input.focus();
+    input.select();
   };
 
   NavigationKeyTips.prototype._handleVisibilityChange = function () {

--- a/site/assets/docs-search.js
+++ b/site/assets/docs-search.js
@@ -131,6 +131,10 @@
       e.preventDefault();
       var entry = currentResults[activeIndex];
       if (entry) window.location.href = entry.url;
+    } else if (e.key === "Enter" && activeIndex < 0 && currentResults.length === 1) {
+      // Single result: navigate directly without explicit selection
+      e.preventDefault();
+      window.location.href = currentResults[0].url;
     } else if (e.key === "Escape") {
       e.preventDefault();
       hide();

--- a/site/foundations/navigation-keytips.md
+++ b/site/foundations/navigation-keytips.md
@@ -12,6 +12,7 @@ order: 90
 | Feature | Navigation Key Tips |
 | Scope | Main Navigation (sidebar) |
 | Trigger | Short press and release of `Alt` |
+| Search focus | `Alt` + `Space` |
 | Selection | `1`–`9` |
 | Dismiss | `Escape`, `Alt`, Pointer click, Navigation |
 | Status | **Experimental** |
@@ -24,6 +25,10 @@ Navigation Key Tips provide a fast keyboard shortcut to open or navigate to top-
 2. Numeric badges appear next to each navigable section.
 3. Press the corresponding number to activate that section or link.
 4. The mode auto-dismisses after selection, or can be cancelled with `Escape`, another `Alt` tap, or any pointer interaction.
+
+### Quick search
+
+Press `Alt` + `Space` at any time to jump directly into the search input. Any existing text is selected so you can immediately type a new query.
 
 ## Key assignments
 
@@ -72,8 +77,23 @@ Key tip badges are rendered via CSS `::after` pseudo-elements — no additional 
 - The `::after` content is presentational and does not alter the computed accessible name of links.
 - `prefers-reduced-motion` disables transitions.
 
+## Touch devices
+
+Key Tips rely on a physical keyboard and the `Alt` key. On touch-only devices (phones, tablets) the feature is inert — no activation path exists, and no UI is rendered. This is intentional: touch navigation uses direct tap targets and does not benefit from a shortcut overlay.
+
+## Scalability
+
+The current design supports up to 9 key tips per scope (digits `1`–`9`). If the navigation grows beyond 9 top-level sections, possible strategies include:
+
+- **Nested scopes**: activate a group first, then show sub-tips within it (two-step selection).
+- **Pagination**: show tips for the visible viewport section, scroll to reveal more.
+- **Priority assignment**: assign tips only to the most-used sections; leave the rest for standard keyboard navigation.
+
+No immediate action is needed — the documentation site currently has 4 sections.
+
 ## Limitations
 
 - Maximum 9 key tips per scope (digits 1–9).
 - Currently limited to the main navigation; not yet applied to sub-navigation or other components.
 - The Alt trigger may not fire reliably if the browser intercepts the keyup event (rare, mostly on Linux with certain window managers).
+- No activation path on touch-only devices (by design — see above).


### PR DESCRIPTION
- Activate `e.preventDefault()` on Alt keydown to suppress browser menu bar (Windows/Linux) - Add `Alt+Space` shortcut to focus search input immediately - Auto-navigate on Enter when search shows a single result - Add touch-device and scalability notes to keytips docs - Declare `aria-keyshortcuts="Alt+Space"` on search input