### PR TITLE
fix: add prefers-reduced-motion reset for accessibility

### DIFF
--- a/src/core/base/reset.css
+++ b/src/core/base/reset.css
@@ -45,4 +45,15 @@
   h6 {
     overflow-wrap: break-word;
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Adds a global `prefers-reduced-motion: reduce` media query to the reset layer that disables transitions, animations, and smooth scrolling for users who request reduced motion.

## What changed

- `src/core/base/reset.css` — added `@media (prefers-reduced-motion: reduce)` block

## Why

Six patterns (accordion, link, select, tabs, textarea, tooltip) use CSS transitions but the system had no reduced-motion support. This is a WCAG 2.1 SC 2.3.3 accessibility requirement.

A single rule in the reset layer covers all current and future patterns without modifying individual files.

## Checks run

- `npm run ci:check` ✅ (lint, unit tests, build, smoke, token validation, asset check, rule validation, docs build)
- Pre-commit hooks ✅

## Risks

- `!important` is intentional here — it ensures the override applies regardless of specificity in individual patterns. This is a well-established pattern (used by A11y Project, HTML5 Boilerplate, etc.)
- Duration is `0.01ms` rather than `0s` to avoid edge cases where some browsers fire transition/animation-end events incorrectly with zero duration

## No new tokens

No CSS variables were invented. This is pure CSS behavior, not token-dependent.