### PR TITLE
Adopt UIF public API namespace decision

### DIFF
--- a/.uif/packs/governance/contracts/naming-contract.json
+++ b/.uif/packs/governance/contracts/naming-contract.json
@@ -3,15 +3,15 @@
   "contract_id": "governance-pack.naming-contract",
   "title": "Naming Contract",
   "type": "naming-contract",
-  "status": "draft",
+  "status": "review",
   "authority": "derived",
   "owner": "ui-foundations",
   "schema_version": "1.0.0",
-  "contract_version": "0.1.0",
-  "governance_pack_version": "0.7.0",
-  "channel": "draft",
-  "release_date": "2026-07-09",
-  "updated": "2026-07-09",
+  "contract_version": "0.2.0",
+  "governance_pack_version": "0.8.0",
+  "channel": "review",
+  "release_date": "2026-07-15",
+  "updated": "2026-07-15",
   "normativity": {
     "rules_are_normative": true,
     "examples_are_normative": false,
@@ -22,6 +22,15 @@
     "pack_manifest": "exports/governance-pack/pack.yml",
     "pack_changelog": "exports/governance-pack/CHANGELOG.md",
     "canonical_sources": [
+      {
+        "id": "adr.uif-public-api-namespace",
+        "path": "decisions/uif-public-api-namespace.md",
+        "sections": [
+          "Decision",
+          "Consequences",
+          "Verification"
+        ]
+      },
       {
         "id": "specification.pattern.schema",
         "path": "patterns/schemas/pattern.schema.md",
@@ -98,6 +107,36 @@
         "unscoped public tokens such as --button-*"
       ]
     },
+    "nunjucks_macro_namespace": {
+      "alias": "uif",
+      "invocation_pattern": "uif.*",
+      "scope": "public Nunjucks examples and generated snippets",
+      "required": true,
+      "consumer_selected_alias": true,
+      "does_not_govern": [
+        "macro module package path",
+        "named macro exports",
+        "compatibility or migration behavior"
+      ]
+    },
+    "custom_element_tag_prefix": {
+      "prefix": "uif-",
+      "tag_pattern": "uif-[component]",
+      "scope": "public autonomous Custom Element tag names",
+      "required": true,
+      "governs": [
+        "registration strings",
+        "authored tag names",
+        "HTMLElementTagNameMap keys"
+      ],
+      "does_not_govern": [
+        "JavaScript constructor names",
+        "JavaScript export names",
+        "module filenames",
+        "package subpaths",
+        "compatibility or migration behavior"
+      ]
+    },
     "proof_token_prefix": {
       "prefix": "--uif-proof-",
       "scope": "experimental unresolved proof tokens",
@@ -169,6 +208,16 @@
       "label": "non-normative example",
       "kind": "component_token_slot",
       "value": "--uif-button-background"
+    },
+    {
+      "label": "non-normative example",
+      "kind": "nunjucks_macro_invocation",
+      "value": "uif.button(...)"
+    },
+    {
+      "label": "non-normative example",
+      "kind": "custom_element_tag",
+      "value": "<uif-button>"
     },
     {
       "label": "non-normative example",

--- a/.uif/packs/governance/decisions/uif-public-api-namespace.md
+++ b/.uif/packs/governance/decisions/uif-public-api-namespace.md
@@ -1,0 +1,104 @@
+---
+id: adr.uif-public-api-namespace
+title: UIF Public API Namespace
+type: adr
+status: review
+owners:
+  - ui-foundations
+created: 2026-07-15
+updated: 2026-07-15
+authority: source
+summary: Defines the canonical UIF namespace for public macro invocations and Custom Element tag names.
+applies_to:
+  - ui-foundations
+related:
+  governs:
+    - export-pack.governance.naming-rules
+    - export-pack.governance.naming-contract
+  references:
+    - governance.precedence
+    - governance.lifecycle
+---
+
+# ADR: UIF Public API Namespace
+
+## Context
+
+UI Foundations already reserves `uif-` for public CSS classes and `--uif-`
+for UIF-owned public CSS custom properties. Its Nunjucks examples currently use
+the consumer-selected alias `ui`, and its autonomous Custom Elements are
+registered with `ui-*` tag names.
+
+Version 1.0 is intentionally breaking. The public namespace therefore needs to
+be decided before macro examples or Custom Element registrations are migrated.
+
+## Decision
+
+All UIF-owned public APIs use the canonical `uif` namespace unless an accepted
+or stable decision defines a separate namespace contract for a specific API.
+
+For the surfaces approved by this decision:
+
+- Public Nunjucks examples and generated snippets import the macro module with
+  the consumer-selected alias `uif` and invoke macros as `uif.*`.
+- Public autonomous Custom Element tag names use the `uif-` prefix and the form
+  `<uif-[component]>`.
+
+The Nunjucks alias rule governs invocation examples, not the macro module's
+package path or its named macro exports. The Custom Element rule governs tag
+names, including registration strings and `HTMLElementTagNameMap` keys.
+
+This decision does not define compatibility aliases, dual registration,
+deprecation periods, or migration sequencing. It also does not decide whether
+JavaScript constructor names, JavaScript exports, element module filenames, or
+package subpaths must be renamed. Those surfaces require explicit follow-up
+decisions before implementation changes them.
+
+## Rationale
+
+A single visible namespace makes UIF ownership recognizable across CSS,
+templates, and HTML. `uif` is already the canonical CSS namespace and avoids
+introducing a second public abbreviation for the same owner.
+
+Nunjucks import aliases are selected by consumers, so adopting `uif.*` does not
+require a new macro implementation. Custom Element tag names are registered
+public APIs, so their migration is a breaking runtime change and must follow a
+separately reviewed implementation plan.
+
+## Consequences
+
+- New public macro documentation uses `uif.*`.
+- New UIF Custom Element APIs use `<uif-*>`.
+- Existing `ui.*` documentation and `<ui-*>` registrations become migration
+  inventory for the v1 implementation work.
+- No compatibility behavior can be inferred from this ADR.
+- Package paths and JavaScript identifiers remain unchanged until separately
+  decided.
+- Consuming repositories adopt the corresponding governance-pack version only
+  through reviewed local changes.
+
+## Alternatives Considered
+
+- Keep `ui.*` and `<ui-*>`: rejected because it preserves a second public UIF
+  namespace without a separately approved contract.
+- Change only Custom Elements: rejected because public examples would continue
+  to teach inconsistent ownership prefixes.
+- Rename every adjacent `ui` identifier immediately: rejected because package
+  paths and JavaScript identifiers have distinct compatibility consequences
+  that were not approved by this decision.
+- Define aliases or dual registration here: rejected because compatibility and
+  migration behavior require separate evidence and approval.
+
+## Verification
+
+- The canonical naming contract contains a Nunjucks alias rule with `uif`.
+- The canonical naming contract contains a Custom Element tag prefix rule with
+  `uif-`.
+- Examples in the naming contract are explicitly non-normative.
+- Runtime implementation does not begin until compatibility and migration
+  policy are approved.
+
+## Related
+
+- Runtime issue: https://github.com/tbielich/ui-foundations/issues/154
+- Governance pack: `exports/governance-pack/`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,6 +9,8 @@ stable location for humans and agents.
 
 - `adr-agentic-docs-restructure.md` — documentation structure and agent consumption model
 - `adr-github-projects-workflow.md` — GitHub Projects delivery workflow (proposed)
+- `adr-uif-public-api-namespace.md` — canonical `uif.*` macro invocation and
+  `<uif-*>` Custom Element namespaces (proposed)
 
 ## Related docs
 

--- a/docs/adr/adr-uif-public-api-namespace.md
+++ b/docs/adr/adr-uif-public-api-namespace.md
@@ -1,0 +1,98 @@
+---
+title: ADR – UIF Public API Namespace
+status: proposed
+type: adr
+issue: 154
+vault_decision: adr.uif-public-api-namespace
+governance_pack: 0.8.0-review
+---
+
+# ADR: UIF Public API Namespace
+
+## Context
+
+UI Foundations already uses `uif-` for public CSS classes and `--uif-` for
+UIF-owned public CSS custom properties. Public Nunjucks examples currently use
+the consumer-selected alias `ui`, while autonomous Custom Elements are
+registered with `ui-*` tag names.
+
+Version 1.0 is intentionally breaking. Issue
+[#154](https://github.com/tbielich/ui-foundations/issues/154) assessed the
+affected source, exports, tests, examples, documentation, and package entry
+points before approving the canonical namespace for these two surfaces.
+
+## Decision
+
+Adopt the canonical UIF namespace defined by Vault decision
+`adr.uif-public-api-namespace` and Governance Pack `0.8.0`:
+
+- Public Nunjucks documentation and generated snippets import the existing
+  macro module with the consumer-selected alias `uif` and invoke macros as
+  `uif.*`.
+- Public autonomous Custom Element tag names use `<uif-[component]>`.
+
+The Nunjucks decision changes the recommended import alias only. It does not
+rename `macros/ui.njk` or its named macro exports.
+
+The Custom Element decision governs registration strings, authored tag names,
+and `HTMLElementTagNameMap` keys. It does not yet decide JavaScript constructor
+or export names, module filenames, or package subpaths.
+
+## Implementation Boundary
+
+This ADR authorizes the namespace direction, not the runtime migration.
+Implementation remains blocked until a reviewed plan explicitly decides:
+
+1. whether v1 removes `<ui-*>` registrations outright or provides any
+   compatibility period;
+2. migration sequencing across source, tests, examples, documentation, types,
+   and generated package output;
+3. treatment of element module subpaths and exported `UI*` JavaScript names.
+
+No alias, wrapper constructor, dual registration, deprecation period, or package
+redirect is implied by this decision.
+
+## Rationale
+
+The visible public namespace becomes consistent across CSS, templates, and
+HTML, while surfaces with different compatibility costs remain explicit rather
+than being renamed by inference.
+
+Because a Nunjucks import alias is selected by the consumer, `uif.*` can be
+adopted without changing the macro implementation. Custom Element tag names are
+registered public APIs and therefore require a separately approved breaking
+migration.
+
+## Consequences
+
+- New and migrated macro examples will use `uif.*`.
+- New and migrated Custom Element examples will use `<uif-*>`.
+- Existing `ui.*` examples and `<ui-*>` registrations are migration inventory.
+- Compatibility behavior remains an explicit open decision.
+- Runtime package paths and JavaScript identifiers remain unchanged until
+  separately approved.
+- The consumed naming contract is updated through a reviewed runtime change;
+  no automatic cross-repository synchronization is introduced.
+
+## Alternatives Considered
+
+| Alternative | Outcome |
+|---|---|
+| Keep `ui.*` and `<ui-*>` | Rejected because it preserves a second public UIF namespace without an approved exception. |
+| Rename every adjacent `ui` identifier now | Rejected because package and JavaScript identifiers were not approved by this decision. |
+| Define compatibility aliases here | Rejected because compatibility requires a separate implementation decision. |
+
+## Verification
+
+- The consumed naming contract requires the `uif` Nunjucks alias and `uif-`
+  Custom Element tag prefix.
+- Generated runtime contract data remains synchronized with the consumed JSON.
+- No runtime registration, macro implementation, package export, example, or
+  documentation call site is renamed in this governance change.
+
+## Related
+
+- [Issue #154](https://github.com/tbielich/ui-foundations/issues/154)
+- Vault decision `decisions/uif-public-api-namespace.md`
+- `.uif/packs/governance/contracts/naming-contract.json`
+

--- a/scripts/vault-naming-contract.generated.js
+++ b/scripts/vault-naming-contract.generated.js
@@ -93,9 +93,10 @@ const VAULT_NAMING_CONTRACT = Object.freeze({
   },
   "source": {
     "packId": "governance-pack",
-    "packVersion": "0.7.0",
+    "packVersion": "0.8.0",
     "sourceArtifacts": [
       ".uif/packs/governance/contracts/naming-contract.json",
+      ".uif/packs/governance/decisions/uif-public-api-namespace.md",
       ".uif/packs/governance/exports/governance-pack/pack.yml",
       ".uif/packs/governance/governance/lifecycle.md",
       ".uif/packs/governance/patterns/schemas/pattern.schema.md",


### PR DESCRIPTION
## What changed

- adds the runtime ADR adopting `uif.*` and `<uif-*>` as canonical public namespaces
- consumes the proposed Vault Governance Pack 0.8.0 naming contract and source ADR
- regenerates the derived runtime naming contract data

## Why

Issue #154 approved the namespace direction after assessing all macro and Custom
Element usages. The decision must be governed and consumed before runtime names
are migrated.

## Boundaries

This PR makes no runtime naming changes. It does not define aliases, dual
registration, deprecation periods, migration sequencing, JavaScript identifier
renames, module filename changes, or package subpath changes.

Merge dependency: https://github.com/tbielich/ui-foundations-vault/pull/11

## Validation

- `npm run lint`
- `npm run test:unit` (84 passing)
- `npm run ci:check`
- `npm run naming:check` (passes with 341 existing legacy warnings)
- `git diff --check`

Closes #154
