### PR TITLE
Migration: Adopt UIF-prefixed naming for ButtonGroup

### DIFF
--- a/figma/exports/Patterns (UI).tokens.json
+++ b/figma/exports/Patterns (UI).tokens.json
@@ -1158,13 +1158,36 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--button-group-gap)"
+            "WEB": "var(--uif-button-group-gap)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:3",
             "targetVariableName": "Brand/Size/Spacing/Component",
             "targetVariableSetId": "VariableCollectionId:1:177",
             "targetVariableSetName": "Semantics (Brands)"
+          },
+          "com.figma.isOverride": true
+        }
+      },
+      "Border Radius": {
+        "$type": "number",
+        "$value": {
+          "$ref": "Button/Border/Radius"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:3083:2",
+          "com.figma.scopes": [
+            "CORNER_RADIUS"
+          ],
+          "com.figma.hiddenFromPublishing": false,
+          "com.figma.codeSyntax": {
+            "WEB": "var(--uif-button-group-border-radius)"
+          },
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:3:14",
+            "targetVariableName": "Button/Border/Radius",
+            "targetVariableSetId": "VariableCollectionId:1:264",
+            "targetVariableSetName": "Patterns (UI)"
           },
           "com.figma.isOverride": true
         }

--- a/schemas/web-button-group.figma.ts
+++ b/schemas/web-button-group.figma.ts
@@ -12,20 +12,20 @@ figma.connect(
       attached: figma.boolean("Attached", { true: "true", false: "false" }),
     },
     example: ({ orientation, attached }: ButtonGroupProps) => html`<div
-      class="button-group"
+      class="uif-button-group"
       role="group"
       data-orientation="${orientation}"
       data-attached="${attached}"
       data-justify="start"
       aria-label="Button group"
     >
-      <button type="button" class="button outline">
+      <button type="button" class="uif-button outline">
         Day 1
       </button>
-      <button type="button" class="button outline">
+      <button type="button" class="uif-button outline">
         Day 2
       </button>
-      <button type="button" class="button outline">
+      <button type="button" class="uif-button outline">
         Day 3
       </button>
     </div>`,

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -13,7 +13,7 @@
 {% macro buttonGroup(attached=false, orientation='horizontal', justify='start', ariaLabel='', className='') -%}
 {%- set resolvedOrientation = "vertical" if orientation == "vertical" else "horizontal" -%}
 {%- set resolvedJustify = "stretch" if justify == "stretch" else "start" -%}
-{%- set classes = "button-group" -%}
+{%- set classes = "uif-button-group" -%}
 {%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
 <div class="{{ classes }}" role="group" data-orientation="{{ resolvedOrientation }}" data-attached="{{ "true" if attached else "false" }}" data-justify="{{ resolvedJustify }}"{% if ariaLabel %} aria-label="{{ ariaLabel }}"{% endif %}>{{ caller() }}</div>
 {%- endmacro %}

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -483,7 +483,7 @@
       String(props.tertiaryLabel || "Day 3"),
     ];
 
-    element.className = "button-group";
+    element.className = "uif-button-group";
     element.setAttribute("role", "group");
     element.dataset.orientation = orientation;
     element.dataset.justify = justify;
