### PR TITLE
chore: release v0.8.0 — README update, hook fix

### DIFF
--- a/.kiro/hooks/readme-release-update.json
+++ b/.kiro/hooks/readme-release-update.json
@@ -3,12 +3,12 @@
   "hooks": [
     {
       "name": "Update README on Release",
-      "description": "When package.json is edited (e.g. version bump for a release), remind the agent to update the README with the new version, any new components, changed features, or updated links.",
-      "trigger": "PostFileSave",
-      "matcher": "package\\.json$",
+      "description": "After a bash command runs, check if it was a version bump (npm version / release:minor etc.) and update the README accordingly.",
+      "trigger": "PostToolUse",
+      "matcher": "execute_bash",
       "action": {
         "type": "agent",
-        "prompt": "The package.json was just edited. If the version field changed, this is a release. Review the README.md and update it to reflect the new release: update any version references, add newly introduced components to the feature list if applicable, and ensure installation instructions and links are current. Keep the README concise and aligned with the existing tone and structure."
+        "prompt": "A bash command just completed. Check if it was a version bump (e.g. npm version, release:patch, release:minor, release:major). If it was, read package.json for the new version, then review README.md and update it: update any version references, add newly introduced components or features to the feature list if applicable, and ensure installation instructions and links are current. Keep the README concise and aligned with the existing tone and structure. If the command was NOT a version bump, do nothing."
       },
       "enabled": true
     }

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Patterns consume Semantic or Core tokens. Never raw values.
 
 ### Component Integration
 
-Every component ships with:
+Every pattern ships with:
 
 ```
  ┌────────────┬────────────┬────────────┐
@@ -107,7 +107,7 @@ Every component ships with:
  └────────────┴────────────┴────────────┘
 ```
 
-All surfaces must be present for the component to work predictably across
+All surfaces must be present for the pattern to work predictably across
 docs, playgrounds, and consumer apps.
 
 ---
@@ -252,7 +252,7 @@ Agents operate in modes:
  ├── validation/    ← CI pipeline, parity checks
  └── token-pipeline.md
  site/
- ├── components/    ← Component docs + playgrounds
+ ├── patterns/      ← Pattern docs + playgrounds
  ├── foundations/   ← Token and principle pages
  └── examples/     ← Usage examples
 ```
@@ -273,7 +273,7 @@ npm run docs:dev        # build + serve docs site
 ```
 ╭──────────────────────────────────────╮
 │ ╻╻· │ FOUNDATIONS                    │
-│ ┗┛╹ │ BUILD 0.7.0                    │
+│ ┗┛╹ │ BUILD 0.8.0                    │
 ╰──────────────────────────────────────╯
 █ ICONS                             [OK]
 ├ Entries                           0289
@@ -354,9 +354,9 @@ Figma integration uses the Model Context Protocol. Token exports live in
 - Validate before commit: `npm run ci:check`
 - Work on feature branches
 
-### Adding a New Component
+### Adding a New Pattern
 
-Load the `#component-creation` steering file for the full 10-phase workflow.
+Load the `#pattern-creation` steering file for the full 10-phase workflow.
 Key steps: semantic HTML first, then Figma tokens (bind variables, never hardcode),
 CSS pattern, Nunjucks macro, React wrapper, docs page, playground, Code Connect.
 
@@ -384,7 +384,7 @@ npm run release:publish
  ├────────────────┼───────────────────────────┤
  │ Design         │ Figma + MCP               │
  ├────────────────┼───────────────────────────┤
- │ Components     │ Vanilla CSS (@layer)      │
+ │ Patterns       │ Vanilla CSS (@layer)      │
  ├────────────────┼───────────────────────────┤
  │ Optional       │ React wrappers            │
  └────────────────┴───────────────────────────┘
@@ -395,6 +395,7 @@ npm run release:publish
 ## Roadmap
 
 - **Calendar Component** — first functional component with state, date logic, and keyboard navigation. Built on top of existing patterns.
+- **Navigation Key Tips** — experimental Alt-triggered keyboard shortcuts for fast docs navigation (available now).
 - **Web Components** — replace React wrappers with framework-agnostic custom elements (light DOM, no shadow DOM) so patterns are truly platform-independent (#104).
 
 ---


### PR DESCRIPTION
- Bump version to 0.8.0 - Update README: rename components → patterns throughout, update version refs, add keytips to roadmap - Fix readme-release-update hook: trigger on PostToolUse/execute_bash instead of PostFileSave