### PR TITLE
fix(ci): add smoke checks for dist/macros and dist/ui artifacts

### DIFF
--- a/scripts/smoke-check.mjs
+++ b/scripts/smoke-check.mjs
@@ -70,6 +70,11 @@ function run() {
   });
   ensureFile("dist/react/index.js", { nonEmpty: true });
   ensureFile("dist/elements/index.js", { nonEmpty: true });
+  ensureFile("dist/macros/ui.njk", { nonEmpty: true, mustInclude: "macro" });
+  ensureFile("dist/ui/index.css", {
+    nonEmpty: true,
+    mustInclude: "layer(components)",
+  });
   ensureTokenCssFiles();
   ensureElementsBundle();
 


### PR DESCRIPTION
## Summary

Add smoke-check assertions for two critical build artifacts that were previously unvalidated:

- **`dist/macros/ui.njk`** — Nunjucks macro bundle consumed by the docs site and external consumers. Asserts the file exists, is non-empty, and contains `macro` (indicating valid macro content).
- **`dist/ui/index.css`** — UI pattern entry point for consumer CSS imports. Asserts the file exists, is non-empty, and contains `layer(components)` (confirming correct CSS layer assignment).

## What was tested

- `npm run ci:check` passes (lint → test:unit → build:all → smoke:check → tokens:validate → tokens:usage → dtcg:validate → assets:check → rules:validate → docs:build)
- Pre-commit hooks pass (70/70 tests)

## Risk

**None.** This change only adds assertions to the validation pipeline — it cannot break builds, only catch regressions earlier.

## Follow-up

None required. If future build changes accidentally omit these artifacts, the smoke check will catch it.