### PR TITLE
fix: correct broken package export for component tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "./tokens/color-light.css": "./dist/tokens/css/appearance-modes.tokens.mode-light.css",
     "./tokens/color-dark.css": "./dist/tokens/css/appearance-modes.tokens.mode-dark.css",
     "./tokens/semantic.css": "./dist/tokens/css/semantics-roles.tokens.css",
-    "./tokens/components.css": "./dist/tokens/css/components-ui.tokens.css",
+    "./tokens/components.css": "./dist/tokens/css/patterns-ui.tokens.css",
     "./macros/ui.njk": "./dist/macros/ui.njk"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

The `exports` field in `package.json` mapped `./tokens/components.css` to a non-existent file:

```
"./tokens/components.css": "./dist/tokens/css/components-ui.tokens.css"
```

The actual generated file is `patterns-ui.tokens.css`. Any consumer importing `ui-foundations/tokens/components.css` would get a module resolution error.

## Change

Updated the path to point to the correct file:

```
"./tokens/components.css": "./dist/tokens/css/patterns-ui.tokens.css"
```

## Checks

- `npm run ci:check` passes (lint, unit tests, build, smoke, token validation, DTCG, assets, rules, docs)
- Pre-commit hooks pass

## Risk

**Very low.** This fixes a broken path — no behavior change for existing consumers who weren't using this export (it never resolved). Consumers who attempt to use it will now succeed.