### PR TITLE
chore: release v0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui-foundations",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui-foundations",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "devDependencies": {
         "@11ty/eleventy": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-foundations",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Token-first UI foundations with CSS, tokens, and React exports.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "repository": {


### PR DESCRIPTION
Bump version to 0.8.0 (minor release). Changes since v0.7.0: - Migrate hooks to v2 JSON format - Keytips: Alt preventDefault for menu bar suppression - Keytips: Alt+Space to focus search - Search: Enter navigates directly on single result - Keytips docs: touch device and scalability notes