### PR TITLE
fix: add .is-disabled class to button disabled state

### DIFF
--- a/src/ui/patterns/button.css
+++ b/src/ui/patterns/button.css
@@ -151,12 +151,14 @@
   }
 
   .button:disabled,
-  .button[disabled] {
+  .button[disabled],
+  .button.is-disabled {
     cursor: not-allowed;
     opacity: 0.6;
     background: var(--button-container-background-disabled);
     border-color: var(--button-border-color-disabled);
     color: var(--button-text-color-disabled);
+    pointer-events: none;
   }
 
   .button-group {


### PR DESCRIPTION
## Summary

The button pattern was the only interactive pattern missing `.is-disabled` class support in its disabled rule. All other patterns (input, select, textarea, checkbox, radio, switch, link, accordion, tabs) already support it.

## Changes

- **`src/ui/patterns/button.css`**: Added `.button.is-disabled` selector to the disabled rule and `pointer-events: none` to prevent hover/active style leakage when disabled via class (native `:disabled` already blocks pointer events, but the class path does not).

## Why

- Consistency: every other interactive pattern supports `.is-disabled` for state demonstration in docs, playgrounds, and Code Connect previews.
- Correctness: without `pointer-events: none`, a `.button.is-disabled` element would still show hover/active styles because `:disabled` only applies to actually-disabled form elements.

## Checks

- `npm run ci:check` ✅ (lint, unit tests, build, smoke, token validation, asset check, rule validation, docs build)

## Risk

Minimal. Additive change — no existing selectors are modified, only a new class selector added to an existing rule.