### PR TITLE
fix(a11y): transparent outline for forced-colors focus visibility

### DIFF
--- a/src/ui/patterns/accordion.css
+++ b/src/ui/patterns/accordion.css
@@ -58,7 +58,7 @@
 
   .accordion-item > summary:focus-visible,
   .accordion-item > summary.is-focus-visible {
-    outline: none;
+    outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 

--- a/src/ui/patterns/button.css
+++ b/src/ui/patterns/button.css
@@ -64,7 +64,7 @@
     background: var(--button-solid-container-background-focus);
     border-color: var(--button-solid-border-color-focus);
     color: var(--button-solid-text-color-default);
-    outline: none;
+    outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
@@ -105,7 +105,7 @@
     background: var(--button-outline-container-background-focus);
     border-color: var(--button-outline-border-color-focus);
     color: var(--button-outline-text-color-default);
-    outline: none;
+    outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
@@ -146,7 +146,7 @@
     background: var(--button-ghost-container-background-focus);
     border-color: var(--button-ghost-border-color-focus);
     color: var(--button-ghost-text-color-default);
-    outline: none;
+    outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 

--- a/src/ui/patterns/checkbox.css
+++ b/src/ui/patterns/checkbox.css
@@ -131,7 +131,7 @@
   .checkbox:focus-visible,
   .checkbox.is-focus-visible {
     border-color: var(--checkbox-border-color-focus);
-    outline: none;
+    outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 

--- a/src/ui/patterns/input.css
+++ b/src/ui/patterns/input.css
@@ -22,7 +22,7 @@
   }
 
   .input:focus-visible {
-    outline: none;
+    outline: 2px solid transparent;
     box-shadow: none;
   }
 
@@ -139,7 +139,7 @@
   .input-field.is-focus-visible {
     background: var(--input-container-background-focus);
     border-color: var(--input-border-color-focus);
-    outline: none;
+    outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 

--- a/src/ui/patterns/link.css
+++ b/src/ui/patterns/link.css
@@ -37,7 +37,7 @@
   .link:focus-visible,
   .link.is-focus-visible {
     color: var(--link-text-color-hover);
-    outline: none;
+    outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
     border-radius: var(--size-radius-100);
   }

--- a/src/ui/patterns/radio.css
+++ b/src/ui/patterns/radio.css
@@ -94,7 +94,7 @@
   .radio:focus-visible,
   .radio.is-focus-visible {
     border-color: var(--radio-border-color-focus);
-    outline: none;
+    outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 

--- a/src/ui/patterns/select.css
+++ b/src/ui/patterns/select.css
@@ -155,7 +155,7 @@
   .select.is-focus-visible {
     background: var(--select-container-background-focus);
     border-color: var(--select-border-color-focus);
-    outline: none;
+    outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 

--- a/src/ui/patterns/switch.css
+++ b/src/ui/patterns/switch.css
@@ -126,7 +126,7 @@
   .switch:focus-visible,
   .switch.is-focus-visible {
     border-color: var(--switch-track-border-color-active);
-    outline: none;
+    outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 

--- a/src/ui/patterns/tabs.css
+++ b/src/ui/patterns/tabs.css
@@ -52,7 +52,7 @@
 
   .tab:focus-visible,
   .tab.is-focus-visible {
-    outline: none;
+    outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 

--- a/src/ui/patterns/textarea.css
+++ b/src/ui/patterns/textarea.css
@@ -28,7 +28,7 @@
   .textarea:focus-visible,
   .textarea.is-focus-visible {
     border-color: var(--textarea-border-color-focus);
-    outline: none;
+    outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 


### PR DESCRIPTION
## Summary

Replace `outline: none` with `outline: 2px solid transparent` in all pattern `:focus-visible` rules.

## Why

In Windows High Contrast Mode (`forced-colors: active`), the browser ignores `box-shadow`. Since all patterns used `outline: none` + `box-shadow` for their focus ring, focused elements had **no visible focus indicator** in forced-colors mode.

A transparent outline is invisible in normal rendering but gets remapped to a system color by the UA in forced-colors mode — this is the standard accessible pattern recommended by WCAG 2.4.7 and the CSS WG.

## What changed

- 10 pattern CSS files: `outline: none` → `outline: 2px solid transparent`
- No new tokens, no visual change in standard mode
- Existing `box-shadow` focus ring behavior is unchanged

## Files

```
src/ui/patterns/accordion.css
src/ui/patterns/button.css
src/ui/patterns/checkbox.css
src/ui/patterns/input.css
src/ui/patterns/link.css
src/ui/patterns/radio.css
src/ui/patterns/select.css
src/ui/patterns/switch.css
src/ui/patterns/tabs.css
src/ui/patterns/textarea.css
```

## Checks

- `npm run ci:check` passes (lint, 71 tests, build, smoke, tokens, DTCG, assets, rules, docs)
- Pre-commit hooks pass

## Risk

- **Low** — no visual change in standard mode; transparent outline is the established accessibility best practice
- Tested patterns: button (solid/outline/ghost), input, checkbox, radio, switch, link, select, textarea, tabs, accordion