### PR TITLE
Add UIF governance sync checks and workspace templates

### DIFF
--- a/.uif/packs/agent/README.md
+++ b/.uif/packs/agent/README.md
@@ -1,0 +1,20 @@
+---
+title: Agent Pack Placeholder
+status: placeholder
+pack: agent
+---
+
+# Agent Pack
+
+This directory is reserved for reviewed, versioned, tool-independent agent
+guidance consumed from the UI Foundations Vault.
+
+Expected future artifacts:
+
+- agent operating rules
+- agent mode guidance
+- review checklists
+- model-independent behavior constraints
+
+Do not copy Vault content into this directory without updating
+`.uif/registry/source.yml` and reviewing `.uif/registry/sync-policy.yml`.

--- a/.uif/packs/governance/README.md
+++ b/.uif/packs/governance/README.md
@@ -1,0 +1,20 @@
+---
+title: Governance Pack Placeholder
+status: placeholder
+pack: governance
+---
+
+# Governance Pack
+
+This directory is reserved for reviewed, versioned governance artifacts consumed
+from the UI Foundations Vault.
+
+Expected future artifacts:
+
+- reusable governance rules
+- review criteria
+- architecture constraints
+- naming and ownership policies
+
+Imported governance informs this repository but does not automatically override
+documented local runtime decisions.

--- a/.uif/packs/runtime/README.md
+++ b/.uif/packs/runtime/README.md
@@ -1,0 +1,19 @@
+---
+title: Runtime Pack Placeholder
+status: placeholder
+pack: runtime
+---
+
+# Runtime Pack
+
+This directory is reserved for reviewed, versioned runtime guidance consumed
+from the UI Foundations Vault.
+
+Expected future artifacts:
+
+- runtime repository boundaries
+- package consumption guidance
+- CI expectations
+- documentation integration guidance
+
+Runtime implementation remains owned by this repository.

--- a/.uif/registry/governance-hierarchy.md
+++ b/.uif/registry/governance-hierarchy.md
@@ -1,0 +1,39 @@
+---
+title: UIF Governance Consumption Hierarchy
+status: active
+type: governance-architecture
+owner: ui-foundations-runtime
+---
+
+# UIF Governance Consumption Hierarchy
+
+This repository consumes reusable governance from the UI Foundations Vault while
+remaining an independent runtime repository.
+
+## Hierarchy
+
+1. Knowledge
+   - Reusable findings, practices, constraints, and context.
+2. Governance
+   - Durable rules derived from validated knowledge.
+3. Specifications
+   - Actionable requirements that apply governance to a domain.
+4. Skills
+   - Repeatable operating procedures for humans, agents, and systems.
+5. Export Packs
+   - Versioned bundles prepared by the Vault for downstream consumption.
+6. Runtime Consumption
+   - Local import, review, and interpretation of export packs.
+7. Implementation
+   - Runtime-specific code, documentation, tokens, and workflow changes.
+8. Reflection
+   - Local observations from applying governance in this repository.
+9. Promotion Candidate
+   - Local reflection prepared for Vault review.
+10. Vault
+   - Source of truth for reusable governance after review and promotion.
+
+## Boundary
+
+Imported packs inform local work. They do not automatically change runtime
+implementation, local decisions, or repository ownership.

