### PR TITLE
fix: handle DTCG dimension type in token generator

### DIFF
--- a/scripts/extract-tokens.value.js
+++ b/scripts/extract-tokens.value.js
@@ -136,6 +136,14 @@ function formatTokenValue(token, rawValue, tokenKey, segments) {
     }
   }
 
+  if (type === "dimension") {
+    if (rawValue && typeof rawValue === "object" && rawValue.value !== undefined) {
+      const num = Number(rawValue.value);
+      if (rawValue.unit === "rem") return `${num}rem`;
+      return formatLength(num);
+    }
+  }
+
   if (lowerKey.startsWith("zindex-") || lowerKey.startsWith("z-index-")) {
     return rawValue;
   }

--- a/tests/extract-tokens.scope-value.test.mjs
+++ b/tests/extract-tokens.scope-value.test.mjs
@@ -95,3 +95,24 @@ test("resolveTokenOutputValue falls back to CSS var for unresolved non-font alia
     "var(--color-text-default)",
   );
 });
+
+test("formatTokenValue handles DTCG dimension objects", () => {
+  assert.equal(
+    formatTokenValue(
+      { type: "dimension" },
+      { value: 40, unit: "px" },
+      "select-height",
+      ["Select", "Height"],
+    ),
+    "2.5rem",
+  );
+  assert.equal(
+    formatTokenValue(
+      { type: "dimension" },
+      { value: 1.5, unit: "rem" },
+      "select-height",
+      ["Select", "Height"],
+    ),
+    "1.5rem",
+  );
+});


### PR DESCRIPTION
## Summary

The token generator did not handle `$type: "dimension"` tokens (DTCG 2025.10 format where `$value` is an object `{ value, unit }`). This caused `--select-height` to render as `[object Object]` in generated CSS, making the select pattern fall back to its hardcoded CSS fallback (`2.5rem`) instead of resolving from the token layer.

## Changes

- **`scripts/extract-tokens.value.js`** — Add a `type === "dimension"` branch to `formatTokenValue()` that extracts the numeric value and converts px→rem via `formatLength()`, consistent with how `type === "number"` tokens are processed.
- **`tests/extract-tokens.scope-value.test.mjs`** — Add unit test covering both px and rem dimension objects.

## Generated output (after fix)

```css
/* Before */
--select-height: [object Object];

/* After */
--select-height: 2.5rem;
```

## Validation

- `npm run ci:check` passes (lint → test:unit → build:all → smoke → tokens:validate → dtcg:validate → rules:validate → docs:build)
- No `[object Object]` remains anywhere in dist/
- Token drift: 0 (verified via MCP diagnose_drift)

## Risk

Low. The fix adds handling for a previously-unhandled DTCG type. Only one token in the current Figma export uses `$type: dimension`, but future exports may add more as Figma migrates variable types toward DTCG compliance.