### PR TITLE
fix(label): replace hardcoded font-weight with core token

### DIFF
--- a/src/ui/patterns/label.css
+++ b/src/ui/patterns/label.css
@@ -32,7 +32,7 @@
 
   .field-label-required {
     color: var(--field-label-required-color, currentColor);
-    font-weight: 700;
+    font-weight: var(--font-weight-700);
   }
 
   .field-label-required-text {


### PR DESCRIPTION
## Summary

Replace `font-weight: 700` in `.field-label-required` with `var(--font-weight-700)`.

## Why

The label pattern's required indicator hardcoded `font-weight: 700` instead of referencing the existing core token `--font-weight-700`. This violates the token-first architecture rule: never hardcode values that exist as tokens.

## What changed

- **`src/ui/patterns/label.css`** — line 35: `font-weight: 700` → `font-weight: var(--font-weight-700)`

## Token provenance

`--font-weight-700` is defined in:
- Figma: `Core (Primitives) > Font/Weight/700` with `codeSyntax.WEB: var(--font-weight-700)`
- Generated: `dist/tokens/css/core-primitives.tokens.css` → `--font-weight-700: 700`

## Visual impact

None. The resolved value remains `700`.

## Checks

- `npm run ci:check` ✅ (lint, unit tests, build, smoke, tokens:validate, assets, rules, docs)
- Token drift: 0 after clean rebuild on main

## Risks

- None — this is a pure token reference substitution with no visual or behavioral change.