### PR TITLE
Migrate Button to UIF-prefixed naming

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -75,9 +75,10 @@ Notes:
 
 - Canonical public pattern tokens follow the consumed Vault Naming Contract:
   `Component.variant.part.property.state` → `--uif-component-variant-part-property-state`
-- Current unscoped component tokens such as `--button-*` remain supported as
-  deprecated legacy compatibility and must produce migration warnings, not
-  unclear failures.
+- Migrated components emit only canonical token names. Button uses
+  `--uif-button-*` and intentionally provides no library-owned `--button-*`
+  aliases. Components that have not yet migrated may still expose unscoped
+  names until their scoped migration is approved.
 - Brand semantic: role-based and brand-scoped (e.g. `Brand.Color.*`, `Brand.Corner.*`)
 - States: `default`, `hover`, `active`, `focus`, `disabled`
 - CSS variables: kebab-case with `--`
@@ -115,7 +116,8 @@ HTML patterns:
 
 Legacy bare classes such as `.button`, `.input`, and `.link` are retained for
 existing artifacts during migration and are reported as deprecated usage by
-runtime naming checks.
+runtime naming checks. UIF-owned Button emitters use `.uif-button`; `.button`
+is a CSS-only compatibility selector through v1.x.
 
 Nunjucks:
 

--- a/docs/adr/adr-density-responsive-strategy.md
+++ b/docs/adr/adr-density-responsive-strategy.md
@@ -44,7 +44,7 @@ Density (maps semantic roles to different Core steps per density)
   ↑
 Semantics (Size/Spacing Tight, Size/Spacing Component, etc.)
   ↑