--- a/.uif/registry/source.yml
+++ b/.uif/registry/source.yml
@@ -1,0 +1,68 @@
+schemaVersion: 1
+kind: UIFSourceRegistry
+metadata:
+  repository: ui-foundations
+  repositoryType: runtime
+  version: "0.1.0"
+vault:
+  repository: ui-foundations-vault
+  remote: https://github.com/tbielich/ui-foundations-vault.git
+  ref:
+    strategy:
+      stable: git-tag
+      snapshot: git-sha
+      experimental: branch
+    current:
+      type: sha
+      value: fbeb803e51f11d5c372ece8ced4405f37f999fb3
+      status: snapshot
+    branchPolicy: Branch refs are allowed only for experiments and must not be used for stable pack consumption.
+  sourceOfTruthFor:
+    - reusable-governance
+    - reusable-agent-guidance
+    - reusable-knowledge
+consumption:
+  mode: reviewed-manual
+  automaticSync: false
+  consumedPacks:
+    - id: agent
+      path: ../packs/agent
+      lastKnownVersion: unknown
+      versionStatus: experimental
+      versionRef:
+        type: branch
+        value: main
+      description: Tool-independent agent operating guidance.
+    - id: governance
+      path: ../packs/governance
+      lastKnownVersion: 0.1.0
+      versionStatus: snapshot
+      versionRef:
+        type: sha
+        value: fbeb803e51f11d5c372ece8ced4405f37f999fb3
+      description: Reusable governance rules and review criteria.
+    - id: runtime
+      path: ../packs/runtime
+      lastKnownVersion: unknown
+      versionStatus: experimental
+      versionRef:
+        type: branch
+        value: main
+      description: Runtime repository guidance and boundaries.
+localRuntimeBoundaries:
+  ownedLocally:
+    - runtime-code
+    - components
+    - css
+    - token-exports
+    - build-scripts
+    - package-exports
+    - local-decisions
+    - local-overrides
+    - local-lessons
+  neverImportedBlindly:
+    - generated-files
+    - runtime-implementation
+    - package-scripts
+    - ci-workflows
+    - repository-specific-agent-rules

--- a/.uif/registry/sync-policy.yml
+++ b/.uif/registry/sync-policy.yml
@@ -1,0 +1,95 @@
+schemaVersion: 1
+kind: UIFSyncPolicy
+metadata:
+  repository: ui-foundations
+  repositoryType: runtime
+  mode: governance-consumption
+policy:
+  automaticSyncAllowed: false
+  fileMutationAllowed: false
+  importsAllowed:
+    - governance-documents
+    - agent-guidance
+    - runtime-boundary-guidance
+    - reviewed-knowledge-pack-indexes
+  importsNotAllowed:
+    - runtime-code
+    - components
+    - css
+    - token-values
+    - generated-output
+    - build-output
+    - unreviewed-tool-specific-instructions
+versioning:
+  packVersioning:
+    stable:
+      refType: tag
+      requiredFor: reviewed-pack-consumption
+    snapshot:
+      refType: sha
+      requiredFor: reproducible-snapshot-consumption
+    experimental:
+      refType: branch
+      allowedFor: exploration-only
+  unknownVersionAllowedOnlyWhenStatus: experimental
+  requiredPackFields:
+    - id
+    - path
+    - lastKnownVersion
+    - versionStatus
+    - versionRef
+localOwnership:
+  workspace:
+    path: ../workspace
+    owner: ui-foundations-runtime
+    rule: Local workspace artifacts are owned by this repository.
+  implementation:
+    owner: ui-foundations-runtime
+    rule: Runtime implementation decisions remain local unless promoted.
+overrideRules:
+  allowedWhen:
+    - local-runtime-boundary-is-documented
+    - override-has-owner
+    - override-has-rationale
+    - override-has-review-status
+  requiredLocation: ../workspace/overrides
+  forbidden:
+    - silent-governance-changes
+    - undocumented-exceptions
+    - direct-edits-to-imported-pack-content
+conflicts:
+  strategy: local-documented-decision-wins-until-reviewed
+  priority:
+    - local-runtime-safety-rules
+    - local-documented-overrides
+    - consumed-vault-packs
+    - generic-agent-rules
+  requiredAction:
+    - record-conflict
+    - identify-affected-pack
+    - identify-local-owner
+    - decide-adopt-override-or-promote
+review:
+  owners:
+    governance: TODO-governance-owner
+    runtime: TODO-runtime-owner
+    agent: TODO-agent-owner
+  requiredFor:
+    - new-imported-pack-version
+    - governance-rule-change
+    - override-change
+    - promotion-candidate
+promotion:
+  candidateStatuses:
+    - draft
+    - proposed
+    - approved
+    - rejected
+    - promoted
+  process:
+    - capture-lesson-or-reflection-locally
+    - classify-as-runtime-specific-or-reusable
+    - create-promotion-candidate
+    - review-with-maintainers
+    - submit-to-vault
+    - consume-back-only-after-vault-version-update

