### PR TITLE
fix: add elements bundle to smoke check

### DIFF
--- a/scripts/smoke-check.mjs
+++ b/scripts/smoke-check.mjs
@@ -42,6 +42,23 @@ function ensureTokenCssFiles(minCount = 5) {
   }
 }
 
+function ensureElementsBundle(minCount = 10) {
+  const elementsDir = path.join(REPO_ROOT, "dist", "elements");
+  if (!fs.existsSync(elementsDir)) {
+    fail("Missing dist/elements");
+  }
+
+  const files = fs
+    .readdirSync(elementsDir)
+    .filter((name) => name.endsWith(".js"));
+
+  if (files.length < minCount) {
+    fail(
+      `Expected at least ${minCount} element JS files in dist/elements, found ${files.length}`,
+    );
+  }
+}
+
 function run() {
   ensureFile("dist/main.css", { nonEmpty: true, mustInclude: ".button" });
   ensureFile("dist/tokens/tokens.yaml", {
@@ -52,7 +69,9 @@ function run() {
     nonEmpty: true,
   });
   ensureFile("dist/react/index.js", { nonEmpty: true });
+  ensureFile("dist/elements/index.js", { nonEmpty: true });
   ensureTokenCssFiles();
+  ensureElementsBundle();
 
   console.log("✅ Smoke checks passed");
 }


### PR DESCRIPTION
## Summary

The web components bundle (`dist/elements/`) is exported in `package.json` but was not verified by the smoke check script. If `buildElementsBundle()` failed silently during build, consumers would get broken `./elements` imports at runtime.

## Changes

- `scripts/smoke-check.mjs`: Added `ensureFile` check for `dist/elements/index.js` and a new `ensureElementsBundle()` function that asserts at least 10 `.js` files exist in `dist/elements/`.

## What was tested

- `npm run ci:check` passes (lint, unit tests, build, smoke, token validation, DTCG, assets, rules, docs build)

## Risks

- None. This is additive validation only — no behavior change for consumers.