@@ -520,7 +520,7 @@
     });
 
     const groupAttrs = [
-      'class="button-group"',
+      'class="uif-button-group"',
       'role="group"',
       `data-orientation="${quoteAttr(orientation)}"`,
       `data-attached="${attached ? "true" : "false"}"`,

--- a/site/patterns/button.md
+++ b/site/patterns/button.md
@@ -267,7 +267,7 @@ Use `ButtonGroup` to keep related actions visually and semantically grouped.
 
 ```html
 <div
-  class="button-group"
+  class="uif-button-group"
   role="group"
   aria-label="Travel dates"
   data-orientation="horizontal"

--- a/src/elements/ui-button.js
+++ b/src/elements/ui-button.js
@@ -79,7 +79,7 @@ class UIButtonGroup extends UIElement {
 
     const attrs = [
       'role="group"',
-      'class="button-group"',
+      'class="uif-button-group"',
       `data-orientation="${orientation}"`,
       `data-attached="${attached ? "true" : "false"}"`,
       `data-justify="${justify}"`,

--- a/src/react/button.js
+++ b/src/react/button.js
@@ -76,7 +76,7 @@ export function ButtonGroup({
   children,
   ...props
 }) {
-  const classes = ["uif-button-group"];
+  const classes = ["button-group"];
   if (className) classes.push(className);
 
   return React.createElement(

--- a/src/react/button.js
+++ b/src/react/button.js
@@ -76,7 +76,7 @@ export function ButtonGroup({
   children,
   ...props
 }) {
-  const classes = ["button-group"];
+  const classes = ["uif-button-group"];
   if (className) classes.push(className);
 
   return React.createElement(

--- a/src/ui/patterns/button.css
+++ b/src/ui/patterns/button.css
@@ -165,89 +165,102 @@
     pointer-events: none;
   }
 
-  .button-group {
+  /*
+   * `.button-group` is a deprecated v1.x compatibility selector.
+   * UIF-owned emitters use `.uif-button-group`; remove the alias no earlier than v2.0.
+   */
+
+  :is(.uif-button-group, .button-group) {
     display: inline-flex;
     align-items: stretch;
-    gap: var(--button-group-gap, var(--size-spacing-100, 0.25rem));
+    gap: var(--uif-button-group-gap, var(--size-spacing-100, 0.25rem));
   }
 
-  .button-group[data-orientation="vertical"] {
+  :is(.uif-button-group, .button-group)[data-orientation="vertical"] {
     flex-direction: column;
   }
 
-  .button-group[data-justify="stretch"] {
+  :is(.uif-button-group, .button-group)[data-justify="stretch"] {
     inline-size: 100%;
   }
 
-  .button-group[data-justify="stretch"] > :is(.uif-button, .button) {
+  :is(.uif-button-group, .button-group)[data-justify="stretch"]
+    > :is(.uif-button, .button) {
     flex: 1 1 auto;
     justify-content: center;
   }
 
-  .button-group[data-attached="true"] {
+  :is(.uif-button-group, .button-group)[data-attached="true"] {
     gap: 0;
   }
 
-  .button-group[data-attached="true"] > :is(.uif-button, .button) {
+  :is(.uif-button-group, .button-group)[data-attached="true"]
+    > :is(.uif-button, .button) {
     border-radius: var(--size-radius-000);
   }
 
-  .button-group[data-attached="true"]:not([data-orientation="vertical"])
+  :is(.uif-button-group, .button-group)[data-attached="true"]:not(
+      [data-orientation="vertical"]
+    )
     > :is(.uif-button, .button)
     + :is(.uif-button, .button) {
     border-inline-start-width: 0;
   }
 
-  .button-group[data-attached="true"][data-orientation="vertical"]
+  :is(.uif-button-group, .button-group)[data-attached="true"][data-orientation="vertical"]
     > :is(.uif-button, .button)
     + :is(.uif-button, .button) {
     border-block-start-width: 0;
   }
 
-  .button-group[data-attached="true"]:not([data-orientation="vertical"])
+  :is(.uif-button-group, .button-group)[data-attached="true"]:not(
+      [data-orientation="vertical"]
+    )
     > :is(.uif-button, .button):first-child {
     border-start-start-radius: var(
-      --button-group-border-radius,
+      --uif-button-group-border-radius,
       var(--uif-button-border-radius)
     );
     border-end-start-radius: var(
-      --button-group-border-radius,
+      --uif-button-group-border-radius,
       var(--uif-button-border-radius)
     );
   }
 
-  .button-group[data-attached="true"]:not([data-orientation="vertical"])
+  :is(.uif-button-group, .button-group)[data-attached="true"]:not(
+      [data-orientation="vertical"]
+    )
     > :is(.uif-button, .button):last-child {
     border-start-end-radius: var(
-      --button-group-border-radius,
+      --uif-button-group-border-radius,
       var(--uif-button-border-radius)
     );
     border-end-end-radius: var(
-      --button-group-border-radius,
+      --uif-button-group-border-radius,
       var(--uif-button-border-radius)
     );
   }
 
-  .button-group[data-attached="true"][data-orientation="vertical"]
+  :is(.uif-button-group, .button-group)[data-attached="true"][data-orientation="vertical"]
     > :is(.uif-button, .button):first-child {
     border-start-start-radius: var(
-      --button-group-border-radius,
+      --uif-button-group-border-radius,
       var(--uif-button-border-radius)
     );
     border-start-end-radius: var(
-      --button-group-border-radius,
+      --uif-button-group-border-radius,
       var(--uif-button-border-radius)
     );
   }
 
-  .button-group[data-attached="true"][data-orientation="vertical"]
+  :is(.uif-button-group, .button-group)[data-attached="true"][data-orientation="vertical"]
     > :is(.uif-button, .button):last-child {
     border-end-start-radius: var(
-      --button-group-border-radius,
+      --uif-button-group-border-radius,
       var(--uif-button-border-radius)
     );
     border-end-end-radius: var(
-      --button-group-border-radius,
+      --uif-button-group-border-radius,
       var(--uif-button-border-radius)
     );
   }

--- a/tests/button-group-naming-migration.test.mjs
+++ b/tests/button-group-naming-migration.test.mjs
@@ -24,8 +24,7 @@ test("ButtonGroup Figma export contains canonical tokens without legacy aliases"
 });
 
 test("ButtonGroup-owned emitters produce the canonical root class", async () => {
-  const [react, element, macro, renderer, schema, documentation] = await Promise.all([
-    read("src/react/button.js"),
+  const [element, macro, renderer, schema, documentation] = await Promise.all([
     read("src/elements/ui-button.js"),
     read("site/_includes/macros/ui.njk"),
     read("site/assets/playground/renderers.js"),
@@ -33,13 +32,19 @@ test("ButtonGroup-owned emitters produce the canonical root class", async () => 
     read("site/patterns/button.md"),
   ]);
 
-  for (const source of [react, element, macro, renderer, schema, documentation]) {
+  for (const source of [element, macro, renderer, schema, documentation]) {
     assert.match(source, /uif-button-group/);
   }
 
-  assert.doesNotMatch(react, /const classes = \["button-group"\]/);
   assert.doesNotMatch(element, /class="button-group"/);
   assert.doesNotMatch(macro, /set classes = "button-group"/);
   assert.doesNotMatch(renderer, /class(?:Name)? = "button-group"/);
   assert.doesNotMatch(schema, /class="button-group"/);
+});
+
+test("ButtonGroup migration leaves deprecated React wrappers unchanged", async () => {
+  const react = await read("src/react/button.js");
+
+  assert.match(react, /const classes = \["button-group"\]/);
+  assert.doesNotMatch(react, /const classes = \["uif-button-group"\]/);
 });

--- a/tests/button-group-naming-migration.test.mjs
+++ b/tests/button-group-naming-migration.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("ButtonGroup CSS exposes canonical UIF naming with a v1 class alias", async () => {
+  const css = await read("src/ui/patterns/button.css");
+
+  assert.match(css, /:is\(\.uif-button-group, \.button-group\)/);
+  assert.match(css, /--uif-button-group-gap/);
+  assert.match(css, /--uif-button-group-border-radius/);
+  assert.doesNotMatch(css, /--button-group-/);
+  assert.doesNotMatch(css, /\.button-group(?:__|--)/);
+});
+
+test("ButtonGroup Figma export contains canonical tokens without legacy aliases", async () => {
+  const tokenExport = await read("figma/exports/Patterns (UI).tokens.json");
+
+  assert.match(tokenExport, /var\(--uif-button-group-gap\)/);
+  assert.match(tokenExport, /var\(--uif-button-group-border-radius\)/);
+  assert.match(tokenExport, /"targetVariableName": "Button\/Border\/Radius"/);
+  assert.doesNotMatch(tokenExport, /var\(--button-group-/);
+});
+
+test("ButtonGroup-owned emitters produce the canonical root class", async () => {
+  const [react, element, macro, renderer, schema, documentation] = await Promise.all([
+    read("src/react/button.js"),
+    read("src/elements/ui-button.js"),
+    read("site/_includes/macros/ui.njk"),
+    read("site/assets/playground/renderers.js"),
+    read("schemas/web-button-group.figma.ts"),
+    read("site/patterns/button.md"),
+  ]);
+
+  for (const source of [react, element, macro, renderer, schema, documentation]) {
+    assert.match(source, /uif-button-group/);
+  }
+
+  assert.doesNotMatch(react, /const classes = \["button-group"\]/);
+  assert.doesNotMatch(element, /class="button-group"/);
+  assert.doesNotMatch(macro, /set classes = "button-group"/);
+  assert.doesNotMatch(renderer, /class(?:Name)? = "button-group"/);
+  assert.doesNotMatch(schema, /class="button-group"/);
+});

--- a/tests/button-naming-migration.test.mjs
+++ b/tests/button-naming-migration.test.mjs
@@ -19,7 +19,6 @@ test("Button token export uses UIF names without legacy token aliases", async ()
 
   assert.match(tokenExport, /var\(--uif-button-/);
   assert.doesNotMatch(tokenExport, /var\(--button-(?!group-)/);
-  assert.match(tokenExport, /var\(--button-group-gap\)/);
 });
 
 test("Button-owned emitters use the canonical root and explicit solid variant", async () => {


### PR DESCRIPTION
## Summary

- migrate ButtonGroup-owned retained output to the canonical `.uif-button-group` class
- retain `.button-group` only through equal-specificity v1.x CSS compatibility selectors
- migrate the Figma-owned gap token to `--uif-button-group-gap`
- add Figma `Button/Group/Border Radius`, aliased to `Button/Border/Radius`, and expose `--uif-button-group-border-radius`
- update Custom Element internals, Nunjucks, playground output, Code Connect, documentation, and migration tests
- explicitly leave deprecated React wrappers unchanged for removal through #159

The live Figma file was updated first. Its stale Button-family `codeSyntax.WEB` values were also aligned with the already-merged Button pilot, leaving no live `--button-*` syntax in that family.

## Consumer impact

Canonical retained UIF-owned emitters now produce `.uif-button-group`. Existing authored `.button-group` markup remains styled through the v1.x compatibility window. Legacy ButtonGroup token names are intentionally not aliased.

The deprecated React wrapper continues emitting its existing class and receives no further naming migration. React source and package exports are removed separately at the v1.0 breaking boundary in #159.

Custom Element tag names and the Nunjucks import namespace are unchanged in this PR.

## Validation

- `npm run lint`
- `npm run test:unit`
- `npm run ci:check`
- `npm run pack:check`
- generated CSS, JSON, element, and macro output inspected

Closes #157
Related to #156
React removal prerequisite: #159