-Components (--button-padding-inline, --input-gap, etc.)
+Components (`--uif-button-padding-inline`, `--input-gap`, etc.)
 ```
 
 ### Implementation in Figma

--- a/docs/agentic/assistant-behavior-rules.md
+++ b/docs/agentic/assistant-behavior-rules.md
@@ -35,7 +35,7 @@ type: agent-guide
 9. Every new pattern must have its own pattern-layer tokens. Never reuse tokens from another pattern (e.g. do not use `--input-checkbox-*` for a radio).
    - Check `dist/tokens/css/patterns-ui.tokens.css` for existing tokens.
    - If the pattern has no tokens in Figma yet, propose new public token slots following the Vault naming pattern `--uif-<pattern>-<part>-<property>-<state>` and add them to the `Patterns (UI)` collection, referencing only Semantics (Brands), Appearance, or Core tokens.
-   - Existing unscoped pattern tokens such as `--button-*` are deprecated legacy compatibility and should be migrated with explicit warnings.
+   - Migrated patterns emit canonical `--uif-*` tokens only. Button has no library-owned `--button-*` alias; components that have not yet migrated may retain unscoped tokens until their scoped migration is approved.
    - This keeps patterns independently adaptable across brand/mode context and avoids hidden coupling.
 10. Token alias references must point to tokens that actually exist in the system.
     - Before adding a `$ref`, verify the target exists in `dist/tokens/css/` (Core, Appearance, Semantics (Brands)).

--- a/docs/foundations/foundation-013-class-naming.md
+++ b/docs/foundations/foundation-013-class-naming.md
@@ -69,7 +69,8 @@ namespace prefixes.
 
 ### Migration Note
 
-Existing runtime artifacts still use bare classes such as `.button`, `.input`,
-and `.calendar-cell`. These are deprecated legacy compatibility classes. Runtime
-validation should warn with migration guidance rather than fail existing
-artifacts without context.
+Some runtime artifacts still use bare classes such as `.input` and
+`.calendar-cell`. Button emitters now use `.uif-button`; `.button` remains a
+deprecated CSS-only compatibility selector through v1.x. Runtime validation
+should warn with migration guidance rather than fail existing artifacts without
+context.

--- a/figma/README.md
+++ b/figma/README.md
@@ -34,7 +34,7 @@ Examples:
 
 ## Code Syntax (WEB)
 
-Every variable should have a `codeSyntax.WEB` value set (e.g. `var(--button-border-radius)`). This is how the token pipeline maps Figma variables to CSS Custom Properties.
+Every variable should have a `codeSyntax.WEB` value set (e.g. `var(--uif-button-border-radius)`). This is how the token pipeline maps Figma variables to CSS Custom Properties.
 
 ## Token Foundry Plugin
 

--- a/figma/exports/Patterns (UI).tokens.json
+++ b/figma/exports/Patterns (UI).tokens.json
@@ -12,7 +12,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--button-border-size-hover)"
+            "WEB": "var(--uif-button-border-size-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:7",
@@ -34,7 +34,7 @@
             "STROKE_FLOAT"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--button-border-size-default)"
+            "WEB": "var(--uif-button-border-size-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:7",
@@ -56,7 +56,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--button-border-radius)"
+            "WEB": "var(--uif-button-border-radius)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2006:215",
@@ -78,7 +78,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--button-border-color-disabled)"
+            "WEB": "var(--uif-button-border-color-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:346",
@@ -100,7 +100,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--button-border-size-active)"
+            "WEB": "var(--uif-button-border-size-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:8",
@@ -125,7 +125,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-solid-border-color-default)"
+              "WEB": "var(--uif-button-solid-border-color-default)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:345",
@@ -147,7 +147,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-solid-border-color-hover)"
+              "WEB": "var(--uif-button-solid-border-color-hover)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:345",
@@ -169,7 +169,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-solid-border-color-active)"
+              "WEB": "var(--uif-button-solid-border-color-active)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:345",
@@ -191,7 +191,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-solid-border-color-focus)"
+              "WEB": "var(--uif-button-solid-border-color-focus)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:345",
@@ -214,7 +214,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--button-solid-text-color-default)"
+            "WEB": "var(--uif-button-solid-text-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2616:2",
@@ -237,7 +237,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-solid-container-background-default)"
+              "WEB": "var(--uif-button-solid-container-background-default)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:337",
@@ -259,7 +259,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-solid-container-background-hover)"
+              "WEB": "var(--uif-button-solid-container-background-hover)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:337",
@@ -281,7 +281,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-solid-container-background-active)"
+              "WEB": "var(--uif-button-solid-container-background-active)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:337",
@@ -303,7 +303,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-solid-container-background-focus)"
+              "WEB": "var(--uif-button-solid-container-background-focus)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:337",
@@ -326,7 +326,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--button-solid-text-color-hover)"
+            "WEB": "var(--uif-button-solid-text-color-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2616:2",
@@ -348,7 +348,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--button-solid-text-color-active)"
+            "WEB": "var(--uif-button-solid-text-color-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2616:2",
@@ -373,7 +373,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-outline-border-color-default)"
+              "WEB": "var(--uif-button-outline-border-color-default)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:345",
@@ -395,7 +395,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-outline-border-color-hover)"
+              "WEB": "var(--uif-button-outline-border-color-hover)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:345",
@@ -417,7 +417,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-outline-border-color-active)"
+              "WEB": "var(--uif-button-outline-border-color-active)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:345",
@@ -439,7 +439,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-outline-border-color-focus)"
+              "WEB": "var(--uif-button-outline-border-color-focus)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:345",
@@ -462,7 +462,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--button-outline-text-color-default)"
+            "WEB": "var(--uif-button-outline-text-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:340",
@@ -485,7 +485,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-outline-container-background-default)"
+              "WEB": "var(--uif-button-outline-container-background-default)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:329",
@@ -507,7 +507,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-outline-container-background-active)"
+              "WEB": "var(--uif-button-outline-container-background-active)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:329",
@@ -529,7 +529,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-outline-container-background-hover)"
+              "WEB": "var(--uif-button-outline-container-background-hover)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:329",
@@ -551,7 +551,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-outline-container-background-focus)"
+              "WEB": "var(--uif-button-outline-container-background-focus)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:329",
@@ -574,7 +574,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--button-outline-text-color-hover)"
+            "WEB": "var(--uif-button-outline-text-color-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:340",
@@ -596,7 +596,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--button-outline-text-color-active)"
+            "WEB": "var(--uif-button-outline-text-color-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:340",
@@ -621,7 +621,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-ghost-container-background-default)"
+              "WEB": "var(--uif-button-ghost-container-background-default)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:329",
@@ -643,7 +643,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-ghost-container-background-hover)"
+              "WEB": "var(--uif-button-ghost-container-background-hover)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:329",
@@ -665,7 +665,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-ghost-container-background-focus)"
+              "WEB": "var(--uif-button-ghost-container-background-focus)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:329",
@@ -687,7 +687,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-ghost-container-background-active)"
+              "WEB": "var(--uif-button-ghost-container-background-active)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:329",
@@ -711,7 +711,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-ghost-border-color-default)"
+              "WEB": "var(--uif-button-ghost-border-color-default)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2006:195",
@@ -733,7 +733,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-ghost-border-color-hover)"
+              "WEB": "var(--uif-button-ghost-border-color-hover)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2006:195",
@@ -755,7 +755,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-ghost-border-color-focus)"
+              "WEB": "var(--uif-button-ghost-border-color-focus)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2006:195",
@@ -777,7 +777,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--button-ghost-border-color-active)"
+              "WEB": "var(--uif-button-ghost-border-color-active)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2006:195",
@@ -800,7 +800,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--button-ghost-text-color-default)"
+            "WEB": "var(--uif-button-ghost-text-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:340",
@@ -822,7 +822,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--button-ghost-text-color-hover)"
+            "WEB": "var(--uif-button-ghost-text-color-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:340",
@@ -844,7 +844,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--button-ghost-text-color-active)"
+            "WEB": "var(--uif-button-ghost-text-color-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:340",
@@ -867,7 +867,7 @@
           "FONT_FAMILY"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--button-font-family)"
+          "WEB": "var(--uif-button-font-family)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:2006:214",
@@ -889,7 +889,7 @@
           "LINE_HEIGHT"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--button-line-height)"
+          "WEB": "var(--uif-button-line-height)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3014:10",
@@ -911,7 +911,7 @@
           "FONT_STYLE"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--button-font-weight)"
+          "WEB": "var(--uif-button-font-weight)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3014:8",
@@ -933,7 +933,7 @@
           "FONT_SIZE"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--button-font-size)"
+          "WEB": "var(--uif-button-font-size)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3014:9",
@@ -955,7 +955,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--button-padding-inline)"
+          "WEB": "var(--uif-button-padding-inline)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:5",
@@ -977,7 +977,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--button-gap)"
+          "WEB": "var(--uif-button-gap)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:3",
@@ -999,7 +999,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--button-padding-block)"
+          "WEB": "var(--uif-button-padding-block)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:3",
@@ -1022,7 +1022,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--button-container-background-disabled)"
+            "WEB": "var(--uif-button-container-background-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:330",
@@ -1046,7 +1046,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--button-text-color-disabled)"
+            "WEB": "var(--uif-button-text-color-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:328",
@@ -1069,7 +1069,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--button-overlay-hover)"
+          "WEB": "var(--uif-button-overlay-hover)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:2016:1881",
@@ -1091,7 +1091,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--button-overlay-active)"
+          "WEB": "var(--uif-button-overlay-active)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:2016:1882",
@@ -1113,7 +1113,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--button-padding-inline-icon-only)"
+          "WEB": "var(--uif-button-padding-inline-icon-only)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:3",
@@ -1135,7 +1135,7 @@
           "WIDTH_HEIGHT"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--button-height-min)"
+          "WEB": "var(--uif-button-height-min)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3020:2",
@@ -1181,7 +1181,7 @@
           "WIDTH_HEIGHT"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--button-width-min)"
+          "WEB": "var(--uif-button-width-min)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3020:2",

--- a/packages/mcp-server/src/resources/components.ts
+++ b/packages/mcp-server/src/resources/components.ts
@@ -74,20 +74,27 @@ function parseFrontmatter(content: string): Record<string, string> {
 
 /**
  * Extracts variant class names from a CSS pattern file.
- * Looks for `.component.variant` selectors (e.g., `.button.outline`, `.button.ghost`).
+ * Looks for canonical or legacy component variant selectors (for example,
+ * `.uif-button.outline` or `.button.outline`).
  */
 function extractVariants(cssContent: string, componentName: string): string[] {
   const variants = new Set<string>();
-  // Match patterns like .componentName.variantName (including kebab-case variants)
+  // Match canonical and legacy class chains, including compatibility :is() groups.
   const baseClass = componentName.replace(/-/g, '[-]?');
-  const regex = new RegExp(`\\.${baseClass}\\.([a-z][a-z0-9-]*)`, 'g');
-  let match: RegExpExecArray | null;
+  const classSelector = `\\.(?:uif-)?${baseClass}`;
+  const regexes = [
+    new RegExp(`${classSelector}\\.([a-z][a-z0-9-]*)`, 'g'),
+    new RegExp(`:is\\([^)]*${classSelector}[^)]*\\)\\.([a-z][a-z0-9-]*)`, 'g'),
+  ];
 
-  while ((match = regex.exec(cssContent)) !== null) {
-    const variant = match[1];
-    // Skip state classes (is-hover, is-active, etc.)
-    if (!variant.startsWith('is-')) {
-      variants.add(variant);
+  for (const regex of regexes) {
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(cssContent)) !== null) {
+      const variant = match[1];
+      // Skip state classes (is-hover, is-active, etc.)
+      if (!variant.startsWith('is-')) {
+        variants.add(variant);
+      }
     }
   }
 
@@ -126,14 +133,20 @@ function extractStates(cssContent: string): string[] {
  * Extracts an HTML pattern example from the CSS file or generates a basic one
  * based on the component's class name.
  */
-function generateHtmlPattern(componentName: string, cssContent: string): string {
-  // Determine the primary class name from the CSS (first class selector found)
+function extractPrimaryClassName(componentName: string, cssContent: string): string {
+  const canonicalClassName = `uif-${componentName}`;
+  if (cssContent.includes(`.${canonicalClassName}`)) return canonicalClassName;
+
   const classMatch = cssContent.match(/^\s*\.([a-z][a-z0-9-]*)\s*\{/m);
-  const className = classMatch ? classMatch[1] : componentName;
+  return classMatch ? classMatch[1] : componentName;
+}
+
+function generateHtmlPattern(componentName: string, cssContent: string): string {
+  const className = extractPrimaryClassName(componentName, cssContent);
 
   // Generate a basic HTML pattern based on component type
   if (componentName === 'button') {
-    return `<button class="${className}" type="button">Label</button>`;
+    return `<button class="${className} solid" type="button">Label</button>`;
   }
   if (componentName === 'input') {
     return `<input class="${className}" type="text" />`;
@@ -227,11 +240,7 @@ async function buildComponentData(
   try {
     const cssResult = await reader.read(`${CSS_PATTERNS_DIR}/${componentName}.css`);
     cssContent = cssResult.content;
-    // Extract the primary class name from the CSS
-    const classMatch = cssContent.match(/^\s*\.([a-z][a-z0-9-]*)\s*\{/m);
-    if (classMatch) {
-      cssClassName = classMatch[1];
-    }
+    cssClassName = extractPrimaryClassName(componentName, cssContent);
   } catch {
     // CSS file may not exist for all components
   }

--- a/packages/mcp-server/src/resources/patterns.ts
+++ b/packages/mcp-server/src/resources/patterns.ts
@@ -67,7 +67,7 @@ function extractRelatedComponents(content: string): string[] {
 /**
  * Extracts related tokens from pattern markdown content.
  *
- * Looks for CSS custom property references (e.g., `--button-solid-container-background`)
+ * Looks for CSS custom property references (e.g., `--uif-button-solid-container-background`)
  * and token dot-notation references (e.g., `Button.solid.container`).
  */
 function extractRelatedTokens(content: string): string[] {

--- a/packages/mcp-server/tests/properties/resolution.property.test.ts
+++ b/packages/mcp-server/tests/properties/resolution.property.test.ts
@@ -95,7 +95,7 @@ async function setupTestFixtures(): Promise<string> {
   await mkdir(join(dir, 'src', 'ui', 'patterns'), { recursive: true });
   await writeFile(
     join(dir, 'src', 'ui', 'patterns', 'button.css'),
-    `.button {\n  display: inline-flex;\n}\n.button.outline {\n  background: transparent;\n}\n.button:hover,\n.button.is-hover {\n  opacity: 0.9;\n}\n.button:disabled,\n.button.is-disabled {\n  opacity: 0.5;\n}\n`,
+    `:is(.uif-button, .button),\n:is(.uif-button, .button).solid {\n  display: inline-flex;\n}\n:is(.uif-button, .button).outline {\n  background: transparent;\n}\n:is(.uif-button, .button):hover,\n:is(.uif-button, .button).is-hover {\n  opacity: 0.9;\n}\n:is(.uif-button, .button):disabled,\n:is(.uif-button, .button).is-disabled {\n  opacity: 0.5;\n}\n`,
     'utf8',
   );
   await writeFile(

--- a/packages/mcp-server/tests/resources/components.test.ts
+++ b/packages/mcp-server/tests/resources/components.test.ts
@@ -47,36 +47,37 @@ describe('handleComponents', () => {
     await writeFile(
       join(testDir, 'src', 'ui', 'patterns', 'button.css'),
       `@layer components {
-  .button {
+  :is(.uif-button, .button),
+  :is(.uif-button, .button).solid {
     display: inline-flex;
-    background: var(--button-solid-container-background-default);
+    background: var(--uif-button-solid-container-background-default);
   }
 
-  .button:hover,
-  .button.is-hover {
-    background: var(--button-solid-container-background-hover);
+  :is(.uif-button, .button):hover,
+  :is(.uif-button, .button).is-hover {
+    background: var(--uif-button-solid-container-background-hover);
   }
 
-  .button:active,
-  .button.is-active {
-    background: var(--button-solid-container-background-active);
+  :is(.uif-button, .button):active,
+  :is(.uif-button, .button).is-active {
+    background: var(--uif-button-solid-container-background-active);
   }
 
-  .button:focus-visible,
-  .button.is-focus-visible {
-    border-color: var(--button-solid-border-color-focus);
+  :is(.uif-button, .button):focus-visible,
+  :is(.uif-button, .button).is-focus-visible {
+    border-color: var(--uif-button-solid-border-color-focus);
   }
 
-  .button:disabled,
-  .button.is-disabled {
+  :is(.uif-button, .button):disabled,
+  :is(.uif-button, .button).is-disabled {
     opacity: 0.5;
   }
 
-  .button.outline {
-    background: var(--button-outline-container-background-default);
+  :is(.uif-button, .button).outline {
+    background: var(--uif-button-outline-container-background-default);
   }
 
-  .button.ghost {
+  :is(.uif-button, .button).ghost {
     background: transparent;
   }
 }`,
@@ -182,8 +183,8 @@ describe('handleComponents', () => {
       assert.equal(data.name, 'button');
       assert.equal(data.description, 'Buttons allow users to perform an action.');
       assert.ok(data.documentation.includes('# Button'));
-      assert.equal(data.cssClassName, 'button');
-      assert.ok(data.htmlPattern.includes('button'));
+      assert.equal(data.cssClassName, 'uif-button');
+      assert.match(data.htmlPattern, /class="uif-button solid"/);
       assert.ok(Array.isArray(data.variants));
       assert.ok(Array.isArray(data.states));
       assert.ok(Array.isArray(data.tokens));
@@ -197,6 +198,7 @@ describe('handleComponents', () => {
 
       assert.ok(data.variants.includes('outline'));
       assert.ok(data.variants.includes('ghost'));
+      assert.ok(data.variants.includes('solid'));
     });
 
     it('extracts states from CSS', async () => {

--- a/schemas/web-button.figma.ts
+++ b/schemas/web-button.figma.ts
@@ -6,9 +6,9 @@ figma.connect(
   {
     props: {
       className: figma.className([
-        "button",
+        "uif-button",
         figma.enum("Variant", {
-          Solid: undefined,
+          Solid: "solid",
           Outline: "outline",
           Ghost: "ghost",
         }),

--- a/scripts/smoke-check.mjs
+++ b/scripts/smoke-check.mjs
@@ -86,7 +86,7 @@ function ensureCoreIndexIntegrity() {
 }
 
 function run() {
-  ensureFile("dist/main.css", { nonEmpty: true, mustInclude: ".button" });
+  ensureFile("dist/main.css", { nonEmpty: true, mustInclude: ".uif-button" });
   ensureFile("dist/tokens/tokens.yaml", {
     nonEmpty: true,
     mustInclude: "tokens:",

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -5,8 +5,8 @@
 {%- endmacro %}
 
 {% macro button(label, variant='', disabled=false, type='button') -%}
-{%- set classes = "button" -%}
-{%- if variant -%}{%- set classes = classes + " " + variant -%}{%- endif -%}
+{%- set resolvedVariant = variant if variant == "outline" or variant == "ghost" else "solid" -%}
+{%- set classes = "uif-button " + resolvedVariant -%}
 <button type="{{ type }}" class="{{ classes }}"{% if disabled %} disabled{% endif %}>{{ label }}</button>
 {%- endmacro %}
 

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -100,10 +100,9 @@
       ? startIcon || endIcon || "none"
       : startIcon;
     const iconEnd = resolvedIconOnly ? "" : endIcon;
-    const classes = ["button"];
-
-    if (variant === "outline") classes.push("outline");
-    if (variant === "ghost") classes.push("ghost");
+    const resolvedVariant =
+      variant === "outline" || variant === "ghost" ? variant : "solid";
+    const classes = ["uif-button", resolvedVariant];
     if (resolvedIconOnly) classes.push("icon-only");
     if (previewState === "hover") classes.push("is-hover");
     if (previewState === "active") classes.push("is-active");
@@ -862,7 +861,7 @@
     <input class="input" type="password" />
   </div>
   <div class="form-actions"${alignAttr}>
-    <button class="button solid" type="submit"><span class="label-content"><span class="label-content-text">Sign in</span></span></button>
+    <button class="uif-button solid" type="submit"><span class="label-content"><span class="label-content-text">Sign in</span></span></button>
   </div>
 </form>`;
 

--- a/site/examples/pricing.md
+++ b/site/examples/pricing.md
@@ -118,7 +118,7 @@ breadcrumb:
     margin-block-start: auto;
   }
 
-  .pricing-card-cta .button {
+  .pricing-card-cta .uif-button {
     inline-size: 100%;
     justify-content: center;
   }

--- a/site/examples/vanilla-starter.md
+++ b/site/examples/vanilla-starter.md
@@ -40,7 +40,7 @@ import "ui-foundations/tokens/components.css";
 
 ## 3. Render an example page
 
-Use package classes like `.button`, `.input`, `.field-label`, and `.checkbox`.
+Use package classes like `.uif-button`, `.input`, `.field-label`, and `.checkbox`.
 
 ```js
 document.querySelector("#app").innerHTML = `
@@ -55,7 +55,7 @@ document.querySelector("#app").innerHTML = `
     <input class="input" id="email" type="email" placeholder="name@example.com" />
 
     <div style="height: 0.75rem"></div>
-    <button class="button" type="button">
+    <button class="uif-button solid" type="button">
       <span class="label-content"><span class="label-content-text">Submit</span></span>
     </button>
   </main>

--- a/site/foundations/class-naming.md
+++ b/site/foundations/class-naming.md
@@ -63,6 +63,7 @@ The examples below illustrate the consumed contract. They are not source rules.
 
 ## Migration
 
-Existing runtime artifacts still use bare classes such as `.button`, `.input`,
-and `.calendar-cell`. These are deprecated legacy compatibility classes. Runtime
-validation warns with migration guidance while the migration is in progress.
+Some runtime artifacts still use bare classes such as `.input` and
+`.calendar-cell`. Button emitters now use `.uif-button`; `.button` remains a
+deprecated CSS-only compatibility selector through v1.x. Runtime validation
+warns with migration guidance while the migration is in progress.

--- a/site/getting-started.md
+++ b/site/getting-started.md
@@ -65,7 +65,7 @@ generation, and optional React wrappers.
 ### HTML
 
 ```html
-<button class="button" type="button">Label</button>
+<button class="uif-button solid" type="button">Label</button>
 <input class="input" type="text" placeholder="Email" />
 <a href="/page" class="link">Go to page</a>
 ```

--- a/site/patterns/button.md
+++ b/site/patterns/button.md
@@ -214,7 +214,7 @@ consistent and accessible across brands and modes.
   </div>
   <div class="docs-guideline-item" data-type="dont">
     <div class="docs-guideline-preview">
-      <button class="button docs-dont-custom-color" type="button">Continue</button>
+      <button class="uif-button solid docs-dont-custom-color" type="button">Continue</button>
     </div>
     <div class="docs-guideline-body">
       <p class="docs-guideline-label">Don't</p>
@@ -274,9 +274,9 @@ Use `ButtonGroup` to keep related actions visually and semantically grouped.
   data-attached="false"
   data-justify="start"
 >
-  <button class="button outline" type="button">Day 1</button>
-  <button class="button outline" type="button">Day 2</button>
-  <button class="button outline" type="button">Day 3</button>
+  <button class="uif-button outline" type="button">Day 1</button>
+  <button class="uif-button outline" type="button">Day 2</button>
+  <button class="uif-button outline" type="button">Day 3</button>
 </div>
 ```
 

--- a/src/elements/ui-button.js
+++ b/src/elements/ui-button.js
@@ -27,9 +27,8 @@ class UIButton extends UIElement {
     const endIcon = this.getAttr("end-icon");
     const ariaLabel = this.getAttr("aria-label");
 
-    const classes = ["button"];
-    if (variant === "outline") classes.push("outline");
-    if (variant === "ghost") classes.push("ghost");
+    const resolvedVariant = variant === "outline" || variant === "ghost" ? variant : "solid";
+    const classes = ["uif-button", resolvedVariant];
     if (iconOnly) classes.push("icon-only");
 
     const text = this.textContent.trim();

--- a/src/react/button.js
+++ b/src/react/button.js
@@ -10,6 +10,10 @@ function normalizeJustify(value) {
   return value === "stretch" ? "stretch" : "start";
 }
 
+function normalizeVariant(value) {
+  return value === "outline" || value === "ghost" ? value : "solid";
+}
+
 export function Button({
   variant = "solid",
   className = "",
@@ -22,10 +26,7 @@ export function Button({
   children,
   ...props
 }) {
-  const classes = ["button"];
-
-  if (variant === "outline") classes.push("outline");
-  if (variant === "ghost") classes.push("ghost");
+  const classes = ["uif-button", normalizeVariant(variant)];
   if (className) classes.push(className);
 
   const content = children ?? label;

--- a/src/ui/patterns/button.css
+++ b/src/ui/patterns/button.css
@@ -1,163 +1,167 @@
 @layer components {
-  /* Button token usage examples (ui-foundations) */
+  /*
+   * `.button` is a deprecated v1.x compatibility selector.
+   * UIF-owned emitters use `.uif-button`; remove the alias no earlier than v2.0.
+   */
 
-  .button {
+  :is(.uif-button, .button),
+  :is(.uif-button, .button).solid {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     white-space: nowrap;
-    min-height: var(--button-height-min);
-    background: var(--button-solid-container-background-default);
-    border-color: var(--button-solid-border-color-default);
-    border-width: var(--button-border-size-default);
+    min-height: var(--uif-button-height-min);
+    background: var(--uif-button-solid-container-background-default);
+    border-color: var(--uif-button-solid-border-color-default);
+    border-width: var(--uif-button-border-size-default);
     border-style: solid;
-    color: var(--button-solid-text-color-default);
-    border-radius: var(--button-border-radius);
-    padding-inline: var(--button-padding-inline);
-    padding-block: var(--button-padding-block);
+    color: var(--uif-button-solid-text-color-default);
+    border-radius: var(--uif-button-border-radius);
+    padding-inline: var(--uif-button-padding-inline);
+    padding-block: var(--uif-button-padding-block);
     cursor: pointer;
     -webkit-text-fill-color: currentColor;
   }
 
-  .button .label-content {
+  :is(.uif-button, .button) .label-content {
     line-height: inherit;
     color: inherit;
     -webkit-text-fill-color: currentColor;
   }
 
-  .button .label-content-text,
-  .button .icon {
+  :is(.uif-button, .button) .label-content-text,
+  :is(.uif-button, .button) .icon {
     color: inherit;
     -webkit-text-fill-color: currentColor;
   }
 
-  .button.icon-only {
-    padding-inline: var(--button-padding-block);
+  :is(.uif-button, .button).icon-only {
+    padding-inline: var(--uif-button-padding-block);
   }
 
-  .button:hover,
-  .button.is-hover {
+  :is(.uif-button, .button):hover,
+  :is(.uif-button, .button).is-hover {
     background: linear-gradient(
         0deg,
-        var(--button-overlay-hover),
-        var(--button-overlay-hover)
+        var(--uif-button-overlay-hover),
+        var(--uif-button-overlay-hover)
       ),
-      var(--button-solid-container-background-default);
-    border-color: var(--button-solid-border-color-hover);
-    color: var(--button-solid-text-color-hover);
+      var(--uif-button-solid-container-background-default);
+    border-color: var(--uif-button-solid-border-color-hover);
+    color: var(--uif-button-solid-text-color-hover);
   }
 
-  .button:active,
-  .button.is-active {
+  :is(.uif-button, .button):active,
+  :is(.uif-button, .button).is-active {
     background: linear-gradient(
         0deg,
-        var(--button-overlay-active),
-        var(--button-overlay-active)
+        var(--uif-button-overlay-active),
+        var(--uif-button-overlay-active)
       ),
-      var(--button-solid-container-background-default);
-    border-color: var(--button-solid-border-color-active);
-    color: var(--button-solid-text-color-active);
+      var(--uif-button-solid-container-background-default);
+    border-color: var(--uif-button-solid-border-color-active);
+    color: var(--uif-button-solid-text-color-active);
   }
 
-  .button:focus-visible,
-  .button.is-focus-visible {
-    background: var(--button-solid-container-background-focus);
-    border-color: var(--button-solid-border-color-focus);
-    color: var(--button-solid-text-color-default);
+  :is(.uif-button, .button):focus-visible,
+  :is(.uif-button, .button).is-focus-visible {
+    background: var(--uif-button-solid-container-background-focus);
+    border-color: var(--uif-button-solid-border-color-focus);
+    color: var(--uif-button-solid-text-color-default);
     outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
-  .button.outline {
-    background: var(--button-outline-container-background-default);
-    border-color: var(--button-outline-border-color-default);
-    border-width: var(--button-border-size-default);
+  :is(.uif-button, .button).outline {
+    background: var(--uif-button-outline-container-background-default);
+    border-color: var(--uif-button-outline-border-color-default);
+    border-width: var(--uif-button-border-size-default);
     border-style: solid;
-    color: var(--button-outline-text-color-default);
+    color: var(--uif-button-outline-text-color-default);
   }
 
-  .button.outline:hover,
-  .button.outline.is-hover {
+  :is(.uif-button, .button).outline:hover,
+  :is(.uif-button, .button).outline.is-hover {
     background: linear-gradient(
         0deg,
-        var(--button-overlay-hover),
-        var(--button-overlay-hover)
+        var(--uif-button-overlay-hover),
+        var(--uif-button-overlay-hover)
       ),
-      var(--button-outline-container-background-default);
-    border-color: var(--button-outline-border-color-hover);
-    color: var(--button-outline-text-color-default);
+      var(--uif-button-outline-container-background-default);
+    border-color: var(--uif-button-outline-border-color-hover);
+    color: var(--uif-button-outline-text-color-default);
   }
 
-  .button.outline:active,
-  .button.outline.is-active {
+  :is(.uif-button, .button).outline:active,
+  :is(.uif-button, .button).outline.is-active {
     background: linear-gradient(
         0deg,
-        var(--button-overlay-active),
-        var(--button-overlay-active)
+        var(--uif-button-overlay-active),
+        var(--uif-button-overlay-active)
       ),
-      var(--button-outline-container-background-default);
-    border-color: var(--button-outline-border-color-active);
-    color: var(--button-outline-text-color-active);
+      var(--uif-button-outline-container-background-default);
+    border-color: var(--uif-button-outline-border-color-active);
+    color: var(--uif-button-outline-text-color-active);
   }
 
-  .button.outline:focus-visible,
-  .button.outline.is-focus-visible {
-    background: var(--button-outline-container-background-focus);
-    border-color: var(--button-outline-border-color-focus);
-    color: var(--button-outline-text-color-default);
+  :is(.uif-button, .button).outline:focus-visible,
+  :is(.uif-button, .button).outline.is-focus-visible {
+    background: var(--uif-button-outline-container-background-focus);
+    border-color: var(--uif-button-outline-border-color-focus);
+    color: var(--uif-button-outline-text-color-default);
     outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
-  .button.ghost {
-    background: var(--button-ghost-container-background-default);
-    border-color: var(--button-ghost-border-color-default);
-    border-width: var(--button-border-size-default);
+  :is(.uif-button, .button).ghost {
+    background: var(--uif-button-ghost-container-background-default);
+    border-color: var(--uif-button-ghost-border-color-default);
+    border-width: var(--uif-button-border-size-default);
     border-style: solid;
-    color: var(--button-ghost-text-color-default);
+    color: var(--uif-button-ghost-text-color-default);
   }
 
-  .button.ghost:hover,
-  .button.ghost.is-hover {
+  :is(.uif-button, .button).ghost:hover,
+  :is(.uif-button, .button).ghost.is-hover {
     background: linear-gradient(
         0deg,
-        var(--button-overlay-hover),
-        var(--button-overlay-hover)
+        var(--uif-button-overlay-hover),
+        var(--uif-button-overlay-hover)
       ),
-      var(--button-ghost-container-background-default);
-    border-color: var(--button-ghost-border-color-hover);
-    color: var(--button-ghost-text-color-default);
+      var(--uif-button-ghost-container-background-default);
+    border-color: var(--uif-button-ghost-border-color-hover);
+    color: var(--uif-button-ghost-text-color-default);
   }
 
-  .button.ghost:active,
-  .button.ghost.is-active {
+  :is(.uif-button, .button).ghost:active,
+  :is(.uif-button, .button).ghost.is-active {
     background: linear-gradient(
         0deg,
-        var(--button-overlay-active),
-        var(--button-overlay-active)
+        var(--uif-button-overlay-active),
+        var(--uif-button-overlay-active)
       ),
-      var(--button-ghost-container-background-default);
-    border-color: var(--button-ghost-border-color-active);
-    color: var(--button-ghost-text-color-active);
+      var(--uif-button-ghost-container-background-default);
+    border-color: var(--uif-button-ghost-border-color-active);
+    color: var(--uif-button-ghost-text-color-active);
   }
 
-  .button.ghost:focus-visible,
-  .button.ghost.is-focus-visible {
-    background: var(--button-ghost-container-background-focus);
-    border-color: var(--button-ghost-border-color-focus);
-    color: var(--button-ghost-text-color-default);
+  :is(.uif-button, .button).ghost:focus-visible,
+  :is(.uif-button, .button).ghost.is-focus-visible {
+    background: var(--uif-button-ghost-container-background-focus);
+    border-color: var(--uif-button-ghost-border-color-focus);
+    color: var(--uif-button-ghost-text-color-default);
     outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
-  .button:disabled,
-  .button[disabled],
-  .button.is-disabled {
+  :is(.uif-button, .button):disabled,
+  :is(.uif-button, .button)[disabled],
+  :is(.uif-button, .button).is-disabled {
     cursor: not-allowed;
     opacity: 0.6;
-    background: var(--button-container-background-disabled);
-    border-color: var(--button-border-color-disabled);
-    color: var(--button-text-color-disabled);
+    background: var(--uif-button-container-background-disabled);
+    border-color: var(--uif-button-border-color-disabled);
+    color: var(--uif-button-text-color-disabled);
     pointer-events: none;
   }
 
@@ -175,7 +179,7 @@
     inline-size: 100%;
   }
 
-  .button-group[data-justify="stretch"] > .button {
+  .button-group[data-justify="stretch"] > :is(.uif-button, .button) {
     flex: 1 1 auto;
     justify-content: center;
   }
@@ -184,67 +188,67 @@
     gap: 0;
   }
 
-  .button-group[data-attached="true"] > .button {
+  .button-group[data-attached="true"] > :is(.uif-button, .button) {
     border-radius: var(--size-radius-000);
   }
 
   .button-group[data-attached="true"]:not([data-orientation="vertical"])
-    > .button
-    + .button {
+    > :is(.uif-button, .button)
+    + :is(.uif-button, .button) {
     border-inline-start-width: 0;
   }
 
   .button-group[data-attached="true"][data-orientation="vertical"]
-    > .button
-    + .button {
+    > :is(.uif-button, .button)
+    + :is(.uif-button, .button) {
     border-block-start-width: 0;
   }
 
   .button-group[data-attached="true"]:not([data-orientation="vertical"])
-    > .button:first-child {
+    > :is(.uif-button, .button):first-child {
     border-start-start-radius: var(
       --button-group-border-radius,
-      var(--button-border-radius)
+      var(--uif-button-border-radius)
     );
     border-end-start-radius: var(
       --button-group-border-radius,
-      var(--button-border-radius)
+      var(--uif-button-border-radius)
     );
   }
 
   .button-group[data-attached="true"]:not([data-orientation="vertical"])
-    > .button:last-child {
+    > :is(.uif-button, .button):last-child {
     border-start-end-radius: var(
       --button-group-border-radius,
-      var(--button-border-radius)
+      var(--uif-button-border-radius)
     );
     border-end-end-radius: var(
       --button-group-border-radius,
-      var(--button-border-radius)
+      var(--uif-button-border-radius)
     );
   }
 
   .button-group[data-attached="true"][data-orientation="vertical"]
-    > .button:first-child {
+    > :is(.uif-button, .button):first-child {
     border-start-start-radius: var(
       --button-group-border-radius,
-      var(--button-border-radius)
+      var(--uif-button-border-radius)
     );
     border-start-end-radius: var(
       --button-group-border-radius,
-      var(--button-border-radius)
+      var(--uif-button-border-radius)
     );
   }
 
   .button-group[data-attached="true"][data-orientation="vertical"]
-    > .button:last-child {
+    > :is(.uif-button, .button):last-child {
     border-end-start-radius: var(
       --button-group-border-radius,
-      var(--button-border-radius)
+      var(--uif-button-border-radius)
     );
     border-end-end-radius: var(
       --button-group-border-radius,
-      var(--button-border-radius)
+      var(--uif-button-border-radius)
     );
   }
 }

--- a/src/ui/patterns/input.css
+++ b/src/ui/patterns/input.css
@@ -55,7 +55,7 @@
     font-family: var(--input-font-family);
     font-weight: var(--input-font-weight);
     font-size: var(--input-font-size);
-    line-height: var(--input-line-height, var(--button-line-height, 1.5));
+    line-height: var(--input-line-height, var(--typography-body-line-height));
     color: var(--input-text-color-default);
     background: var(--input-container-background-default);
     border-style: solid;

--- a/tests/button-naming-migration.test.mjs
+++ b/tests/button-naming-migration.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("Button CSS exposes canonical UIF naming with a v1 class alias", async () => {
+  const css = await read("src/ui/patterns/button.css");
+
+  assert.match(css, /:is\(\.uif-button, \.button\)/);
+  assert.match(css, /:is\(\.uif-button, \.button\)\.solid/);
+  assert.match(css, /\.uif-button/);
+  assert.doesNotMatch(css, /--button-(?!group-)/);
+  assert.doesNotMatch(css, /\.button(?:__|--)/);
+});
+
+test("Button token export uses UIF names without legacy token aliases", async () => {
+  const tokenExport = await read("figma/exports/Patterns (UI).tokens.json");
+
+  assert.match(tokenExport, /var\(--uif-button-/);
+  assert.doesNotMatch(tokenExport, /var\(--button-(?!group-)/);
+  assert.match(tokenExport, /var\(--button-group-gap\)/);
+});
+
+test("Button-owned emitters use the canonical root and explicit solid variant", async () => {
+  const [react, element, macro, renderer, schema] = await Promise.all([
+    read("src/react/button.js"),
+    read("src/elements/ui-button.js"),
+    read("site/_includes/macros/ui.njk"),
+    read("site/assets/playground/renderers.js"),
+    read("schemas/web-button.figma.ts"),
+  ]);
+
+  for (const source of [react, element, macro, renderer, schema]) {
+    assert.match(source, /uif-button/);
+    assert.match(source, /solid/);
+  }
+
+  assert.doesNotMatch(react, /const classes = \["button"\]/);
+  assert.doesNotMatch(element, /const classes = \["button"\]/);
+});
+
+test("Input no longer depends on the removed legacy Button token", async () => {
+  const inputCss = await read("src/ui/patterns/input.css");
+
+  assert.doesNotMatch(inputCss, /--button-line-height/);
+  assert.match(inputCss, /--typography-body-line-height/);
+});


### PR DESCRIPTION
Closes #146

## What changed

- Migrates Button CSS and Figma WEB token syntax to `.uif-button` and `--uif-button-*`.
- Makes `solid`, `outline`, and `ghost` explicit in UIF-owned emitters while preserving `.button` as a deprecated CSS selector alias through v1.x.
- Publishes no legacy `--button-*` token aliases; `--button-group-*` remains outside this pilot.
- Removes Input's legacy `--button-line-height` fallback and updates React, custom elements, Nunjucks, playground output, Code Connect, docs, examples, MCP resources, and smoke checks.
- Adds regression coverage for canonical output, class compatibility, token alias absence, and the Input dependency boundary.

## Impact

Button consumers should migrate markup to `.uif-button` and token overrides to `--uif-button-*`. Existing `.button` markup remains styled during v1.x, but old Button token overrides are intentionally a v1 breaking change.

## Validation

- `npm run ci:check`
- `npm run pack:check`
- `npm run lint`
- `npm run test:unit`
- `npm run docs:build`
- `cd packages/mcp-server && npm run test:unit && npm run build`