### PR TITLE
refactor: migrate all BEM __ class names to hyphen-compound (Foundation-013)

### DIFF
--- a/schemas/web-accordion.figma.ts
+++ b/schemas/web-accordion.figma.ts
@@ -11,7 +11,7 @@ figma.connect(
     example: ({ open, title }: AccordionItemProps) =>
       html`<details class="accordion-item" ${open}>
   <summary>${title}</summary>
-  <div class="accordion-item__content">
+  <div class="accordion-item-content">
     <p>Content</p>
   </div>
 </details>`,

--- a/schemas/web-avatar.figma.ts
+++ b/schemas/web-avatar.figma.ts
@@ -18,6 +18,6 @@ figma.connect(
       initials: figma.string("Initials"),
     },
     example: ({ className, initials }: AvatarProps) =>
-      html`<span class="${className}" role="img" aria-label="${initials}"><span class="avatar__initials">${initials}</span></span>`,
+      html`<span class="${className}" role="img" aria-label="${initials}"><span class="avatar-initials">${initials}</span></span>`,
   },
 );

--- a/schemas/web-badge.figma.ts
+++ b/schemas/web-badge.figma.ts
@@ -21,6 +21,6 @@ figma.connect(
       text: figma.string("Text"),
     },
     example: ({ className, text }: BadgeProps) =>
-      html`<span class="${className}"><span class="badge__text">${text}</span></span>`,
+      html`<span class="${className}"><span class="badge-text">${text}</span></span>`,
   },
 );

--- a/schemas/web-button.figma.ts
+++ b/schemas/web-button.figma.ts
@@ -19,9 +19,9 @@ figma.connect(
         }),
         figma.enum("Icon Only", {
           False: undefined,
-          True: "button--icon-only",
+          True: "icon-only",
           false: undefined,
-          true: "button--icon-only",
+          true: "icon-only",
         }),
       ]),
       disabled: figma.boolean("Disabled"),
@@ -40,7 +40,7 @@ figma.connect(
       aria-label="${ariaLabel}"
     >
       <span class="label-content">
-        <span class="label-content__text">${text}</span>
+        <span class="label-content-text">${text}</span>
       </span>
     </button>`,
   },

--- a/schemas/web-checkbox.figma.ts
+++ b/schemas/web-checkbox.figma.ts
@@ -86,7 +86,7 @@ figma.connect(
         checked="${checked}"
         disabled="${disabled}"
       />
-      <span class="checkbox-field__text">${text}</span>
+      <span class="checkbox-field-text">${text}</span>
     </label>`,
   },
 );

--- a/schemas/web-form.figma.ts
+++ b/schemas/web-form.figma.ts
@@ -17,12 +17,12 @@ figma.connect(
       }),
     },
     example: ({ state, helperText }: FormProps) => html`<div
-      class="form__field"
+      class="form-field"
       data-state="${state}"
     >
       <label class="field-label" for="form-field-input" style="line-height: 24px;">
         <span class="label-content">
-          <span class="label-content__text">Field label</span>
+          <span class="label-content-text">Field label</span>
         </span>
       </label>
       <input
@@ -31,7 +31,7 @@ figma.connect(
         type="text"
         placeholder="Enter value"
       />
-      <p class="form__helper">
+      <p class="form-field-helper">
         ${helperText}
       </p>
     </div>`,

--- a/schemas/web-input.figma.ts
+++ b/schemas/web-input.figma.ts
@@ -36,7 +36,7 @@ figma.connect(
     readonly="${readonlyAttr}"
     disabled="${disabled}"
   />
-  <span class="input-field__control">
+  <span class="input-field-control">
     <!-- Control buttons rendered by type -->
   </span>
 </div>`,

--- a/schemas/web-label.figma.ts
+++ b/schemas/web-label.figma.ts
@@ -13,7 +13,7 @@ figma.connect(
     },
     example: ({ className, text }: LabelProps) => html`<span style="line-height: 24px;">
       <span class="${className}">
-        <span class="label-content__text">${text}</span>
+        <span class="label-content-text">${text}</span>
       </span>
     </span>`,
   },

--- a/schemas/web-radio.figma.ts
+++ b/schemas/web-radio.figma.ts
@@ -64,7 +64,7 @@ figma.connect(
         checked="${checked}"
         disabled="${disabled}"
       />
-      <span class="radio-field__text">${text}</span>
+      <span class="radio-field-text">${text}</span>
     </label>`,
   },
 );

