### PR TITLE
fix(ci): add smoke check for dist/core/index.css integrity

### DIFF
--- a/scripts/smoke-check.mjs
+++ b/scripts/smoke-check.mjs
@@ -59,6 +59,32 @@ function ensureElementsBundle(minCount = 10) {
   }
 }
 
+function ensureCoreIndexIntegrity() {
+  const coreIndex = path.join(REPO_ROOT, "dist", "core", "index.css");
+  if (!fs.existsSync(coreIndex)) {
+    fail("Missing dist/core/index.css");
+  }
+
+  const content = fs.readFileSync(coreIndex, "utf8");
+  if (!content.includes("layer(tokens)")) {
+    fail("dist/core/index.css does not import any token files");
+  }
+
+  // Verify every referenced token CSS file actually exists
+  const importPattern = /@import\s+url\(["']([^"']+)["']\)/g;
+  const baseDir = path.dirname(coreIndex);
+  let match;
+  while ((match = importPattern.exec(content)) !== null) {
+    const importPath = match[1];
+    const resolved = path.resolve(baseDir, importPath);
+    if (!fs.existsSync(resolved)) {
+      fail(
+        `dist/core/index.css references missing file: ${importPath}`,
+      );
+    }
+  }
+}
+
 function run() {
   ensureFile("dist/main.css", { nonEmpty: true, mustInclude: ".button" });
   ensureFile("dist/tokens/tokens.yaml", {
@@ -77,6 +103,7 @@ function run() {
   });
   ensureTokenCssFiles();
   ensureElementsBundle();
+  ensureCoreIndexIntegrity();
 
   console.log("✅ Smoke checks passed");
 }


### PR DESCRIPTION
## Summary

Adds a smoke check that validates `dist/core/index.css` — the primary consumer entry point — exists, imports token files (`layer(tokens)`), and all referenced `@import` paths resolve to actual files on disk.

## Motivation

A stale `calendar.tokens.css` was referenced in `dist/core/index.css` after a previous build but no longer existed after a clean `tokens:generate`. Consumers importing `core.css` would get broken builds. This check catches that class of error in CI.

## What changed

- `scripts/smoke-check.mjs`: added `ensureCoreIndexIntegrity()` function

## Checks run

- `npm run ci:check` — full pipeline passed (lint, unit tests, build, smoke, tokens:validate, tokens:usage, dtcg:validate, assets:check, rules:validate, docs:build)
- Pre-commit hooks passed (lint + unit tests)

## Risks

- None. Additive check only — cannot break existing passing builds.
- Only fails if `dist/core/index.css` is missing or contains dangling references, which is always a real error.