--- a/.uif/schemas/source.schema.json
+++ b/.uif/schemas/source.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "source.schema.json",
+  "title": "UIF Source Registry",
+  "type": "object",
+  "required": ["schemaVersion", "kind", "metadata", "vault", "consumption", "localRuntimeBoundaries"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "kind": { "const": "UIFSourceRegistry" },
+    "metadata": {
+      "type": "object",
+      "required": ["repository", "repositoryType", "version"],
+      "properties": {
+        "repositoryType": { "const": "runtime" }
+      }
+    },
+    "vault": {
+      "type": "object",
+      "required": ["repository", "remote", "ref", "sourceOfTruthFor"],
+      "properties": {
+        "repository": { "const": "ui-foundations-vault" },
+        "remote": { "type": "string", "minLength": 1 },
+        "ref": {
+          "type": "object",
+          "required": ["strategy", "current", "branchPolicy"],
+          "properties": {
+            "strategy": {
+              "type": "object",
+              "required": ["stable", "snapshot", "experimental"],
+              "properties": {
+                "stable": { "const": "git-tag" },
+                "snapshot": { "const": "git-sha" },
+                "experimental": { "const": "branch" }
+              }
+            },
+            "current": {
+              "type": "object",
+              "required": ["type", "value", "status"],
+              "properties": {
+                "type": { "enum": ["tag", "sha", "branch"] },
+                "status": { "enum": ["stable", "snapshot", "experimental"] }
+              }
+            }
+          }
+        }
+      }
+    },
+    "consumption": {
+      "type": "object",
+      "required": ["mode", "automaticSync", "consumedPacks"],
+      "properties": {
+        "mode": { "const": "reviewed-manual" },
+        "automaticSync": { "const": false },
+        "consumedPacks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "path", "lastKnownVersion", "versionStatus", "versionRef", "description"],
+            "properties": {
+              "id": { "enum": ["agent", "governance", "runtime"] },
+              "versionStatus": { "enum": ["stable", "snapshot", "experimental"] },
+              "versionRef": {
+                "type": "object",
+                "required": ["type", "value"],
+                "properties": {
+                  "type": { "enum": ["tag", "sha", "branch"] }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.uif/schemas/sync-policy.schema.json
+++ b/.uif/schemas/sync-policy.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "sync-policy.schema.json",
+  "title": "UIF Sync Policy",
+  "type": "object",
+  "required": ["schemaVersion", "kind", "metadata", "policy", "versioning", "localOwnership", "overrideRules", "conflicts", "review", "promotion"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "kind": { "const": "UIFSyncPolicy" },
+    "metadata": {
+      "type": "object",
+      "required": ["repository", "repositoryType", "mode"],
+      "properties": {
+        "repositoryType": { "const": "runtime" },
+        "mode": { "const": "governance-consumption" }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "required": ["automaticSyncAllowed", "fileMutationAllowed", "importsAllowed", "importsNotAllowed"],
+      "properties": {
+        "automaticSyncAllowed": { "const": false },
+        "fileMutationAllowed": { "const": false }
+      }
+    },
+    "versioning": {
+      "type": "object",
+      "required": ["packVersioning", "unknownVersionAllowedOnlyWhenStatus", "requiredPackFields"]
+    },
+    "conflicts": {
+      "type": "object",
+      "required": ["strategy", "priority", "requiredAction"],
+      "properties": {
+        "priority": {
+          "const": [
+            "local-runtime-safety-rules",
+            "local-documented-overrides",
+            "consumed-vault-packs",
+            "generic-agent-rules"
+          ]
+        }
+      }
+    },
+    "review": {
+      "type": "object",
+      "required": ["owners", "requiredFor"]
+    },
+    "promotion": {
+      "type": "object",
+      "required": ["candidateStatuses", "process"],
+      "properties": {
+        "candidateStatuses": {
+          "const": ["draft", "proposed", "approved", "rejected", "promoted"]
+        }
+      }
+    }
+  }
+}

--- a/.uif/schemas/workspace-decision.schema.json
+++ b/.uif/schemas/workspace-decision.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "workspace-decision.schema.json",
+  "title": "UIF Decision Frontmatter",
+  "type": "object",
+  "required": ["schemaVersion", "kind", "id", "status", "date", "owner", "relatedPacks", "affectedArtifacts", "promotionCandidate"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "kind": { "const": "UIFDecisionRecord" },
+    "status": { "enum": ["draft", "proposed", "approved", "rejected", "promoted"] },
+    "relatedPacks": { "type": "array" },
+    "affectedArtifacts": { "type": "array" },
+    "promotionCandidate": { "type": "boolean" }
+  }
+}

--- a/.uif/schemas/workspace-lesson.schema.json
+++ b/.uif/schemas/workspace-lesson.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "workspace-lesson.schema.json",
+  "title": "UIF Lesson Frontmatter",
+  "type": "object",
+  "required": ["schemaVersion", "kind", "id", "status", "date", "owner", "relatedPacks", "affectedArtifacts", "shouldPromoteToVault"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "kind": { "const": "UIFLesson" },
+    "status": { "enum": ["draft", "proposed", "approved", "rejected", "promoted"] },
+    "relatedPacks": { "type": "array" },
+    "affectedArtifacts": { "type": "array" },
+    "shouldPromoteToVault": { "enum": ["unknown", true, false] }
+  }
+}

--- a/.uif/schemas/workspace-override.schema.json
+++ b/.uif/schemas/workspace-override.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "workspace-override.schema.json",
+  "title": "UIF Override Frontmatter",
+  "type": "object",
+  "required": ["schemaVersion", "kind", "id", "status", "date", "owner", "sourcePack", "sourceRule", "affectedArtifacts", "reviewRequired", "promotionCandidate"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "kind": { "const": "UIFOverride" },
+    "status": { "enum": ["draft", "proposed", "approved", "rejected", "promoted"] },
+    "affectedArtifacts": { "type": "array" },
+    "reviewRequired": { "type": "boolean" },
+    "promotionCandidate": { "type": "boolean" }
+  }
+}

--- a/.uif/schemas/workspace-reflection.schema.json
+++ b/.uif/schemas/workspace-reflection.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "workspace-reflection.schema.json",
+  "title": "UIF Reflection Frontmatter",
+  "type": "object",
+  "required": ["schemaVersion", "kind", "id", "status", "date", "owner", "trigger", "relatedPacks", "promotionCandidate"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "kind": { "const": "UIFReflection" },
+    "status": { "enum": ["draft", "proposed", "approved", "rejected", "promoted"] },
+    "relatedPacks": { "type": "array" },
+    "promotionCandidate": { "type": "boolean" }
+  }
+}

--- a/.uif/workspace/decisions/template.md
+++ b/.uif/workspace/decisions/template.md
@@ -1,0 +1,23 @@
+---
+schemaVersion: 1
+kind: UIFDecisionRecord
+id: decision-0000
+status: draft
+date: YYYY-MM-DD
+owner: ""
+relatedPacks: []
+affectedArtifacts: []
+promotionCandidate: false
+---
+
+# Decision Record Template
+
+## Context
+
+## Decision
+
+## Rationale
+
+## Consequences
+
+## Review Status

--- a/.uif/workspace/lessons/template.md
+++ b/.uif/workspace/lessons/template.md
@@ -1,0 +1,25 @@
+---
+schemaVersion: 1
+kind: UIFLesson
+id: lesson-0000
+status: draft
+date: YYYY-MM-DD
+owner: ""
+relatedPacks: []
+affectedArtifacts: []
+shouldPromoteToVault: unknown
+---
+
+# Lesson Template
+
+## Context
+
+## Observation
+
+## Decision
+
+## Impact
+
+## Should Flow Back To Vault?
+
+## Affected Artifacts

--- a/.uif/workspace/overrides/template.md
+++ b/.uif/workspace/overrides/template.md
@@ -1,0 +1,25 @@
+---
+schemaVersion: 1
+kind: UIFOverride
+id: override-0000
+status: draft
+date: YYYY-MM-DD
+owner: ""
+sourcePack: ""
+sourceRule: ""
+affectedArtifacts: []
+reviewRequired: true
+promotionCandidate: false
+---
+
+# Override Template
+
+## Local Boundary
+
+## Overridden Rule
+
+## Reason
+
+## Scope
+
+## Expiry Or Review Trigger

--- a/.uif/workspace/reflection/template.md
+++ b/.uif/workspace/reflection/template.md
@@ -1,0 +1,25 @@
+---
+schemaVersion: 1
+kind: UIFReflection
+id: reflection-0000
+status: draft
+date: YYYY-MM-DD
+owner: ""
+trigger: ""
+relatedPacks: []
+promotionCandidate: false
+---
+
+# Reflection Template
+
+## Trigger
+
+## What Happened
+
+## What Worked
+
+## What Failed
+
+## Reusable Insight
+
+## Promotion Recommendation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,16 @@ Do not edit generated files in `dist/`.
 
 ---
 
+## UIF Governance Consumption
+
+- `.uif/packs/` contains consumed governance from the UI Foundations Vault.
+- `.uif/workspace/` belongs only to this repository and stores local decisions, overrides, lessons, and reflection.
+- Governance must never be changed silently; document the owner, rationale, and review status.
+- New insights start locally in `.uif/workspace/lessons/` or `.uif/workspace/reflection/`.
+- Only reviewed promotion candidates can become Vault governance.
+
+---
+
 ## Validation (REQUIRED)
 
 Before completion:

--- a/docs/uif-governance.md
+++ b/docs/uif-governance.md
@@ -1,0 +1,163 @@
+---
+title: UIF Governance Consumption
+status: active
+type: governance
+owner: ui-foundations-runtime
+---
+
+# UIF Governance Consumption
+
+## Purpose
+
+This repository consumes reusable governance from the UI Foundations Vault while
+remaining an independent runtime repository. The Vault is the source of truth for
+reusable governance. Local runtime decisions stay local unless reviewed and
+promoted.
+
+## Architecture
+
+Governance consumption lives under `.uif/`:
+
+- `.uif/registry/` records source, hierarchy, and sync policy.
+- `.uif/packs/` reserves reviewed Vault pack locations.
+- `.uif/workspace/` stores local runtime decisions, overrides, lessons, and reflection.
+
+No automatic synchronization is implemented. Imports are reviewed manually and
+must be versioned through the registry.
+
+## Governance Hierarchy
+
+The operating hierarchy is:
+
+1. Knowledge
+2. Governance
+3. Specifications
+4. Skills
+5. Export Packs
+6. Runtime Consumption
+7. Implementation
+8. Reflection
+9. Promotion Candidate
+10. Vault
+
+The short architecture contract is stored in
+`.uif/registry/governance-hierarchy.md`.
+
+## Pack Concept
+
+Packs are consumed governance bundles. This repository currently reserves these
+pack channels:
+
+- `agent`: tool-independent agent operating guidance.
+- `governance`: reusable governance rules and review criteria.
+- `runtime`: runtime repository boundaries and consumption guidance.
+
+Pack directories are placeholders until a reviewed Vault version is imported.
+Vault content must not be copied into a pack without updating
+`.uif/registry/source.yml` and reviewing `.uif/registry/sync-policy.yml`.
+
+## Versioning
+
+Pack consumption must be reproducible:
+
+- Stable pack consumption uses Git tags.
+- Reproducible snapshots may use Git SHAs.
+- Branch refs are allowed only for experiments.
+
+Pack versions are tracked in `.uif/registry/source.yml`. A pack may use
+`lastKnownVersion: unknown` only when its `versionStatus` is explicitly
+`experimental`. Reviewed consumption should replace experimental branch refs
+with a tag or SHA before the pack is treated as stable governance.
+
+The first reproducible Governance Pack source is Vault commit
+`fbeb803e51f11d5c372ece8ced4405f37f999fb3`, recorded as a `snapshot` SHA in
+`.uif/registry/source.yml`. Branch refs remain valid only for explicitly
+experimental pack exploration.
+
+## Workspace Concept
+
+The workspace is local to this repository:
+
+- `decisions/`: local decision records.
+- `overrides/`: documented local exceptions to consumed governance.
+- `lessons/`: observations from applying governance in this runtime.
+- `reflection/`: broader review notes and reusable insight candidates.
+
+Workspace artifacts use YAML frontmatter so humans, agents, and CI can inspect
+ownership, status, affected artifacts, and promotion intent.
+
+## Owners
+
+Review ownership is declared in `.uif/registry/sync-policy.yml`.
+
+Current owner values are placeholders until maintainers assign named owners:
+
+- `TODO-governance-owner`
+- `TODO-runtime-owner`
+- `TODO-agent-owner`
+
+The placeholders make missing ownership visible without inventing authority.
+
+## Promotion Process
+
+Local insight becomes reusable governance only after review:
+
+1. Capture a lesson or reflection locally.
+2. Decide whether it is runtime-specific or reusable.
+3. Mark it as a promotion candidate.
+4. Review the candidate with repository maintainers.
+5. Submit the candidate to the Vault.
+6. Consume it back only after the Vault publishes a reviewed pack version.
+
+Until that happens, the insight remains local and must not be treated as Vault
+governance.
+
+Promotion candidates use these lifecycle statuses:
+
+- `draft`: captured locally but not ready for review.
+- `proposed`: submitted for repository review.
+- `approved`: accepted locally as suitable for Vault submission.
+- `rejected`: reviewed and not suitable for promotion.
+- `promoted`: accepted into the Vault and available through a reviewed pack.
+
+## Responsibilities
+
+Humans own final governance decisions, local overrides, and promotion approval.
+
+Agents may read packs, create local workspace artifacts, propose changes, and
+run validation. Agents must not silently alter governance or treat local lessons
+as Vault rules.
+
+Systems may validate registry, pack, and workspace structure. Systems must not
+perform automatic synchronization or mutate repository files as part of sync
+checks.
+
+## Conflict Handling
+
+When consumed governance conflicts with documented runtime decisions, the local
+documented decision wins until reviewed. The conflict must be recorded as a
+decision, override, lesson, or reflection, depending on its scope.
+
+Conflict priority is fixed:
+
+1. Local runtime safety rules
+2. Local documented overrides
+3. Consumed Vault packs
+4. Generic agent rules
+
+This priority prevents generic or imported guidance from silently weakening
+runtime safety or documented local ownership.
+
+## Validation
+
+`scripts/uif-sync-check.mjs` validates only local structure and metadata:
+
+- registry files exist
+- pack and workspace directories exist
+- schemas exist
+- required registry fields are present
+- enum values are valid
+- unknown pack versions are limited to experimental packs
+- workspace Markdown files include valid YAML frontmatter
+
+The script performs no synchronization, no remote access, and no file changes.

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "smoke:check": "node scripts/smoke-check.mjs",
     "assets:check": "node scripts/check-asset-refs.mjs",
     "rules:validate": "node scripts/validate-rule-pipeline.mjs",
+    "uif:sync-check": "node scripts/uif-sync-check.mjs",
     "tokens:generate": "node scripts/extract-tokens.js",
     "tokens:sync": "node scripts/sync-figma-tokens.mjs",
     "tokens:dump": "node scripts/dump-figma-variables.mjs",

--- a/scripts/uif-sync-check.mjs
+++ b/scripts/uif-sync-check.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+
+import { access, readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import yaml from "js-yaml";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+const promotionStatuses = ["draft", "proposed", "approved", "rejected", "promoted"];
+const versionStatuses = ["stable", "snapshot", "experimental"];
+const refTypes = ["tag", "sha", "branch"];
+const statusToRefType = {
+  stable: "tag",
+  snapshot: "sha",
+  experimental: "branch",
+};
+
+const requiredPaths = [
+  ".uif/registry",
+  ".uif/registry/source.yml",
+  ".uif/registry/sync-policy.yml",
+  ".uif/registry/governance-hierarchy.md",
+  ".uif/schemas",
+  ".uif/schemas/source.schema.json",
+  ".uif/schemas/sync-policy.schema.json",
+  ".uif/schemas/workspace-decision.schema.json",
+  ".uif/schemas/workspace-override.schema.json",
+  ".uif/schemas/workspace-lesson.schema.json",
+  ".uif/schemas/workspace-reflection.schema.json",
+  ".uif/packs",
+  ".uif/packs/agent",
+  ".uif/packs/governance",
+  ".uif/packs/runtime",
+  ".uif/workspace",
+  ".uif/workspace/decisions",
+  ".uif/workspace/overrides",
+  ".uif/workspace/lessons",
+  ".uif/workspace/reflection",
+];
+
+const errors = [];
+
+for (const relativePath of requiredPaths) {
+  try {
+    await access(path.join(root, relativePath));
+  } catch {
+    errors.push(`Missing: ${relativePath}`);
+  }
+}
+
+function requireField(object, fieldPath) {
+  const parts = fieldPath.split(".");
+  let current = object;
+
+  for (const part of parts) {
+    if (!current || typeof current !== "object" || !(part in current)) {
+      errors.push(`Missing required field: ${fieldPath}`);
+      return undefined;
+    }
+    current = current[part];
+  }
+
+  return current;
+}
+
+function requireEnum(value, allowed, fieldPath) {
+  if (!allowed.includes(value)) {
+    errors.push(`Invalid enum value at ${fieldPath}: ${String(value)}`);
+  }
+}
+
+function requireArray(value, fieldPath) {
+  if (!Array.isArray(value)) {
+    errors.push(`Expected array at ${fieldPath}`);
+  }
+}
+
+async function readYaml(relativePath) {
+  const content = await readFile(path.join(root, relativePath), "utf8");
+  return yaml.load(content);
+}
+
+function validateSource(source) {
+  requireField(source, "schemaVersion");
+  requireField(source, "kind");
+  requireField(source, "metadata.repository");
+  requireField(source, "metadata.repositoryType");
+  requireField(source, "metadata.version");
+  requireField(source, "vault.repository");
+  requireField(source, "vault.remote");
+  requireField(source, "vault.ref.strategy.stable");
+  requireField(source, "vault.ref.strategy.snapshot");
+  requireField(source, "vault.ref.strategy.experimental");
+
+  const currentRefType = requireField(source, "vault.ref.current.type");
+  const currentRefStatus = requireField(source, "vault.ref.current.status");
+  requireField(source, "vault.ref.current.value");
+  requireEnum(currentRefType, refTypes, "vault.ref.current.type");
+  requireEnum(currentRefStatus, versionStatuses, "vault.ref.current.status");
+
+  if (currentRefStatus && currentRefType && statusToRefType[currentRefStatus] !== currentRefType) {
+    errors.push("Vault current ref type must match its status strategy.");
+  }
+
+  const consumedPacks = requireField(source, "consumption.consumedPacks");
+  requireArray(consumedPacks, "consumption.consumedPacks");
+
+  for (const [index, pack] of (consumedPacks || []).entries()) {
+    const prefix = `consumption.consumedPacks[${index}]`;
+    for (const field of ["id", "path", "lastKnownVersion", "versionStatus", "versionRef", "description"]) {
+      requireField(pack, field);
+    }
+
+    requireEnum(pack.versionStatus, versionStatuses, `${prefix}.versionStatus`);
+    requireEnum(pack.versionRef?.type, refTypes, `${prefix}.versionRef.type`);
+
+    if (pack.versionStatus && pack.versionRef?.type && statusToRefType[pack.versionStatus] !== pack.versionRef.type) {
+      errors.push(`${prefix}.versionRef.type must match versionStatus.`);
+    }
+
+    if (pack.lastKnownVersion === "unknown" && pack.versionStatus !== "experimental") {
+      errors.push(`${prefix}.lastKnownVersion may be unknown only when versionStatus is experimental.`);
+    }
+  }
+}
+
+function validatePolicy(policy) {
+  requireField(policy, "schemaVersion");
+  requireField(policy, "kind");
+  requireField(policy, "metadata.repository");
+  requireField(policy, "metadata.repositoryType");
+  requireField(policy, "metadata.mode");
+  requireField(policy, "policy.automaticSyncAllowed");
+  requireField(policy, "policy.fileMutationAllowed");
+  requireField(policy, "versioning.packVersioning.stable.refType");
+  requireField(policy, "versioning.packVersioning.snapshot.refType");
+  requireField(policy, "versioning.packVersioning.experimental.refType");
+  requireField(policy, "versioning.unknownVersionAllowedOnlyWhenStatus");
+  requireField(policy, "review.owners.governance");
+  requireField(policy, "review.owners.runtime");
+  requireField(policy, "review.owners.agent");
+
+  if (policy.policy?.automaticSyncAllowed !== false) {
+    errors.push("policy.automaticSyncAllowed must be false.");
+  }
+
+  if (policy.policy?.fileMutationAllowed !== false) {
+    errors.push("policy.fileMutationAllowed must be false.");
+  }
+
+  const statuses = requireField(policy, "promotion.candidateStatuses");
+  requireArray(statuses, "promotion.candidateStatuses");
+  if (Array.isArray(statuses) && statuses.join("|") !== promotionStatuses.join("|")) {
+    errors.push("promotion.candidateStatuses must be draft, proposed, approved, rejected, promoted.");
+  }
+
+  const conflictPriority = requireField(policy, "conflicts.priority");
+  requireArray(conflictPriority, "conflicts.priority");
+  const requiredPriority = [
+    "local-runtime-safety-rules",
+    "local-documented-overrides",
+    "consumed-vault-packs",
+    "generic-agent-rules",
+  ];
+  if (Array.isArray(conflictPriority) && conflictPriority.join("|") !== requiredPriority.join("|")) {
+    errors.push("conflicts.priority does not match the required priority order.");
+  }
+}
+
+function parseFrontmatter(content, relativePath) {
+  if (!content.startsWith("---\n")) {
+    errors.push(`Missing YAML frontmatter: ${relativePath}`);
+    return {};
+  }
+
+  const end = content.indexOf("\n---", 4);
+  if (end === -1) {
+    errors.push(`Unclosed YAML frontmatter: ${relativePath}`);
+    return {};
+  }
+
+  return yaml.load(content.slice(4, end)) || {};
+}
+
+function validateWorkspaceFrontmatter(frontmatter, relativePath, expectedKind) {
+  const required = ["schemaVersion", "kind", "id", "status", "date", "owner"];
+  for (const field of required) {
+    requireField(frontmatter, field);
+  }
+
+  if (frontmatter.kind !== expectedKind) {
+    errors.push(`${relativePath} kind must be ${expectedKind}.`);
+  }
+
+  requireEnum(frontmatter.status, promotionStatuses, `${relativePath}.status`);
+
+  const requiredByKind = {
+    UIFDecisionRecord: ["relatedPacks", "affectedArtifacts", "promotionCandidate"],
+    UIFOverride: ["sourcePack", "sourceRule", "affectedArtifacts", "reviewRequired", "promotionCandidate"],
+    UIFLesson: ["relatedPacks", "affectedArtifacts", "shouldPromoteToVault"],
+    UIFReflection: ["trigger", "relatedPacks", "promotionCandidate"],
+  };
+
+  for (const field of requiredByKind[expectedKind] || []) {
+    requireField(frontmatter, field);
+  }
+
+  for (const field of ["relatedPacks", "affectedArtifacts"]) {
+    if (field in frontmatter) {
+      requireArray(frontmatter[field], `${relativePath}.${field}`);
+    }
+  }
+
+  for (const field of ["promotionCandidate", "reviewRequired"]) {
+    if (field in frontmatter && typeof frontmatter[field] !== "boolean") {
+      errors.push(`Expected boolean at ${relativePath}.${field}`);
+    }
+  }
+}
+
+async function validateWorkspaceDirectory(directory, expectedKind) {
+  const fullDirectory = path.join(root, ".uif/workspace", directory);
+  const entries = await readdir(fullDirectory);
+
+  for (const entry of entries) {
+    if (!entry.endsWith(".md")) {
+      continue;
+    }
+
+    const relativePath = `.uif/workspace/${directory}/${entry}`;
+    const content = await readFile(path.join(root, relativePath), "utf8");
+    validateWorkspaceFrontmatter(parseFrontmatter(content, relativePath), relativePath, expectedKind);
+  }
+}
+
+if (errors.length === 0) {
+  validateSource(await readYaml(".uif/registry/source.yml"));
+  validatePolicy(await readYaml(".uif/registry/sync-policy.yml"));
+  await validateWorkspaceDirectory("decisions", "UIFDecisionRecord");
+  await validateWorkspaceDirectory("overrides", "UIFOverride");
+  await validateWorkspaceDirectory("lessons", "UIFLesson");
+  await validateWorkspaceDirectory("reflection", "UIFReflection");
+}
+
+if (errors.length > 0) {
+  console.error("UIF governance structure check failed.");
+  for (const error of errors) {
+    console.error(error);
+  }
+  process.exit(1);
+}
+
+console.log("UIF governance structure and registry check passed.");


### PR DESCRIPTION
## Summary
- Add UIF governance guidance to `AGENTS.md` and document pack ownership and promotion flow
- Introduce `uif:sync-check` to validate governance sync state
- Add registry, schema, and workspace templates for local decisions, lessons, overrides, and reflection

## Testing
- Not run (not requested)