--- a/schemas/web-switch.figma.ts
+++ b/schemas/web-switch.figma.ts
@@ -75,7 +75,7 @@ figma.connect(
         checked="${checked}"
         disabled="${disabled}"
       />
-      <span class="switch-field__text">${text}</span>
+      <span class="switch-field-text">${text}</span>
     </label>`,
   },
 );

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -27,7 +27,7 @@
 {%- if className -%}{%- set wrapperClasses = wrapperClasses + " " + className -%}{%- endif -%}
 <div class="{{ wrapperClasses }}">
   <input class="input" type="{{ type }}"{% if id %} id="{{ id }}"{% endif %}{% if name %} name="{{ name }}"{% endif %}{% if placeholder %} placeholder="{{ placeholder }}"{% endif %}{% if value %} value="{{ value }}"{% endif %}{% if dataPlaygroundControl %} data-playground-control{% endif %}{% if dataProp %} data-prop="{{ dataProp }}"{% endif %}{% if dataSource %} data-source="{{ dataSource }}"{% endif %}{% if dataValueType %} data-value-type="{{ dataValueType }}"{% endif %}{% if dataQueryParam %} data-query-param="{{ dataQueryParam }}"{% endif %}{% if disabled or state == "disabled" %} disabled{% endif %} />
-  <span class="input-field__control">
+  <span class="input-field-control">
     {%- if type == "text" or type == "email" or type == "search" or type == "url" or type == "tel" -%}
     <button type="button" aria-label="Clear input" tabindex="-1"><span class="icon" style="--icon-src: url('/assets/icons/cross-circled.svg');" aria-hidden="true"></span></button>
     {%- elif type == "number" -%}
@@ -56,7 +56,7 @@
 {%- if wrapperClassName -%}{%- set fieldClasses = fieldClasses + " " + wrapperClassName -%}{%- endif -%}
 <label class="{{ fieldClasses }}">
   <input class="{{ checkboxClasses }}" type="checkbox"{% if id %} id="{{ id }}"{% endif %}{% if name %} name="{{ name }}"{% endif %}{% if value %} value="{{ value }}"{% endif %}{% if checked %} checked{% endif %}{% if indeterminate or state == "indeterminate" %} aria-checked="mixed"{% endif %}{% if disabled or state == "disabled" %} disabled{% endif %} />
-  <span class="checkbox-field__text">{{ label }}</span>
+  <span class="checkbox-field-text">{{ label }}</span>
 </label>
 {%- endmacro %}
 
@@ -75,7 +75,7 @@
 {%- if wrapperClassName -%}{%- set fieldClasses = fieldClasses + " " + wrapperClassName -%}{%- endif -%}
 <label class="{{ fieldClasses }}">
   <input class="{{ radioClasses }}" type="radio"{% if id %} id="{{ id }}"{% endif %}{% if name %} name="{{ name }}"{% endif %}{% if value %} value="{{ value }}"{% endif %}{% if checked %} checked{% endif %}{% if disabled or state == "disabled" %} disabled{% endif %} />
-  <span class="radio-field__text">{{ label }}</span>
+  <span class="radio-field-text">{{ label }}</span>
 </label>
 {%- endmacro %}
 
@@ -94,7 +94,7 @@
 {%- if wrapperClassName -%}{%- set fieldClasses = fieldClasses + " " + wrapperClassName -%}{%- endif -%}
 <label class="{{ fieldClasses }}">
   <input class="{{ switchClasses }}" type="checkbox" role="switch"{% if id %} id="{{ id }}"{% endif %}{% if name %} name="{{ name }}"{% endif %}{% if value %} value="{{ value }}"{% endif %}{% if checked %} checked{% endif %}{% if disabled or state == "disabled" %} disabled{% endif %} />
-  <span class="switch-field__text">{{ label }}</span>
+  <span class="switch-field-text">{{ label }}</span>
 </label>
 {%- endmacro %}
 
@@ -114,7 +114,7 @@
 {% macro labelContent(text='', startIcon='', endIcon='', iconOnly=false) -%}
 <span class="label-content{% if iconOnly %} is-icon-only{% endif %}">
   {%- if startIcon %}<span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/{{ startIcon }}.svg');" aria-hidden="true"></span>{% endif -%}
-  {%- if not iconOnly %}<span class="label-content__text">{{ text }}</span>{% endif -%}
+  {%- if not iconOnly %}<span class="label-content-text">{{ text }}</span>{% endif -%}
   {%- if endIcon %}<span class="icon" data-slot="end" style="--icon-src: url('/assets/icons/{{ endIcon }}.svg');" aria-hidden="true"></span>{% endif -%}
 </span>
 {%- endmacro %}
@@ -123,11 +123,11 @@
 <label class="field-label"{% if htmlFor %} for="{{ htmlFor }}"{% endif %}>
   <span class="label-content">
     {%- if startIcon %}<span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/{{ startIcon }}.svg');" aria-hidden="true"></span>{% endif -%}
-    <span class="label-content__text">{{ text }}</span>
+    <span class="label-content-text">{{ text }}</span>
   </span>
   {%- if required %}
-  <span class="field-label__required" aria-hidden="true">*</span>
-  <span class="field-label__required-text"> (required)</span>
+  <span class="field-label-required" aria-hidden="true">*</span>
+  <span class="field-label-required-text"> (required)</span>
   {%- endif %}
 </label>
 {%- endmacro %}
@@ -149,7 +149,7 @@
 {%- if size == "sm" -%}{%- set classes = classes + " sm" -%}{%- endif -%}
 <span class="{{ classes }}">
   {%- if startIcon %}<span class="icon" style="--icon-src: url('/assets/icons/{{ startIcon }}.svg');" aria-hidden="true"></span>{% endif -%}
-  <span class="badge__text">{{ text }}</span>
+  <span class="badge-text">{{ text }}</span>
 </span>
 {%- endmacro %}
 
@@ -174,7 +174,7 @@
 {%- if size and size != "md" -%}{%- set classes = classes + " " + size -%}{%- endif -%}
 {%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
 <span class="{{ classes }}" role="img" aria-label="{{ alt or initials }}">
-  {%- if src -%}<img src="{{ src }}" alt="{{ alt }}" />{%- else -%}<span class="avatar__initials">{{ initials }}</span>{%- endif -%}
+  {%- if src -%}<img src="{{ src }}" alt="{{ alt }}" />{%- else -%}<span class="avatar-initials">{{ initials }}</span>{%- endif -%}
 </span>
 {%- endmacro %}
 
@@ -189,7 +189,7 @@
 {%- if disabled -%}{%- set classes = classes + " is-disabled" -%}{%- endif -%}
 <details class="{{ classes }}"{% if open %} open{% endif %}>
   <summary>{{ title }}</summary>
-  <div class="accordion-item__content">{{ caller() }}</div>
+  <div class="accordion-item-content">{{ caller() }}</div>
 </details>
 {%- endmacro %}
 
@@ -237,7 +237,7 @@
 {%- set classes = "form-group" -%}
 {%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
 <fieldset class="{{ classes }}">
-  {%- if title %}<legend class="form-group__title">{{ title }}</legend>{% endif -%}
+  {%- if title %}<legend class="form-group-title">{{ title }}</legend>{% endif -%}
   {{ caller() }}
 </fieldset>
 {%- endmacro %}
@@ -277,7 +277,7 @@
 {%- endmacro %}
 
 {% macro formHelper(text='') -%}
-<p class="form-field__helper">{{ text }}</p>
+<p class="form-field-helper">{{ text }}</p>
 {%- endmacro %}
 
 {% macro formActions(align='end', className='') -%}

--- a/site/assets/docs.css
+++ b/site/assets/docs.css
@@ -2171,13 +2171,13 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
   margin-bottom: 1rem;
 }
 
-.color-ramp__step {
+.color-ramp-step {
   flex: 1;
   min-width: 0;
   transition: flex 180ms ease;
 }
 
-.color-ramp__step:hover {
+.color-ramp-step:hover {
   flex: 2;
 }
 
@@ -2232,7 +2232,7 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
 }
 
 /* Preview dot */
-.color-table__preview {
+.color-table-preview {
   width: 40px;
   padding-right: 0;
 }
@@ -2248,12 +2248,12 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
 }
 
 /* Columns */
-.color-table__name {
+.color-table-name {
   font-weight: 600;
   white-space: nowrap;
 }
 
-.color-table__token code {
+.color-table-token code {
   font-size: 0.78rem;
   padding: 2px 6px;
   border-radius: 4px;
@@ -2261,14 +2261,14 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
   word-break: break-all;
 }
 
-.color-table__contrast {
+.color-table-contrast {
   font-family: var(--docs-code-font);
   font-size: 0.78rem;
   color: var(--docs-text-1);
   white-space: nowrap;
 }
 
-.color-table__hex code {
+.color-table-hex code {
   font-size: 0.78rem;
   color: var(--docs-text-1);
 }
@@ -2345,7 +2345,7 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
   overflow: hidden;
 }
 
-.type-specimen__sample {
+.type-specimen-sample {
   padding: 32px 24px 24px;
   background: var(--docs-surface-2);
   border-bottom: 1px solid var(--docs-border);
@@ -2354,18 +2354,18 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
   gap: 12px;
 }
 
-.type-specimen__sample * {
+.type-specimen-sample * {
   font-family: inherit;
 }
 
-.type-specimen__large {
+.type-specimen-large {
   font-size: 4rem;
   font-weight: 400;
   line-height: 1;
   letter-spacing: -0.02em;
 }
 
-.type-specimen__alphabet {
+.type-specimen-alphabet {
   font-size: 0.92rem;
   line-height: 1.6;
   color: var(--docs-text-1);
@@ -2373,7 +2373,7 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
   word-break: break-all;
 }
 
-.type-specimen__meta {
+.type-specimen-meta {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -2381,12 +2381,12 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
   padding: 14px 24px;
 }
 
-.type-specimen__name {
+.type-specimen-name {
   font-size: 0.92rem;
   font-weight: 700;
 }
 
-.type-specimen__token {
+.type-specimen-token {
   font-size: 0.78rem;
   padding: 3px 8px;
   border-radius: 6px;
@@ -2435,7 +2435,7 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
   background: rgba(37, 99, 235, 0.02);
 }
 
-.type-scale-table__size {
+.type-scale-table-size {
   width: 80px;
   font-size: 0.78rem;
   font-weight: 700;
@@ -2443,28 +2443,28 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
   white-space: nowrap;
 }
 
-.type-scale-table__class {
+.type-scale-table-class {
   width: 240px;
   white-space: nowrap;
 }
 
-.type-scale-table__class code {
+.type-scale-table-class code {
   font-size: 0.78rem;
   padding: 2px 6px;
   border-radius: 4px;
   background: var(--docs-surface-2);
 }
 
-.type-scale-table__sample {
+.type-scale-table-sample {
   color: var(--docs-text-0);
 }
 
-.type-scale-table__sample .heading-xxxl,
-.type-scale-table__sample .heading-xxl,
-.type-scale-table__sample .heading-xl,
-.type-scale-table__sample .heading-lg,
-.type-scale-table__sample .heading-md,
-.type-scale-table__sample .heading-sm {
+.type-scale-table-sample .heading-xxxl,
+.type-scale-table-sample .heading-xxl,
+.type-scale-table-sample .heading-xl,
+.type-scale-table-sample .heading-lg,
+.type-scale-table-sample .heading-md,
+.type-scale-table-sample .heading-sm {
   margin: 0;
   color: inherit;
 }
@@ -2517,14 +2517,14 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
   background: var(--docs-surface-2);
 }
 
-.type-token-table__value {
+.type-token-table-value {
   font-family: var(--docs-code-font);
   font-size: 0.82rem;
   color: var(--docs-text-1);
   white-space: nowrap;
 }
 
-.type-token-table__preview {
+.type-token-table-preview {
   color: var(--docs-text-0);
 }
 
@@ -2550,7 +2550,7 @@ html[data-brand="c"] .palette-group[data-brand-scope="b"] {
   text-align: center;
 }
 
-.pipeline-step__label {
+.pipeline-step-label {
   font-family: var(--docs-code-font);
   font-size: 0.82rem;
   font-weight: 600;
@@ -2612,7 +2612,7 @@ details.color-family[open] {
   margin-bottom: 16px;
 }
 
-.color-family__summary {
+.color-family-summary {
   display: flex;
   align-items: center;
   gap: 12px;
@@ -2623,22 +2623,22 @@ details.color-family[open] {
   transition: background 120ms ease;
 }
 
-.color-family__summary::-webkit-details-marker {
+.color-family-summary::-webkit-details-marker {
   display: none;
 }
 
-.color-family__summary:hover {
+.color-family-summary:hover {
   background: var(--docs-surface-2);
 }
 
-.color-family__name {
+.color-family-name {
   font-size: 0.9rem;
   font-weight: 700;
   color: var(--docs-text-0);
   min-width: 140px;
 }
 
-.color-family__ramp {
+.color-family-ramp {
   display: flex;
   flex: 1;
   height: 24px;
@@ -2647,7 +2647,7 @@ details.color-family[open] {
   border: 1px solid rgba(0, 0, 0, 0.06);
 }
 
-.color-family__ramp-step {
+.color-family-ramp-step {
   flex: 1;
   min-width: 0;
 }

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -104,7 +104,7 @@
 
     if (variant === "outline") classes.push("outline");
     if (variant === "ghost") classes.push("ghost");
-    if (resolvedIconOnly) classes.push("button--icon-only");
+    if (resolvedIconOnly) classes.push("icon-only");
     if (previewState === "hover") classes.push("is-hover");
     if (previewState === "active") classes.push("is-active");
     if (previewState === "focus") classes.push("is-focus-visible");
@@ -127,7 +127,7 @@
 
     if (!resolvedIconOnly && hasText) {
       const textNode = document.createElement("span");
-      textNode.className = "label-content__text";
+      textNode.className = "label-content-text";
       textNode.textContent = rawLabel;
       content.append(textNode);
     }
@@ -149,7 +149,7 @@
     const codeContent = [
       labelIconCode(iconStart, "start"),
       !resolvedIconOnly && hasText
-        ? `<span class="label-content__text">${quoteAttr(rawLabel)}</span>`
+        ? `<span class="label-content-text">${quoteAttr(rawLabel)}</span>`
         : "",
       labelIconCode(iconEnd, "end"),
     ]
@@ -224,7 +224,7 @@
 
     if (!iconOnly && hasText) {
       const textElement = document.createElement("span");
-      textElement.className = "label-content__text";
+      textElement.className = "label-content-text";
       textElement.textContent = text;
       labelContent.append(textElement);
     }
@@ -236,13 +236,13 @@
 
     if (mode === "field" && required) {
       const requiredMarker = document.createElement("span");
-      requiredMarker.className = "field-label__required";
+      requiredMarker.className = "field-label-required";
       requiredMarker.setAttribute("aria-hidden", "true");
       requiredMarker.textContent = "*";
       host.append(requiredMarker);
 
       const requiredText = document.createElement("span");
-      requiredText.className = "field-label__required-text";
+      requiredText.className = "field-label-required-text";
       requiredText.textContent = " (required)";
       host.append(requiredText);
     }
@@ -255,7 +255,7 @@
     const contentMarkup = [
       labelIconCode(iconStart, "start"),
       !iconOnly && hasText
-        ? `<span class="label-content__text">${quoteAttr(text)}</span>`
+        ? `<span class="label-content-text">${quoteAttr(text)}</span>`
         : "",
       labelIconCode(iconEnd, "end"),
     ]
@@ -264,7 +264,7 @@
 
     if (mode === "field") {
       const requiredMarkup = required
-        ? '<span class="field-label__required" aria-hidden="true">*</span><span class="field-label__required-text"> (required)</span>'
+        ? '<span class="field-label-required" aria-hidden="true">*</span><span class="field-label-required-text"> (required)</span>'
         : "";
       const code = `<label for="${quoteAttr(forId)}" class="field-label" style="${quoteAttr(hostStyleEntries.join("; "))}"><span class="${quoteAttr(contentClasses.join(" "))}">${contentMarkup}</span>${requiredMarkup}</label>`;
       return { element: host, code };
@@ -303,7 +303,7 @@
     wrapper.appendChild(input);
 
     const control = document.createElement("span");
-    control.className = "input-field__control";
+    control.className = "input-field-control";
 
     let controlIcons = [];
     if (type === "number") {
@@ -356,7 +356,7 @@
 
     const code = `<div class="${quoteAttr(wrapper.className)}">
   <input ${inputAttrs.join(" ")} />
-  <span class="input-field__control">
+  <span class="input-field-control">
     ${controlCode}
   </span>
 </div>`;
@@ -395,7 +395,7 @@
     if (indeterminate) input.setAttribute("aria-checked", "mixed");
 
     const text = document.createElement("span");
-    text.className = "checkbox-field__text";
+    text.className = "checkbox-field-text";
     text.textContent = labelText;
 
     wrapper.append(input, text);
@@ -408,7 +408,7 @@
     if (indeterminate) attrs.push('aria-checked="mixed"');
     if (disabled) attrs.push("disabled");
 
-    const code = `<label class="${quoteAttr(wrapper.className)}"><input ${attrs.join(" ")} /><span class="checkbox-field__text">${quoteAttr(labelText)}</span></label>`;
+    const code = `<label class="${quoteAttr(wrapper.className)}"><input ${attrs.join(" ")} /><span class="checkbox-field-text">${quoteAttr(labelText)}</span></label>`;
     return { element: wrapper, code };
   };
 
@@ -440,7 +440,7 @@
     input.setAttribute("role", "switch");
 
     const text = document.createElement("span");
-    text.className = "switch-field__text";
+    text.className = "switch-field-text";
     text.textContent = labelText;
 
     wrapper.append(input, text);
@@ -453,7 +453,7 @@
     if (checked) attrs.push("checked");
     if (disabled) attrs.push("disabled");
 
-    const code = `<label class="${quoteAttr(wrapper.className)}"><input ${attrs.join(" ")} /><span class="switch-field__text">${quoteAttr(labelText)}</span></label>`;
+    const code = `<label class="${quoteAttr(wrapper.className)}"><input ${attrs.join(" ")} /><span class="switch-field-text">${quoteAttr(labelText)}</span></label>`;
     return { element: wrapper, code };
   };
 
@@ -558,7 +558,7 @@
     input.disabled = disabled;
 
     const text = document.createElement("span");
-    text.className = "radio-field__text";
+    text.className = "radio-field-text";
     text.textContent = labelText;
 
     wrapper.append(input, text);
@@ -570,7 +570,7 @@
     if (checked) attrs.push("checked");
     if (disabled) attrs.push("disabled");
 
-    const code = `<label class="${quoteAttr(wrapper.className)}"><input ${attrs.join(" ")} /><span class="radio-field__text">${quoteAttr(labelText)}</span></label>`;
+    const code = `<label class="${quoteAttr(wrapper.className)}"><input ${attrs.join(" ")} /><span class="radio-field-text">${quoteAttr(labelText)}</span></label>`;
     return { element: wrapper, code };
   };
 
@@ -593,13 +593,13 @@
     }
 
     const textSpan = document.createElement("span");
-    textSpan.className = "badge__text";
+    textSpan.className = "badge-text";
     textSpan.textContent = rawText;
     element.append(textSpan);
 
     const codeClasses = classes.map((c) => quoteAttr(c)).join(" ");
     const iconMarkup = startIcon ? iconCode({ name: startIcon, decorative: true }) : "";
-    const code = `<span class="${codeClasses}">${iconMarkup}<span class="badge__text">${quoteAttr(rawText)}</span></span>`;
+    const code = `<span class="${codeClasses}">${iconMarkup}<span class="badge-text">${quoteAttr(rawText)}</span></span>`;
 
     return { element, code };
   };
@@ -646,7 +646,7 @@
       element.append(img);
     } else {
       const span = document.createElement("span");
-      span.className = "avatar__initials";
+      span.className = "avatar-initials";
       span.textContent = initials;
       element.append(span);
     }
@@ -654,7 +654,7 @@
     const codeClasses = classes.join(" ");
     const inner = src
       ? `<img src="${quoteAttr(src)}" alt="${quoteAttr(initials)}" />`
-      : `<span class="avatar__initials">${quoteAttr(initials)}</span>`;
+      : `<span class="avatar-initials">${quoteAttr(initials)}</span>`;
     const code = `<span class="${codeClasses}" role="img" aria-label="${quoteAttr(initials)}">${inner}</span>`;
 
     return { element, code };
@@ -675,7 +675,7 @@
       const summary = document.createElement("summary");
       summary.textContent = `Item ${i + 1}`;
       const content = document.createElement("div");
-      content.className = "accordion-item__content";
+      content.className = "accordion-item-content";
       content.innerHTML = `<p>Content for item ${i + 1}</p>`;
       details.append(summary, content);
       wrapper.append(details);
@@ -683,7 +683,7 @@
       const openAttr = i === openIndex ? " open" : "";
       codeLines.push(`  <details class="accordion-item"${openAttr}>`);
       codeLines.push(`    <summary>Item ${i + 1}</summary>`);
-      codeLines.push(`    <div class="accordion-item__content"><p>Content for item ${i + 1}</p></div>`);
+      codeLines.push(`    <div class="accordion-item-content"><p>Content for item ${i + 1}</p></div>`);
       codeLines.push(`  </details>`);
     }
     codeLines.push("</div>");
@@ -781,7 +781,7 @@
 
     const label1 = document.createElement("label");
     label1.className = "field-label";
-    label1.innerHTML = '<span class="label-content"><span class="label-content__text">Email</span></span><span class="field-label__required" aria-hidden="true">*</span>';
+    label1.innerHTML = '<span class="label-content"><span class="label-content-text">Email</span></span><span class="field-label-required" aria-hidden="true">*</span>';
 
     const input1 = document.createElement("input");
     input1.className = "input";
@@ -790,11 +790,11 @@
 
     if (labelPosition === "side") {
       const body1 = document.createElement("div");
-      body1.className = "form-field__body";
+      body1.className = "form-field-body";
       body1.append(input1);
       if (invalid) {
         const helper = document.createElement("p");
-        helper.className = "form-field__helper";
+        helper.className = "form-field-helper";
         helper.textContent = "Please enter a valid email address.";
         body1.append(helper);
       }
@@ -803,7 +803,7 @@
       field1.append(label1, input1);
       if (invalid) {
         const helper = document.createElement("p");
-        helper.className = "form-field__helper";
+        helper.className = "form-field-helper";
         helper.textContent = "Please enter a valid email address.";
         field1.append(helper);
       }
@@ -816,7 +816,7 @@
 
     const label2 = document.createElement("label");
     label2.className = "field-label";
-    label2.innerHTML = '<span class="label-content"><span class="label-content__text">Password</span></span>';
+    label2.innerHTML = '<span class="label-content"><span class="label-content-text">Password</span></span>';
 
     const input2 = document.createElement("input");
     input2.className = "input";
@@ -824,7 +824,7 @@
 
     if (labelPosition === "side") {
       const body2 = document.createElement("div");
-      body2.className = "form-field__body";
+      body2.className = "form-field-body";
       body2.append(input2);
       field2.append(label2, body2);
     } else {
@@ -839,7 +839,7 @@
     const btn = document.createElement("button");
     btn.className = "button solid";
     btn.type = "submit";
-    btn.innerHTML = '<span class="label-content"><span class="label-content__text">Sign in</span></span>';
+    btn.innerHTML = '<span class="label-content"><span class="label-content-text">Sign in</span></span>';
     actions.append(btn);
 
     form.append(field1, field2, actions);
@@ -847,18 +847,18 @@
     const lp = labelPosition === "side" ? ' data-label-position="side"' : "";
     const inv = invalid ? " is-invalid" : "";
     const alignAttr = actionsAlign !== "end" ? ` data-align="${actionsAlign}"` : "";
-    const helperCode = invalid ? '\n    <p class="form-field__helper">Please enter a valid email address.</p>' : "";
+    const helperCode = invalid ? '\n    <p class="form-field-helper">Please enter a valid email address.</p>' : "";
     const code = `<form class="${formClasses.join(" ")}" novalidate>
   <div class="form-field${inv}"${lp}>
-    <label class="field-label"><span class="label-content"><span class="label-content__text">Email</span></span><span class="field-label__required" aria-hidden="true">*</span></label>
+    <label class="field-label"><span class="label-content"><span class="label-content-text">Email</span></span><span class="field-label-required" aria-hidden="true">*</span></label>
     <input class="input" type="email" placeholder="you@example.com" />${helperCode}
   </div>
   <div class="form-field"${lp}>
-    <label class="field-label"><span class="label-content"><span class="label-content__text">Password</span></span></label>
+    <label class="field-label"><span class="label-content"><span class="label-content-text">Password</span></span></label>
     <input class="input" type="password" />
   </div>
   <div class="form-actions"${alignAttr}>
-    <button class="button solid" type="submit"><span class="label-content"><span class="label-content__text">Sign in</span></span></button>
+    <button class="button solid" type="submit"><span class="label-content"><span class="label-content-text">Sign in</span></span></button>
   </div>
 </form>`;
 

--- a/site/examples/login-form.md
+++ b/site/examples/login-form.md
@@ -33,7 +33,7 @@ breadcrumb:
 <div class="example-form-shell">
   {% call ui.form(borderless=true) %}
     {% call ui.formGroup(title="Sign in") %}
-      <p class="form-field__helper">Use your account email and password.</p>
+      <p class="form-field-helper">Use your account email and password.</p>
       {% call ui.formField() %}
         {{ ui.fieldLabel("Email address", htmlFor="login-email", required=true) }}
         {{ ui.input(type="email", id="login-email", name="email", placeholder="name@example.com") }}
@@ -41,7 +41,7 @@ breadcrumb:
       {% call ui.formField() %}
         {{ ui.fieldLabel("Password", htmlFor="login-password", required=true) }}
         {{ ui.input(type="password", id="login-password", name="password", placeholder="Enter password") }}
-        <a class="form-field__link" href="#">Forgot password?</a>
+        <a class="form-field-link" href="#">Forgot password?</a>
       {% endcall %}
     {% endcall %}
     {% call ui.formActions(align="stretch") %}
@@ -61,17 +61,17 @@ breadcrumb:
 <div class="example-form-shell">
   {% call ui.form(borderless=true) %}
     {% call ui.formGroup(title="Sign in") %}
-      <p class="form-field__helper">Use your account email and password.</p>
+      <p class="form-field-helper">Use your account email and password.</p>
       {% call ui.formField(invalid=true) %}
         {{ ui.fieldLabel("Email address", htmlFor="login-email-err", required=true) }}
         {{ ui.input(type="email", id="login-email-err", name="email", placeholder="name@example.com", className="is-invalid") }}
-        <p class="form-field__helper">Please enter a valid email address.</p>
+        <p class="form-field-helper">Please enter a valid email address.</p>
       {% endcall %}
       {% call ui.formField(invalid=true) %}
         {{ ui.fieldLabel("Password", htmlFor="login-password-err", required=true) }}
         {{ ui.input(type="password", id="login-password-err", name="password", placeholder="Enter password", className="is-invalid") }}
-        <p class="form-field__helper">Password is required.</p>
-        <a class="form-field__link" href="#">Forgot password?</a>
+        <p class="form-field-helper">Password is required.</p>
+        <a class="form-field-link" href="#">Forgot password?</a>
       {% endcall %}
     {% endcall %}
     {% call ui.formActions(align="stretch") %}

--- a/site/examples/pricing.md
+++ b/site/examples/pricing.md
@@ -54,13 +54,13 @@ breadcrumb:
     transform: translate(-50%, -50%);
   }
 
-  .pricing-card__header {
+  .pricing-card-header {
     display: grid;
     gap: var(--size-spacing-200);
     text-align: center;
   }
 
-  .pricing-card__plan {
+  .pricing-card-plan {
     margin: 0;
     font-family: var(--typography-heading-font-family);
     font-size: var(--typography-heading-font-size-md);
@@ -69,7 +69,7 @@ breadcrumb:
     color: var(--color-text-default);
   }
 
-  .pricing-card__price {
+  .pricing-card-price {
     margin: 0;
     font-family: var(--typography-heading-font-family);
     font-size: var(--typography-heading-font-size-xl);
@@ -78,20 +78,20 @@ breadcrumb:
     color: var(--color-text-default);
   }
 
-  .pricing-card__price-period {
+  .pricing-card-price-period {
     font-size: var(--font-size-sm);
     font-weight: var(--font-weight-400);
     color: var(--color-text-subtle);
   }
 
-  .pricing-card__subtitle {
+  .pricing-card-subtitle {
     margin: 0;
     font-size: var(--font-size-sm);
     line-height: var(--line-height-sm);
     color: var(--color-text-subtle);
   }
 
-  .pricing-card__features {
+  .pricing-card-features {
     list-style: none;
     margin: 0;
     padding: 0;
@@ -100,7 +100,7 @@ breadcrumb:
     flex: 1;
   }
 
-  .pricing-card__feature {
+  .pricing-card-feature {
     display: flex;
     align-items: flex-start;
     gap: var(--size-spacing-200);
@@ -109,16 +109,16 @@ breadcrumb:
     color: var(--color-text-default);
   }
 
-  .pricing-card__feature .icon {
+  .pricing-card-feature .icon {
     flex-shrink: 0;
     color: var(--color-text-success);
   }
 
-  .pricing-card__cta {
+  .pricing-card-cta {
     margin-block-start: auto;
   }
 
-  .pricing-card__cta .button {
+  .pricing-card-cta .button {
     inline-size: 100%;
     justify-content: center;
   }
@@ -144,30 +144,30 @@ breadcrumb:
 
   {# ── Starter ── #}
   <article class="pricing-card" role="listitem">
-    <div class="pricing-card__header">
-      <h3 class="pricing-card__plan">Starter</h3>
-      <p class="pricing-card__price">$9<span class="pricing-card__price-period"> / mo</span></p>
-      <p class="pricing-card__subtitle">For individuals getting started.</p>
+    <div class="pricing-card-header">
+      <h3 class="pricing-card-plan">Starter</h3>
+      <p class="pricing-card-price">$9<span class="pricing-card-price-period"> / mo</span></p>
+      <p class="pricing-card-subtitle">For individuals getting started.</p>
     </div>
-    <ul class="pricing-card__features">
-      <li class="pricing-card__feature">
+    <ul class="pricing-card-features">
+      <li class="pricing-card-feature">
         {{ ui.icon("shield-check", "Included") }}
         <span>5 projects</span>
       </li>
-      <li class="pricing-card__feature">
+      <li class="pricing-card-feature">
         {{ ui.icon("shield-check", "Included") }}
         <span>1 GB storage</span>
       </li>
-      <li class="pricing-card__feature">
+      <li class="pricing-card-feature">
         {{ ui.icon("shield-check", "Included") }}
         <span>Email support</span>
       </li>
-      <li class="pricing-card__feature">
+      <li class="pricing-card-feature">
         {{ ui.icon("shield-check", "Included") }}
         <span>Basic analytics</span>
       </li>
     </ul>
-    <div class="pricing-card__cta">
+    <div class="pricing-card-cta">
       {{ ui.button(label="Get Started", variant="outline") }}
     </div>
   </article>
@@ -175,72 +175,72 @@ breadcrumb:
   {# ── Pro (recommended) ── #}
   <article class="pricing-card pricing-card--recommended" role="listitem">
     {{ ui.badge("Recommended", variant="brand", size="sm") }}
-    <div class="pricing-card__header">
-      <h3 class="pricing-card__plan">Pro</h3>
-      <p class="pricing-card__price">$29<span class="pricing-card__price-period"> / mo</span></p>
-      <p class="pricing-card__subtitle">For growing teams that need more.</p>
+    <div class="pricing-card-header">
+      <h3 class="pricing-card-plan">Pro</h3>
+      <p class="pricing-card-price">$29<span class="pricing-card-price-period"> / mo</span></p>
+      <p class="pricing-card-subtitle">For growing teams that need more.</p>
     </div>
-    <ul class="pricing-card__features">
-      <li class="pricing-card__feature">
+    <ul class="pricing-card-features">
+      <li class="pricing-card-feature">
         {{ ui.icon("shield-check", "Included") }}
         <span>Unlimited projects</span>
       </li>
-      <li class="pricing-card__feature">
+      <li class="pricing-card-feature">
         {{ ui.icon("shield-check", "Included") }}
         <span>50 GB storage</span>
       </li>
-      <li class="pricing-card__feature">
+      <li class="pricing-card-feature">
         {{ ui.icon("shield-check", "Included") }}
         <span>Priority support</span>
       </li>
-      <li class="pricing-card__feature">
+      <li class="pricing-card-feature">
         {{ ui.icon("shield-check", "Included") }}
         <span>Advanced analytics</span>
       </li>
-      <li class="pricing-card__feature">
+      <li class="pricing-card-feature">
         {{ ui.icon("shield-check", "Included") }}
         <span>Custom integrations</span>
       </li>
     </ul>
-    <div class="pricing-card__cta">
+    <div class="pricing-card-cta">
       {{ ui.button(label="Get Started", variant="solid") }}
     </div>
   </article>
 
   {# ── Business ── #}
   <article class="pricing-card" role="listitem">
-    <div class="pricing-card__header">
-      <h3 class="pricing-card__plan">Business</h3>
-      <p class="pricing-card__price">$79<span class="pricing-card__price-period"> / mo</span></p>
-      <p class="pricing-card__subtitle">For organizations at scale.</p>
+    <div class="pricing-card-header">
+      <h3 class="pricing-card-plan">Business</h3>
+      <p class="pricing-card-price">$79<span class="pricing-card-price-period"> / mo</span></p>
+      <p class="pricing-card-subtitle">For organizations at scale.</p>
     </div>
-    <ul class="pricing-card__features">
-      <li class="pricing-card__feature">
+    <ul class="pricing-card-features">
+      <li class="pricing-card-feature">
         {{ ui.icon("shield-check", "Included") }}
         <span>Unlimited projects</span>
       </li>
-      <li class="pricing-card__feature">
+      <li class="pricing-card-feature">
         {{ ui.icon("shield-check", "Included") }}
         <span>500 GB storage</span>
       </li>
-      <li class="pricing-card__feature">
+      <li class="pricing-card-feature">
         {{ ui.icon("shield-check", "Included") }}
         <span>Dedicated support</span>
       </li>
-      <li class="pricing-card__feature">
+      <li class="pricing-card-feature">
         {{ ui.icon("shield-check", "Included") }}
         <span>Advanced analytics</span>
       </li>
-      <li class="pricing-card__feature">
+      <li class="pricing-card-feature">
         {{ ui.icon("shield-check", "Included") }}
         <span>SSO &amp; audit logs</span>
       </li>
-      <li class="pricing-card__feature">
+      <li class="pricing-card-feature">
         {{ ui.icon("shield-check", "Included") }}
         <span>SLA guarantee</span>
       </li>
     </ul>
-    <div class="pricing-card__cta">
+    <div class="pricing-card-cta">
       {{ ui.button(label="Contact Sales", variant="outline") }}
     </div>
   </article>

--- a/site/examples/vanilla-starter.md
+++ b/site/examples/vanilla-starter.md
@@ -49,14 +49,14 @@ document.querySelector("#app").innerHTML = `
 
     <label class="field-label" for="email">
       <span class="label-content">
-        <span class="label-content__text">Email</span>
+        <span class="label-content-text">Email</span>
       </span>
     </label>
     <input class="input" id="email" type="email" placeholder="name@example.com" />
 
     <div style="height: 0.75rem"></div>
     <button class="button" type="button">
-      <span class="label-content"><span class="label-content__text">Submit</span></span>
+      <span class="label-content"><span class="label-content-text">Submit</span></span>
     </button>
   </main>
 `;

--- a/site/foundations/architecture.md
+++ b/site/foundations/architecture.md
@@ -146,23 +146,23 @@ permalink: /foundations/architecture/
 
 <div class="pipeline-flow">
   <div class="pipeline-step">
-    <span class="pipeline-step__label">Figma Variables</span>
+    <span class="pipeline-step-label">Figma Variables</span>
   </div>
   <div class="pipeline-arrow"><span>export</span></div>
   <div class="pipeline-step">
-    <span class="pipeline-step__label">figma/exports/*.tokens.json</span>
+    <span class="pipeline-step-label">figma/exports/*.tokens.json</span>
   </div>
   <div class="pipeline-arrow"><span>npm run tokens:generate</span></div>
   <div class="pipeline-step">
-    <span class="pipeline-step__label">dist/tokens/css/*.css + tokens.yaml</span>
+    <span class="pipeline-step-label">dist/tokens/css/*.css + tokens.yaml</span>
   </div>
   <div class="pipeline-arrow"><span>npm run build:css</span></div>
   <div class="pipeline-step">
-    <span class="pipeline-step__label">dist/main.css (bundled, layered)</span>
+    <span class="pipeline-step-label">dist/main.css (bundled, layered)</span>
   </div>
   <div class="pipeline-arrow"><span>npm run docs:site</span></div>
   <div class="pipeline-step">
-    <span class="pipeline-step__label">_site/ (documentation website)</span>
+    <span class="pipeline-step-label">_site/ (documentation website)</span>
   </div>
 </div>
 

--- a/site/foundations/governance.md
+++ b/site/foundations/governance.md
@@ -33,15 +33,15 @@ excludeFromNav: true
 
 <div class="pipeline-flow">
   <div class="pipeline-step">
-    <span class="pipeline-step__label">Design Principles — the "why" of composition</span>
+    <span class="pipeline-step-label">Design Principles — the "why" of composition</span>
   </div>
   <div class="pipeline-arrow"><span>informs</span></div>
   <div class="pipeline-step">
-    <span class="pipeline-step__label">Usability Heuristics — the "how" of interaction</span>
+    <span class="pipeline-step-label">Usability Heuristics — the "how" of interaction</span>
   </div>
   <div class="pipeline-arrow"><span>evaluated by</span></div>
   <div class="pipeline-step">
-    <span class="pipeline-step__label">Design Intelligence — the "is this good?" judgment</span>
+    <span class="pipeline-step-label">Design Intelligence — the "is this good?" judgment</span>
   </div>
 </div>
 

--- a/site/patterns/form.md
+++ b/site/patterns/form.md
@@ -124,7 +124,7 @@ Use `data-label-position="side"` for horizontal label layout. Best suited for wi
 {% call ui.form() %}
   {% call ui.formField(labelPosition="side") %}
     {{ ui.fieldLabel("Username") }}
-    <div class="form-field__body">
+    <div class="form-field-body">
       {{ ui.input(placeholder="janedoe") }}
       {{ ui.formHelper("Visible to other users.") }}
     </div>

--- a/site/patterns/icon.md
+++ b/site/patterns/icon.md
@@ -148,7 +148,7 @@ needed.
 <div class="docs-guideline">
   <div class="docs-guideline-item" data-type="do">
     <div class="docs-guideline-preview">
-      <span class="label-content"><span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span><span class="label-content__text">Search</span></span>
+      <span class="label-content"><span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span><span class="label-content-text">Search</span></span>
     </div>
     <div class="docs-guideline-body">
       <p class="docs-guideline-label">Do</p>

--- a/site/patterns/index.md
+++ b/site/patterns/index.md
@@ -60,7 +60,7 @@ permalink: /patterns/
     <div class="docs-component-card-preview">
       <span class="label-content">
         <span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
-        <span class="label-content__text">Search</span>
+        <span class="label-content-text">Search</span>
       </span>
     </div>
     <div class="docs-component-card-body">

--- a/site/patterns/label.md
+++ b/site/patterns/label.md
@@ -26,7 +26,7 @@ playgroundLabel: Open Label Playground
     <div class="docs-hero-preview-stage">
       <span class="label-content">
         <span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
-        <span class="label-content__text">Search</span>
+        <span class="label-content-text">Search</span>
       </span>
     </div>
   </div>
@@ -57,7 +57,7 @@ playgroundLabel: Open Label Playground
       </span>
       <span class="label-content">
         <span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
-        <span class="label-content__text">Search</span>
+        <span class="label-content-text">Search</span>
       </span>
     </div>
   </div>
@@ -88,7 +88,7 @@ playgroundLabel: Open Label Playground
 <div class="docs-behavior-list">
   <div class="docs-behavior-item">
     <div class="docs-behavior-preview">
-      <span class="label-content"><span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span><span class="label-content__text">Search</span></span>
+      <span class="label-content"><span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span><span class="label-content-text">Search</span></span>
     </div>
     <div class="docs-behavior-body">
       <h3>Icon + text composition</h3>

--- a/site/primitives/color-tokens.md
+++ b/site/primitives/color-tokens.md
@@ -26,16 +26,16 @@ permalink: /primitives/color/
 
 {% for palette in colorDocs.palettes %}
 <details class="color-family" id="family-{{ palette.family | slug }}">
-  <summary class="color-family__summary" id="palette-{{ palette.family | slug }}">
-    <span class="color-family__name">{{ palette.family }}</span>
-    <span class="color-family__ramp">{% for step in palette.steps %}<span class="color-family__ramp-step" style="background: {{ step.hex }};"></span>{% endfor %}</span>
+  <summary class="color-family-summary" id="palette-{{ palette.family | slug }}">
+    <span class="color-family-name">{{ palette.family }}</span>
+    <span class="color-family-ramp">{% for step in palette.steps %}<span class="color-family-ramp-step" style="background: {{ step.hex }};"></span>{% endfor %}</span>
   </summary>
-  <div class="color-ramp">{% for step in palette.steps %}<div class="color-ramp__step" style="background: {{ step.hex }};" title="{{ step.name }} — {{ step.hex }}"></div>{% endfor %}</div>
+  <div class="color-ramp">{% for step in palette.steps %}<div class="color-ramp-step" style="background: {{ step.hex }};" title="{{ step.name }} — {{ step.hex }}"></div>{% endfor %}</div>
   <div class="color-table-wrap">
     <table class="color-table">
       <thead>
         <tr>
-          <th class="color-table__preview"></th>
+          <th class="color-table-preview"></th>
           <th>Name</th>
           <th>Token</th>
           <th>Contrast <span class="th-hint">:1</span></th>
@@ -44,11 +44,11 @@ permalink: /primitives/color/
       </thead>
       <tbody>{% for step in palette.steps %}
         <tr>
-          <td class="color-table__preview"><span class="color-dot" style="background: {{ step.hex }};"></span></td>
-          <td class="color-table__name">{{ palette.family }} {{ step.step }}</td>
-          <td class="color-table__token"><code>{{ step.cssVar }}</code></td>
-          <td class="color-table__contrast">{{ step.contrast }}</td>
-          <td class="color-table__hex"><code>{{ step.hex }}</code></td>
+          <td class="color-table-preview"><span class="color-dot" style="background: {{ step.hex }};"></span></td>
+          <td class="color-table-name">{{ palette.family }} {{ step.step }}</td>
+          <td class="color-table-token"><code>{{ step.cssVar }}</code></td>
+          <td class="color-table-contrast">{{ step.contrast }}</td>
+          <td class="color-table-hex"><code>{{ step.hex }}</code></td>
         </tr>{% endfor %}
       </tbody>
     </table>
@@ -80,7 +80,7 @@ permalink: /primitives/color/
     <table class="color-table">
       <thead>
         <tr>
-          <th class="color-table__preview"></th>
+          <th class="color-table-preview"></th>
           <th>Role</th>
           <th>Token</th>
           <th>Resolved Value</th>
@@ -88,10 +88,10 @@ permalink: /primitives/color/
       </thead>
       <tbody>{% for token in brand.tokens %}
         <tr>
-          <td class="color-table__preview"><span class="color-dot" style="background: var({{ token.cssVar }});"></span></td>
-          <td class="color-table__name">{{ token.name | replace("brand-color-", "") }}</td>
-          <td class="color-table__token"><code>{{ token.cssVar }}</code></td>
-          <td class="color-table__hex"><code>{{ token.value }}</code></td>
+          <td class="color-table-preview"><span class="color-dot" style="background: var({{ token.cssVar }});"></span></td>
+          <td class="color-table-name">{{ token.name | replace("brand-color-", "") }}</td>
+          <td class="color-table-token"><code>{{ token.cssVar }}</code></td>
+          <td class="color-table-hex"><code>{{ token.value }}</code></td>
         </tr>{% endfor %}
       </tbody>
     </table>
@@ -115,7 +115,7 @@ permalink: /primitives/color/
     <table class="color-table">
       <thead>
         <tr>
-          <th class="color-table__preview"></th>
+          <th class="color-table-preview"></th>
           <th>Name</th>
           <th>Token</th>
           <th>Value</th>
@@ -123,10 +123,10 @@ permalink: /primitives/color/
       </thead>
       <tbody>{% for token in group.tokens %}
         <tr>
-          <td class="color-table__preview"><span class="color-dot" style="background: var({{ token.cssVar }});"></span></td>
-          <td class="color-table__name">{{ token.name | replace("color-", "") }}</td>
-          <td class="color-table__token"><code>{{ token.cssVar }}</code></td>
-          <td class="color-table__hex"><code>{{ token.value }}</code></td>
+          <td class="color-table-preview"><span class="color-dot" style="background: var({{ token.cssVar }});"></span></td>
+          <td class="color-table-name">{{ token.name | replace("color-", "") }}</td>
+          <td class="color-table-token"><code>{{ token.cssVar }}</code></td>
+          <td class="color-table-hex"><code>{{ token.value }}</code></td>
         </tr>{% endfor %}
       </tbody>
     </table>
@@ -150,7 +150,7 @@ permalink: /primitives/color/
     <table class="color-table">
       <thead>
         <tr>
-          <th class="color-table__preview"></th>
+          <th class="color-table-preview"></th>
           <th>Name</th>
           <th>Token</th>
           <th>Value</th>
@@ -158,10 +158,10 @@ permalink: /primitives/color/
       </thead>
       <tbody>{% for token in group.tokens %}
         <tr>
-          <td class="color-table__preview"><span class="color-dot" style="background: var({{ token.cssVar }});"></span></td>
-          <td class="color-table__name">{{ token.name | replace("color-", "") }}</td>
-          <td class="color-table__token"><code>{{ token.cssVar }}</code></td>
-          <td class="color-table__hex"><code>{{ token.value }}</code></td>
+          <td class="color-table-preview"><span class="color-dot" style="background: var({{ token.cssVar }});"></span></td>
+          <td class="color-table-name">{{ token.name | replace("color-", "") }}</td>
+          <td class="color-table-token"><code>{{ token.cssVar }}</code></td>
+          <td class="color-table-hex"><code>{{ token.value }}</code></td>
         </tr>{% endfor %}
       </tbody>
     </table>

--- a/site/primitives/typography-tokens.md
+++ b/site/primitives/typography-tokens.md
@@ -20,14 +20,14 @@ permalink: /primitives/typography/
 
 <div class="type-specimens">{% for family in typographyDocs.families %}
   <div class="type-specimen">
-    <div class="type-specimen__sample" style="font-family: var({{ family.cssVar }});">
-      <span class="type-specimen__large">Aa</span>
-      <span class="type-specimen__alphabet">ABCDEFGHIJKLMNOPQRSTUVWXYZ</span>
-      <span class="type-specimen__alphabet">abcdefghijklmnopqrstuvwxyz 0123456789</span>
+    <div class="type-specimen-sample" style="font-family: var({{ family.cssVar }});">
+      <span class="type-specimen-large">Aa</span>
+      <span class="type-specimen-alphabet">ABCDEFGHIJKLMNOPQRSTUVWXYZ</span>
+      <span class="type-specimen-alphabet">abcdefghijklmnopqrstuvwxyz 0123456789</span>
     </div>
-    <div class="type-specimen__meta">
-      <span class="type-specimen__name">{{ family.value }}</span>
-      <code class="type-specimen__token">{{ family.cssVar }}</code>
+    <div class="type-specimen-meta">
+      <span class="type-specimen-name">{{ family.value }}</span>
+      <code class="type-specimen-token">{{ family.cssVar }}</code>
     </div>
   </div>{% endfor %}
 </div>
@@ -50,9 +50,9 @@ permalink: /primitives/typography/
     </thead>
     <tbody>{% for item in typographyDocs.headingScale %}
       <tr>
-        <td class="type-scale-table__size">{{ item.label }}</td>
-        <td class="type-scale-table__class"><code>.{{ item.class }}</code> / <code>&lt;{{ item.element }}&gt;</code></td>
-        <td class="type-scale-table__sample"><span class="{{ item.class }}">The quick brown fox</span></td>
+        <td class="type-scale-table-size">{{ item.label }}</td>
+        <td class="type-scale-table-class"><code>.{{ item.class }}</code> / <code>&lt;{{ item.element }}&gt;</code></td>
+        <td class="type-scale-table-sample"><span class="{{ item.class }}">The quick brown fox</span></td>
       </tr>{% endfor %}
     </tbody>
   </table>
@@ -76,9 +76,9 @@ permalink: /primitives/typography/
     </thead>
     <tbody>{% for item in typographyDocs.textScale %}
       <tr>
-        <td class="type-scale-table__size">{{ item.label }}</td>
-        <td class="type-scale-table__class"><code>.{{ item.class }}</code></td>
-        <td class="type-scale-table__sample"><span class="{{ item.class }}">Clear schedules, gentle spacing, and readable copy for every screen.</span></td>
+        <td class="type-scale-table-size">{{ item.label }}</td>
+        <td class="type-scale-table-class"><code>.{{ item.class }}</code></td>
+        <td class="type-scale-table-sample"><span class="{{ item.class }}">Clear schedules, gentle spacing, and readable copy for every screen.</span></td>
       </tr>{% endfor %}
     </tbody>
   </table>
@@ -103,8 +103,8 @@ permalink: /primitives/typography/
     <tbody>{% for size in typographyDocs.sizes %}
       <tr>
         <td><code>{{ size.cssVar }}</code></td>
-        <td class="type-token-table__value">{{ size.value }}</td>
-        <td class="type-token-table__preview"><span style="font-size: var({{ size.cssVar }}); line-height: 1.2;">Ag</span></td>
+        <td class="type-token-table-value">{{ size.value }}</td>
+        <td class="type-token-table-preview"><span style="font-size: var({{ size.cssVar }}); line-height: 1.2;">Ag</span></td>
       </tr>{% endfor %}
     </tbody>
   </table>
@@ -129,8 +129,8 @@ permalink: /primitives/typography/
     <tbody>{% for weight in typographyDocs.weights %}
       <tr>
         <td><code>{{ weight.cssVar }}</code></td>
-        <td class="type-token-table__value">{{ weight.value }}</td>
-        <td class="type-token-table__preview"><span style="font-weight: var({{ weight.cssVar }});">The quick brown fox</span></td>
+        <td class="type-token-table-value">{{ weight.value }}</td>
+        <td class="type-token-table-preview"><span style="font-weight: var({{ weight.cssVar }});">The quick brown fox</span></td>
       </tr>{% endfor %}
     </tbody>
   </table>
@@ -155,8 +155,8 @@ permalink: /primitives/typography/
     <tbody>{% for lh in typographyDocs.lineHeights %}
       <tr>
         <td><code>{{ lh.cssVar }}</code></td>
-        <td class="type-token-table__value">{{ lh.value }}</td>
-        <td class="type-token-table__preview"><span style="line-height: var({{ lh.cssVar }}); display: inline-block; border-left: 2px solid var(--docs-accent); padding-left: 8px;">Line height<br>demonstration</span></td>
+        <td class="type-token-table-value">{{ lh.value }}</td>
+        <td class="type-token-table-preview"><span style="line-height: var({{ lh.cssVar }}); display: inline-block; border-left: 2px solid var(--docs-accent); padding-left: 8px;">Line height<br>demonstration</span></td>
       </tr>{% endfor %}
     </tbody>
   </table>

--- a/src/elements/ui-accordion.js
+++ b/src/elements/ui-accordion.js
@@ -44,7 +44,7 @@ class UIAccordionItem extends UIElement {
 
     this.innerHTML = `<details ${detailsAttrs.join(" ")}>
   <summary>${title}</summary>
-  <div class="accordion-item__content">${content}</div>
+  <div class="accordion-item-content">${content}</div>
 </details>`;
   }
 }

--- a/src/elements/ui-avatar.js
+++ b/src/elements/ui-avatar.js
@@ -27,7 +27,7 @@ class UIAvatar extends UIElement {
     const label = alt || initials;
     const inner = src
       ? `<img src="${src}" alt="${alt}" />`
-      : `<span class="avatar__initials">${initials}</span>`;
+      : `<span class="avatar-initials">${initials}</span>`;
 
     this.innerHTML = `<span class="${classes.join(" ")}" role="img" aria-label="${label}">${inner}</span>`;
   }

--- a/src/elements/ui-badge.js
+++ b/src/elements/ui-badge.js
@@ -29,7 +29,7 @@ class UIBadge extends UIElement {
       inner += `<span class="icon" style="--icon-src: url('/assets/icons/${startIcon}.svg')" aria-hidden="true"></span>`;
     }
     if (text) {
-      inner += `<span class="badge__text">${text}</span>`;
+      inner += `<span class="badge-text">${text}</span>`;
     }
 
     this.innerHTML = `<span class="${classes.join(" ")}">${inner}</span>`;

--- a/src/elements/ui-button.js
+++ b/src/elements/ui-button.js
@@ -30,7 +30,7 @@ class UIButton extends UIElement {
     const classes = ["button"];
     if (variant === "outline") classes.push("outline");
     if (variant === "ghost") classes.push("ghost");
-    if (iconOnly) classes.push("button--icon-only");
+    if (iconOnly) classes.push("icon-only");
 
     const text = this.textContent.trim();
     const labelContentClasses = ["label-content"];
@@ -43,7 +43,7 @@ class UIButton extends UIElement {
     }
 
     if (!iconOnly && text) {
-      inner += `<span class="label-content__text">${text}</span>`;
+      inner += `<span class="label-content-text">${text}</span>`;
     }
 
     if (endIcon && !iconOnly) {

--- a/src/elements/ui-checkbox.js
+++ b/src/elements/ui-checkbox.js
@@ -46,7 +46,7 @@ class UICheckbox extends UIElement {
 
     this.innerHTML = `<label class="${wrapperClasses.join(" ")}">
   <input ${inputAttrs.join(" ")} />
-  <span class="checkbox-field__text">${label}</span>
+  <span class="checkbox-field-text">${label}</span>
 </label>`;
   }
 }

--- a/src/elements/ui-form.js
+++ b/src/elements/ui-form.js
@@ -37,7 +37,7 @@ class UIFormGroup extends UIElement {
     const title = this.getAttr("title");
     const children = this.innerHTML;
 
-    const legend = title ? `<legend class="form-group__title">${title}</legend>` : "";
+    const legend = title ? `<legend class="form-group-title">${title}</legend>` : "";
     this.innerHTML = `<fieldset class="form-group">${legend}${children}</fieldset>`;
   }
 }
@@ -77,7 +77,7 @@ export { UIFormField };
 class UIFormHelper extends UIElement {
   render() {
     const text = this.textContent.trim();
-    this.innerHTML = `<p class="form-field__helper">${text}</p>`;
+    this.innerHTML = `<p class="form-field-helper">${text}</p>`;
   }
 }
 

--- a/src/elements/ui-input.js
+++ b/src/elements/ui-input.js
@@ -67,7 +67,7 @@ class UIInput extends UIElement {
 
     this.innerHTML = `<div class="${wrapperClasses.join(" ")}">
   <input ${inputAttrs.join(" ")} />
-  <span class="input-field__control">${controlHTML}</span>
+  <span class="input-field-control">${controlHTML}</span>
 </div>`;
   }
 }

--- a/src/elements/ui-label.js
+++ b/src/elements/ui-label.js
@@ -29,11 +29,11 @@ class UIFieldLabel extends UIElement {
 
     let requiredHtml = "";
     if (required) {
-      requiredHtml = `<span class="field-label__required" aria-hidden="true">*</span><span class="field-label__required-text"> (required)</span>`;
+      requiredHtml = `<span class="field-label-required" aria-hidden="true">*</span><span class="field-label-required-text"> (required)</span>`;
     }
 
     this.innerHTML = `<label ${labelAttrs.join(" ")}>
-  <span class="label-content">${iconHtml}<span class="label-content__text">${text}</span></span>${requiredHtml}
+  <span class="label-content">${iconHtml}<span class="label-content-text">${text}</span></span>${requiredHtml}
 </label>`;
   }
 }

--- a/src/elements/ui-radio.js
+++ b/src/elements/ui-radio.js
@@ -45,7 +45,7 @@ class UIRadio extends UIElement {
 
     this.innerHTML = `<label class="${wrapperClasses.join(" ")}">
   <input ${inputAttrs.join(" ")} />
-  <span class="radio-field__text">${label}</span>
+  <span class="radio-field-text">${label}</span>
 </label>`;
   }
 }

--- a/src/elements/ui-switch.js
+++ b/src/elements/ui-switch.js
@@ -45,7 +45,7 @@ class UISwitch extends UIElement {
 
     this.innerHTML = `<label class="${wrapperClasses.join(" ")}">
   <input ${inputAttrs.join(" ")} />
-  <span class="switch-field__text">${label}</span>
+  <span class="switch-field-text">${label}</span>
 </label>`;
   }
 }

--- a/src/react/accordion.js
+++ b/src/react/accordion.js
@@ -31,6 +31,6 @@ export function AccordionItem({ title, open = false, disabled = false, className
     "details",
     { className: classes.join(" "), open, ...props },
     React.createElement("summary", null, title),
-    React.createElement("div", { className: "accordion-item__content" }, children)
+    React.createElement("div", { className: "accordion-item-content" }, children)
   );
 }

--- a/src/react/avatar.js
+++ b/src/react/avatar.js
@@ -24,7 +24,7 @@ export function Avatar({
 
   const children = src
     ? React.createElement("img", { src, alt })
-    : React.createElement("span", { className: "avatar__initials" }, initials);
+    : React.createElement("span", { className: "avatar-initials" }, initials);
 
   return React.createElement(
     "span",

--- a/src/react/badge.js
+++ b/src/react/badge.js
@@ -35,7 +35,7 @@ export function Badge({
     },
     iconElement,
     content != null
-      ? React.createElement("span", { className: "badge__text" }, content)
+      ? React.createElement("span", { className: "badge-text" }, content)
       : null,
   );
 }

--- a/src/react/button.js
+++ b/src/react/button.js
@@ -34,7 +34,7 @@ export function Button({
   const iconStart = resolvedIconOnly ? startIcon || endIcon : startIcon;
   const iconEnd = resolvedIconOnly ? undefined : endIcon;
 
-  if (resolvedIconOnly) classes.push("button--icon-only");
+  if (resolvedIconOnly) classes.push("icon-only");
 
   const buttonProps = {
     type,

--- a/src/react/checkbox.js
+++ b/src/react/checkbox.js
@@ -51,6 +51,6 @@ export function Checkbox({
       className: wrapperClasses.join(" "),
     },
     input,
-    React.createElement("span", { className: "checkbox-field__text" }, content),
+    React.createElement("span", { className: "checkbox-field-text" }, content),
   );
 }

--- a/src/react/form.js
+++ b/src/react/form.js
@@ -41,7 +41,7 @@ export function FormGroup({ title = "", className = "", children, ...props }) {
     "fieldset",
     { className: classes.join(" "), ...props },
     title
-      ? React.createElement("legend", { className: "form-group__title" }, title)
+      ? React.createElement("legend", { className: "form-group-title" }, title)
       : null,
     children,
   );
@@ -82,7 +82,7 @@ export function FormField({
 export function FormHelper({ text, ...props }) {
   return React.createElement(
     "p",
-    { className: "form-field__helper", ...props },
+    { className: "form-field-helper", ...props },
     text,
   );
 }

--- a/src/react/input.js
+++ b/src/react/input.js
@@ -85,7 +85,7 @@ export function Input({
     }),
     React.createElement(
       "span",
-      { className: "input-field__control" },
+      { className: "input-field-control" },
       controlButtons,
     ),
   );

--- a/src/react/label.js
+++ b/src/react/label.js
@@ -54,7 +54,7 @@ export function LabelContent({
   if (className) classes.push(className);
 
   const textNode = hasTextContent(content)
-    ? React.createElement("span", { className: "label-content__text" }, content)
+    ? React.createElement("span", { className: "label-content-text" }, content)
     : null;
 
   return React.createElement(
@@ -88,7 +88,7 @@ export function FieldLabel({
     ? React.createElement(
         "span",
         {
-          className: "field-label__required",
+          className: "field-label-required",
           "aria-hidden": true,
         },
         "*",
@@ -98,7 +98,7 @@ export function FieldLabel({
   const requiredA11yText = required
     ? React.createElement(
         "span",
-        { className: "field-label__required-text" },
+        { className: "field-label-required-text" },
         ` (${requiredText})`,
       )
     : null;

--- a/src/react/radio.js
+++ b/src/react/radio.js
@@ -40,6 +40,6 @@ export function Radio({
       className: wrapperClasses.join(" "),
     },
     input,
-    React.createElement("span", { className: "radio-field__text" }, content),
+    React.createElement("span", { className: "radio-field-text" }, content),
   );
 }

--- a/src/react/switch.js
+++ b/src/react/switch.js
@@ -41,6 +41,6 @@ export function Switch({
       className: wrapperClasses.join(" "),
     },
     input,
-    React.createElement("span", { className: "switch-field__text" }, content),
+    React.createElement("span", { className: "switch-field-text" }, content),
   );
 }

--- a/src/ui/components/input-field.js
+++ b/src/ui/components/input-field.js
@@ -68,7 +68,7 @@ function handleToggleVisibility(field) {
   if (!input || input.disabled) return;
 
   const button = field.querySelector(
-    '.input-field__control button[aria-label="Toggle password visibility"]',
+    '.input-field-control button[aria-label="Toggle password visibility"]',
   );
   const isRevealed = input.type === "text";
 
@@ -87,7 +87,7 @@ function enhanceField(field) {
   if (field.dataset.enhanced) return;
   field.dataset.enhanced = "true";
 
-  const control = field.querySelector(".input-field__control");
+  const control = field.querySelector(".input-field-control");
   if (!control) return;
 
   // Set aria-pressed on password toggle buttons during enhancement

--- a/src/ui/patterns/accordion.css
+++ b/src/ui/patterns/accordion.css
@@ -62,7 +62,7 @@
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
-  .accordion-item__content {
+  .accordion-item-content {
     padding-inline: var(--accordion-padding-inline);
     padding-block: var(--accordion-padding-block);
     font-family: var(--font-family-sans);

--- a/src/ui/patterns/avatar.css
+++ b/src/ui/patterns/avatar.css
@@ -50,7 +50,7 @@
 
   /* ── Initials ── */
 
-  .avatar__initials {
+  .avatar-initials {
     user-select: none;
     text-transform: uppercase;
   }

--- a/src/ui/patterns/button.css
+++ b/src/ui/patterns/button.css
@@ -25,13 +25,13 @@
     -webkit-text-fill-color: currentColor;
   }
 
-  .button .label-content__text,
+  .button .label-content-text,
   .button .icon {
     color: inherit;
     -webkit-text-fill-color: currentColor;
   }
 
-  .button.button--icon-only {
+  .button.icon-only {
     padding-inline: var(--button-padding-block);
   }
 

--- a/src/ui/patterns/form.css
+++ b/src/ui/patterns/form.css
@@ -34,7 +34,7 @@
     min-inline-size: 0;
   }
 
-  .form-group__title {
+  .form-group-title {
     font-family: var(--typography-heading-font-family);
     font-weight: var(--typography-heading-font-weight);
     font-size: var(--typography-heading-font-size-sm);
@@ -64,7 +64,7 @@
     padding-block-start: var(--size-spacing-200);
   }
 
-  .form-field[data-label-position="side"] > .form-field__body {
+  .form-field[data-label-position="side"] > .form-field-body {
     flex: 1;
     display: flex;
     flex-direction: column;
@@ -75,7 +75,7 @@
    * Helper and error text
    * ---------------------------------------------------------------- */
 
-  .form-field__helper {
+  .form-field-helper {
     font-family: var(--typography-body-font-family);
     font-size: var(--font-size-sm);
     line-height: var(--line-height-sm);
@@ -83,17 +83,17 @@
     margin: 0;
   }
 
-  .form-field.is-invalid .form-field__helper {
+  .form-field.is-invalid .form-field-helper {
     color: var(--form-field-helper-text-color-invalid);
   }
 
-  .form-field__link {
+  .form-field-link {
     font-size: var(--font-size-sm);
     color: var(--color-text-brand);
     text-decoration: none;
   }
 
-  .form-field__link:hover {
+  .form-field-link:hover {
     text-decoration: underline;
   }
 

--- a/src/ui/patterns/input.css
+++ b/src/ui/patterns/input.css
@@ -68,7 +68,7 @@
 
   /* --- Control slot --- */
 
-  .input-field__control {
+  .input-field-control {
     display: flex;
     align-items: center;
     gap: var(--input-gap);
@@ -76,22 +76,22 @@
     color: var(--input-text-color-default);
   }
 
-  .input-field__control:empty {
+  .input-field-control:empty {
     display: none;
   }
 
   /* Hide controls when input is empty (showing placeholder) */
-  .input-field:has(.input:placeholder-shown) .input-field__control {
+  .input-field:has(.input:placeholder-shown) .input-field-control {
     visibility: hidden;
   }
 
   /* Hide controls when disabled */
-  .input-field:has(.input:disabled) .input-field__control,
-  .input-field.is-disabled .input-field__control {
+  .input-field:has(.input:disabled) .input-field-control,
+  .input-field.is-disabled .input-field-control {
     visibility: hidden;
   }
 
-  .input-field__control button {
+  .input-field-control button {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -105,11 +105,11 @@
     line-height: 1;
   }
 
-  .input-field__control button:hover {
+  .input-field-control button:hover {
     color: var(--input-text-color-hover);
   }
 
-  .input-field__control .icon {
+  .input-field-control .icon {
     font-size: 1.5rem;
   }
 
@@ -180,8 +180,8 @@
     border-style: dashed;
   }
 
-  .input-field:has(.input:read-only) .input-field__control button,
-  .input-field.is-readonly .input-field__control button {
+  .input-field:has(.input:read-only) .input-field-control button,
+  .input-field.is-readonly .input-field-control button {
     pointer-events: none;
     opacity: 0.4;
   }

--- a/src/ui/patterns/label.css
+++ b/src/ui/patterns/label.css
@@ -13,7 +13,7 @@
     flex: 0 0 auto;
   }
 
-  .label-content__text {
+  .label-content-text {
     line-height: inherit;
   }
 
@@ -30,12 +30,12 @@
     cursor: pointer;
   }
 
-  .field-label__required {
+  .field-label-required {
     color: var(--field-label-required-color, currentColor);
     font-weight: 700;
   }
 
-  .field-label__required-text {
+  .field-label-required-text {
     position: absolute;
     inline-size: 1px;
     block-size: 1px;


### PR DESCRIPTION
## Summary

Enforces Foundation-013 class naming convention across the entire codebase. All double-underscore BEM selectors have been replaced with hyphen-compound equivalents.

## Changes

| Old (BEM) | New (hyphen-compound) |
|-----------|----------------------|
| `.accordion-item__content` | `.accordion-item-content` |
| `.avatar__initials` | `.avatar-initials` |
| `.input-field__control` | `.input-field-control` |
| `.form-field__helper` | `.form-field-helper` |
| `.form-field__link` | `.form-field-link` |
| `.form-group__title` | `.form-group-title` |
| `.field-label__required` | `.field-label-required` |
| `.label-content__text` | `.label-content-text` |
| `.button--icon-only` | `.button.icon-only` |

## Scope

51 files updated across: CSS patterns, React wrappers, custom elements, Nunjucks macros, playground renderers, Code Connect schemas, docs pages, and examples.

## Verified

- Lint: ✅ (76 files)
- Tests: ✅ (70/70 pass)
- Zero `__` class selectors remaining in src/ or site/

## Breaking Change

Consumers referencing the old class names in their own CSS or JS must update their selectors. Consider shipping this with a major version bump or deprecation notice.