### PR TITLE
Migration: Adopt UIF-prefixed naming for Icon

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -31,7 +31,7 @@ Rules: Components reference only Semantic or Core. Never hardcode values.
 - Use logical properties: `inline-size`, `block-size`, not `width`, `height`
 - Use `var(--token-name)` for all values — never hardcode
 - States: both pseudo-classes (`:hover`) and fallback classes (`.is-hover`)
-- Reuse existing patterns: icon-only buttons use `.button.ghost` + `.icon`
+- Reuse existing patterns: icon-only buttons use `.uif-button.ghost` + `.uif-icon`
 
 ## Token Naming
 

--- a/CODEX.md
+++ b/CODEX.md
@@ -92,7 +92,7 @@ Follow existing macros in `site/_includes/macros/ui.njk`:
 
 - Never draw vector graphics — always reuse icons from `src/assets/icons/`
 - If needed, rotate existing icons
-- Use the Icon component (`ui.icon()` macro / `.icon` class)
+- Use the Icon component (`ui.icon()` macro / `.uif-icon` class)
 - Color with semantic tokens: `--color-text-success`, `--color-text-brand`, etc.
 
 ---

--- a/docs/foundations/foundation-012-minimal-markup-and-composition.md
+++ b/docs/foundations/foundation-012-minimal-markup-and-composition.md
@@ -13,7 +13,7 @@ Keep component markup as flat and simple as possible. Complexity in HTML structu
 ## Rules
 
 1. Start with the flattest possible markup.
-   - A link with an icon is `<a class="link"><span class="icon">...</span> Text</a>`, not three nested wrappers.
+   - A link with an icon is `<a class="link"><span class="uif-icon">...</span> Text</a>`, not three nested wrappers.
    - Add structure only when layout or behavior requires it.
 
 2. Use CSS on the component root for layout.

--- a/packages/mcp-server/src/resources/components.ts
+++ b/packages/mcp-server/src/resources/components.ts
@@ -164,7 +164,7 @@ function generateHtmlPattern(componentName: string, cssContent: string): string 
     return `<a class="${className}" href="#">Link text</a>`;
   }
   if (componentName === 'icon') {
-    return `<span class="${className}" style="--icon-src: url('/assets/icons/name.svg');" aria-hidden="true"></span>`;
+    return `<span class="${className}" style="--uif-icon-src: url('/assets/icons/name.svg');" aria-hidden="true"></span>`;
   }
   if (componentName === 'label') {
     return `<span class="label-content"><span class="label-content__text">Label</span></span>`;

--- a/schemas/web-icon.figma.ts
+++ b/schemas/web-icon.figma.ts
@@ -13,8 +13,8 @@ figma.connect(
       }),
     },
     example: ({ name }: IconProps) => html`<span
-      class="icon"
-      style="--icon-src: url('/assets/icons/${name}.svg')"
+      class="uif-icon"
+      style="--uif-icon-src: url('/assets/icons/${name}.svg')"
       aria-hidden="true"
     ></span>`,
   },

--- a/schemas/web-link.figma.ts
+++ b/schemas/web-link.figma.ts
@@ -21,6 +21,6 @@ figma.connect(
       endIcon: figma.boolean("End Icon"),
     },
     example: ({ className, text, href, startIcon, endIcon }: LinkProps) =>
-      html`<a class="${className}" href="${href}">${startIcon && html`<span class="icon" data-slot="start" aria-hidden="true"></span>`}${text}${endIcon && html`<span class="icon" data-slot="end" aria-hidden="true"></span>`}</a>`,
+      html`<a class="${className}" href="${href}">${startIcon && html`<span class="uif-icon" data-slot="start" aria-hidden="true"></span>`}${text}${endIcon && html`<span class="uif-icon" data-slot="end" aria-hidden="true"></span>`}</a>`,
   },
 );

--- a/scripts/validate-token-usage.mjs
+++ b/scripts/validate-token-usage.mjs
@@ -24,7 +24,7 @@ const ALLOWLIST = new Set([
   "--field-label-gap",
   "--field-label-line-height",
   "--field-label-required-color",
-  "--icon-src",
+  "--uif-icon-src",
   // Calendar component extension points (pending Figma export)
   "--calendar-cell-background-selected",
   "--calendar-cell-background-range",

--- a/site/_includes/macros/calendar.njk
+++ b/site/_includes/macros/calendar.njk
@@ -1,7 +1,7 @@
 {# ─── Calendar Macro ────────────────────────────────────────────── #}
 
 {% macro calendarIcon(name) -%}
-<span class="icon" style="--icon-src: url('/assets/icons/{{ name }}.svg');" aria-hidden="true"></span>
+<span class="uif-icon" style="--uif-icon-src: url('/assets/icons/{{ name }}.svg');" aria-hidden="true"></span>
 {%- endmacro %}
 
 {% macro calendarSelect(options=[], value='', disabled=false, className='', name='') -%}

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -29,14 +29,14 @@
   <input class="input" type="{{ type }}"{% if id %} id="{{ id }}"{% endif %}{% if name %} name="{{ name }}"{% endif %}{% if placeholder %} placeholder="{{ placeholder }}"{% endif %}{% if value %} value="{{ value }}"{% endif %}{% if dataPlaygroundControl %} data-playground-control{% endif %}{% if dataProp %} data-prop="{{ dataProp }}"{% endif %}{% if dataSource %} data-source="{{ dataSource }}"{% endif %}{% if dataValueType %} data-value-type="{{ dataValueType }}"{% endif %}{% if dataQueryParam %} data-query-param="{{ dataQueryParam }}"{% endif %}{% if disabled or state == "disabled" %} disabled{% endif %} />
   <span class="input-field-control">
     {%- if type == "text" or type == "email" or type == "search" or type == "url" or type == "tel" -%}
-    <button type="button" aria-label="Clear input" tabindex="-1"><span class="icon" style="--icon-src: url('/assets/icons/cross-circled.svg');" aria-hidden="true"></span></button>
+    <button type="button" aria-label="Clear input" tabindex="-1"><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/cross-circled.svg');" aria-hidden="true"></span></button>
     {%- elif type == "number" -%}
-    <button type="button" aria-label="Decrease value"><span class="icon" style="--icon-src: url('/assets/icons/minus-circled.svg');" aria-hidden="true"></span></button>
-    <button type="button" aria-label="Increase value"><span class="icon" style="--icon-src: url('/assets/icons/plus-circled.svg');" aria-hidden="true"></span></button>
+    <button type="button" aria-label="Decrease value"><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/minus-circled.svg');" aria-hidden="true"></span></button>
+    <button type="button" aria-label="Increase value"><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/plus-circled.svg');" aria-hidden="true"></span></button>
     {%- elif type == "password" -%}
-    <button type="button" aria-label="Toggle password visibility"><span class="icon" style="--icon-src: url('/assets/icons/view.svg');" aria-hidden="true"></span></button>
+    <button type="button" aria-label="Toggle password visibility"><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/view.svg');" aria-hidden="true"></span></button>
     {%- elif type == "date" -%}
-    <button type="button" aria-label="Open date picker"><span class="icon" style="--icon-src: url('/assets/icons/calendar.svg');" aria-hidden="true"></span></button>
+    <button type="button" aria-label="Open date picker"><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/calendar.svg');" aria-hidden="true"></span></button>
     {%- endif -%}
   </span>
 </div>
@@ -108,23 +108,23 @@
 {%- endmacro %}
 
 {% macro icon(name, label='', className='') -%}
-{%- set classes = "icon" -%}
+{%- set classes = "uif-icon" -%}
 {%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
-<span class="{{ classes }}" style="--icon-src: url('/assets/icons/{{ name }}.svg');"{% if label %} role="img" aria-label="{{ label }}"{% else %} aria-hidden="true"{% endif %}></span>
+<span class="{{ classes }}" style="--uif-icon-src: url('/assets/icons/{{ name }}.svg');"{% if label %} role="img" aria-label="{{ label }}"{% else %} aria-hidden="true"{% endif %}></span>
 {%- endmacro %}
 
 {% macro labelContent(text='', startIcon='', endIcon='', iconOnly=false) -%}
 <span class="label-content{% if iconOnly %} is-icon-only{% endif %}">
-  {%- if startIcon %}<span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/{{ startIcon }}.svg');" aria-hidden="true"></span>{% endif -%}
+  {%- if startIcon %}<span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/{{ startIcon }}.svg');" aria-hidden="true"></span>{% endif -%}
   {%- if not iconOnly %}<span class="label-content-text">{{ text }}</span>{% endif -%}
-  {%- if endIcon %}<span class="icon" data-slot="end" style="--icon-src: url('/assets/icons/{{ endIcon }}.svg');" aria-hidden="true"></span>{% endif -%}
+  {%- if endIcon %}<span class="uif-icon" data-slot="end" style="--uif-icon-src: url('/assets/icons/{{ endIcon }}.svg');" aria-hidden="true"></span>{% endif -%}
 </span>
 {%- endmacro %}
 
 {% macro fieldLabel(text, htmlFor='', required=false, startIcon='') -%}
 <label class="field-label"{% if htmlFor %} for="{{ htmlFor }}"{% endif %}>
   <span class="label-content">
-    {%- if startIcon %}<span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/{{ startIcon }}.svg');" aria-hidden="true"></span>{% endif -%}
+    {%- if startIcon %}<span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/{{ startIcon }}.svg');" aria-hidden="true"></span>{% endif -%}
     <span class="label-content-text">{{ text }}</span>
   </span>
   {%- if required %}
@@ -139,9 +139,9 @@
 {%- if state -%}{%- set classes = classes + " is-" + state -%}{%- endif -%}
 {%- if disabled -%}{%- set classes = classes + " is-disabled" -%}{%- endif -%}
 <a class="{{ classes }}" href="{{ href }}"{% if disabled %} aria-disabled="true"{% endif %}>
-  {%- if startIcon %}<span class="icon" style="--icon-src: url('/assets/icons/{{ startIcon }}.svg');" aria-hidden="true"></span> {% endif -%}
+  {%- if startIcon %}<span class="uif-icon" style="--uif-icon-src: url('/assets/icons/{{ startIcon }}.svg');" aria-hidden="true"></span> {% endif -%}
   {{ text }}
-  {%- if endIcon %} <span class="icon" style="--icon-src: url('/assets/icons/{{ endIcon }}.svg');" aria-hidden="true"></span>{% endif -%}
+  {%- if endIcon %} <span class="uif-icon" style="--uif-icon-src: url('/assets/icons/{{ endIcon }}.svg');" aria-hidden="true"></span>{% endif -%}
 </a>
 {%- endmacro %}
 
@@ -150,7 +150,7 @@
 {%- if variant -%}{%- set classes = classes + " " + variant -%}{%- endif -%}
 {%- if size == "sm" -%}{%- set classes = classes + " sm" -%}{%- endif -%}
 <span class="{{ classes }}">
-  {%- if startIcon %}<span class="icon" style="--icon-src: url('/assets/icons/{{ startIcon }}.svg');" aria-hidden="true"></span>{% endif -%}
+  {%- if startIcon %}<span class="uif-icon" style="--uif-icon-src: url('/assets/icons/{{ startIcon }}.svg');" aria-hidden="true"></span>{% endif -%}
   <span class="badge-text">{{ text }}</span>
 </span>
 {%- endmacro %}

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -18,9 +18,9 @@
     if (!normalizedName) return null;
 
     const element = document.createElement("span");
-    element.className = "icon";
+    element.className = "uif-icon";
     element.style.setProperty(
-      "--icon-src",
+      "--uif-icon-src",
       `url("${iconSrcFromName(normalizedName)}")`,
     );
     element.style.color = color || "inherit";
@@ -43,14 +43,14 @@
     if (!normalizedName) return "";
 
     const styleEntries = [
-      `--icon-src: url('/assets/icons/${quoteAttr(normalizedName)}.svg')`,
+      `--uif-icon-src: url('/assets/icons/${quoteAttr(normalizedName)}.svg')`,
     ];
     if (color) {
       styleEntries.push(`color: ${color}`);
     }
 
     const attrs = [
-      'class="icon"',
+      'class="uif-icon"',
       `style="${quoteAttr(styleEntries.join("; "))}"`,
     ];
 
@@ -78,8 +78,8 @@
     const iconMarkup = iconCode({ name, decorative: true });
     if (!iconMarkup) return "";
     return iconMarkup.replace(
-      'class="icon"',
-      `class="icon" data-slot="${position}"`,
+      'class="uif-icon"',
+      `class="uif-icon" data-slot="${position}"`,
     );
   };
 
@@ -1055,7 +1055,7 @@
 
     // Build header with selects
     let headerHtml = `<div class="calendar-header">`;
-    headerHtml += `<button type="button" class="button ghost" aria-label="Previous month"${disabledAttr}><span class="icon" style="--icon-src: url('/assets/icons/chevron--left.svg');" aria-hidden="true"></span></button>`;
+    headerHtml += `<button type="button" class="button ghost" aria-label="Previous month"${disabledAttr}><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/chevron--left.svg');" aria-hidden="true"></span></button>`;
     headerHtml += `<span class="calendar-selectors">`;
     headerHtml += `<select class="select calendar-header-select" name="month" aria-label="Month"${disabledAttr}>`;
     months.forEach((m, i) => { headerHtml += `<option value="${i}"${i === selectedMonth ? " selected" : ""}>${m}</option>`; });
@@ -1063,7 +1063,7 @@
     headerHtml += `<select class="select calendar-header-select" name="year" aria-label="Year"${disabledAttr}>`;
     for (let y = 2020; y <= 2030; y++) { headerHtml += `<option value="${y}"${y === selectedYear ? " selected" : ""}>${y}</option>`; }
     headerHtml += `</select></span>`;
-    headerHtml += `<button type="button" class="button ghost" aria-label="Next month"${disabledAttr}><span class="icon" style="--icon-src: url('/assets/icons/chevron.svg');" aria-hidden="true"></span></button>`;
+    headerHtml += `<button type="button" class="button ghost" aria-label="Next month"${disabledAttr}><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/chevron.svg');" aria-hidden="true"></span></button>`;
     headerHtml += `</div>`;
 
     // Build table
@@ -1147,16 +1147,16 @@
     html += `</div>`;
     html += `<span class="input-field-control">`;
     html += `<button type="button" aria-label="Open calendar" aria-expanded="${isOpen}" aria-haspopup="grid" aria-controls="date-picker-playground-calendar"${disabledAttr}>`;
-    html += `<span class="icon" style="--icon-src: url('/assets/icons/calendar.svg');" aria-hidden="true"></span>`;
+    html += `<span class="uif-icon" style="--uif-icon-src: url('/assets/icons/calendar.svg');" aria-hidden="true"></span>`;
     html += `</button></span>`;
     html += `<div class="calendar" id="date-picker-playground-calendar"><div class="calendar-header">`;
-    html += `<button type="button" class="button ghost" aria-label="Previous month"><span class="icon" style="--icon-src: url('/assets/icons/chevron--left.svg');" aria-hidden="true"></span></button>`;
+    html += `<button type="button" class="button ghost" aria-label="Previous month"><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/chevron--left.svg');" aria-hidden="true"></span></button>`;
     html += `<span class="calendar-selectors"><select class="select calendar-header-select" name="month" aria-label="Month">`;
     monthNames.forEach((m, i) => { html += `<option value="${i}"${i === visibleMonth ? " selected" : ""}>${m}</option>`; });
     html += `</select><select class="select calendar-header-select" name="year" aria-label="Year">`;
     for (let y = 2020; y <= 2030; y++) { html += `<option value="${y}"${y === visibleYear ? " selected" : ""}>${y}</option>`; }
     html += `</select></span>`;
-    html += `<button type="button" class="button ghost" aria-label="Next month"><span class="icon" style="--icon-src: url('/assets/icons/chevron.svg');" aria-hidden="true"></span></button>`;
+    html += `<button type="button" class="button ghost" aria-label="Next month"><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/chevron.svg');" aria-hidden="true"></span></button>`;
     const monthLabel = `${monthNames[visibleMonth]} ${visibleYear}`;
     html += `</div><table class="calendar-table" role="grid" aria-label="${monthLabel}"><thead><tr>`;
     weekdayNames.forEach((d) => { html += `<th scope="col">${d}</th>`; });

--- a/site/components/date-picker.md
+++ b/site/components/date-picker.md
@@ -41,7 +41,7 @@ playgroundLabel: Open Date Picker Playground
           </div>
           <span class="input-field-control">
             <button type="button" aria-label="Open calendar" aria-expanded="false" aria-haspopup="grid" aria-controls="date-input-demo-calendar">
-              <span class="icon" style="--icon-src: url('/assets/icons/calendar.svg');" aria-hidden="true"></span>
+              <span class="uif-icon" style="--uif-icon-src: url('/assets/icons/calendar.svg');" aria-hidden="true"></span>
             </button>
           </span>
           {{ ui.calendar("July 2026", todayDate="1", id="date-input-demo-calendar") }}
@@ -73,7 +73,7 @@ Together they form a component that can be opened, navigated, and dismissed — 
     │   └── input.date-segment.year [maxlength=4, aria-label="Year"]
     ├── .input-field-control
     │   └── button [aria-label="Open calendar", aria-expanded, aria-controls]
-    │       └── span.icon (calendar icon)
+    │       └── span.uif-icon (calendar icon)
     └── .calendar [hidden until opened]
         ├── .calendar-header
         └── table.calendar-table [role="grid"]

--- a/site/examples/pricing.md
+++ b/site/examples/pricing.md
@@ -109,7 +109,7 @@ breadcrumb:
     color: var(--color-text-default);
   }
 
-  .pricing-card-feature .icon {
+  .pricing-card-feature .uif-icon {
     flex-shrink: 0;
     color: var(--color-text-success);
   }

--- a/site/patterns/icon.md
+++ b/site/patterns/icon.md
@@ -24,9 +24,9 @@ playgroundLabel: Open Icon Playground
       </span>
     </div>
     <div class="docs-hero-preview-stage">
-      <span class="icon" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
-      <span class="icon" style="--icon-src: url('/assets/icons/menu.svg');" aria-hidden="true"></span>
-      <span class="icon" style="--icon-src: url('/assets/icons/plus.svg');" aria-hidden="true"></span>
+      <span class="uif-icon" style="--uif-icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
+      <span class="uif-icon" style="--uif-icon-src: url('/assets/icons/menu.svg');" aria-hidden="true"></span>
+      <span class="uif-icon" style="--uif-icon-src: url('/assets/icons/plus.svg');" aria-hidden="true"></span>
     </div>
   </div>
   <div class="docs-hero-meta">
@@ -50,7 +50,7 @@ playgroundLabel: Open Icon Playground
         <span class="docs-anatomy-badge">1</span>
         <span class="docs-anatomy-callout-line"></span>
       </span>
-      <span class="icon" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
+      <span class="uif-icon" style="--uif-icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
     </div>
   </div>
   <ol class="docs-anatomy-footnotes">
@@ -67,9 +67,9 @@ from assistive technology with `aria-hidden="true"`. When an icon is the only
 content (no adjacent label), it must have an accessible name via `aria-label`.
 
 <div class="docs-stack docs-icon-line-height">
-  <span class="icon" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
-  <span class="icon docs-icon-color-brand" style="--icon-src: url('/assets/icons/star.svg');" aria-hidden="true"></span>
-  <span class="icon docs-icon-color-danger" style="--icon-src: url('/assets/icons/login.svg');" aria-hidden="true"></span>
+  <span class="uif-icon" style="--uif-icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
+  <span class="uif-icon docs-icon-color-brand" style="--uif-icon-src: url('/assets/icons/star.svg');" aria-hidden="true"></span>
+  <span class="uif-icon docs-icon-color-danger" style="--uif-icon-src: url('/assets/icons/login.svg');" aria-hidden="true"></span>
 </div>
 
 ### Color
@@ -91,7 +91,7 @@ needed.
     <tr><th>Property</th><th>Values</th><th>Default</th></tr>
   </thead>
   <tbody>
-    <tr><td><code>--icon-src</code></td><td>icon URL path</td><td>—</td></tr>
+    <tr><td><code>--uif-icon-src</code></td><td>icon URL path</td><td>—</td></tr>
     <tr><td>color</td><td>Inherited from <code>currentColor</code></td><td>parent text color</td></tr>
     <tr><td>size</td><td>Inherited from parent <code>line-height</code></td><td><code>1lh</code></td></tr>
     <tr><td><code>aria-hidden</code></td><td><code>true</code> (decorative) / omitted (meaningful)</td><td><code>true</code></td></tr>
@@ -99,12 +99,20 @@ needed.
   </tbody>
 </table>
 
+### v1 naming migration
+
+Use `.uif-icon` with `--uif-icon-src` in all new and migrated markup. The
+legacy `.icon` selector remains available throughout v1.x, but the legacy
+`--icon-src` custom property has no library-owned alias or fallback. Consumers
+must rename both public API names together. Removal of the legacy class selector
+is deferred to Wave 4 in v2.0 or later.
+
 <h2 id="behaviors">Behaviors</h2>
 
 <div class="docs-behavior-list">
   <div class="docs-behavior-item">
     <div class="docs-behavior-preview">
-      <span class="icon" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
+      <span class="uif-icon" style="--uif-icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
     </div>
     <div class="docs-behavior-body">
       <h3>Color inheritance</h3>
@@ -113,7 +121,7 @@ needed.
   </div>
   <div class="docs-behavior-item">
     <div class="docs-behavior-preview docs-icon-line-height">
-      <span class="icon" style="--icon-src: url('/assets/icons/star.svg');" aria-hidden="true"></span>
+      <span class="uif-icon" style="--uif-icon-src: url('/assets/icons/star.svg');" aria-hidden="true"></span>
     </div>
     <div class="docs-behavior-body">
       <h3>Size from line-height</h3>
@@ -122,7 +130,7 @@ needed.
   </div>
   <div class="docs-behavior-item">
     <div class="docs-behavior-preview">
-      <span class="icon" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
+      <span class="uif-icon" style="--uif-icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
       <span>Search</span>
     </div>
     <div class="docs-behavior-body">
@@ -132,7 +140,7 @@ needed.
   </div>
   <div class="docs-behavior-item">
     <div class="docs-behavior-preview">
-      <span class="icon" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
+      <span class="uif-icon" style="--uif-icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
     </div>
     <div class="docs-behavior-body">
       <h3>CSS mask rendering</h3>
@@ -148,7 +156,7 @@ needed.
 <div class="docs-guideline">
   <div class="docs-guideline-item" data-type="do">
     <div class="docs-guideline-preview">
-      <span class="label-content"><span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span><span class="label-content-text">Search</span></span>
+      <span class="label-content"><span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span><span class="label-content-text">Search</span></span>
     </div>
     <div class="docs-guideline-body">
       <p class="docs-guideline-label">Do</p>
@@ -157,7 +165,7 @@ needed.
   </div>
   <div class="docs-guideline-item" data-type="dont">
     <div class="docs-guideline-preview">
-      <span class="icon" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
+      <span class="uif-icon" style="--uif-icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
     </div>
     <div class="docs-guideline-body">
       <p class="docs-guideline-label">Don't</p>
@@ -171,7 +179,7 @@ needed.
 <div class="docs-guideline">
   <div class="docs-guideline-item" data-type="do">
     <div class="docs-guideline-preview">
-      <span class="icon docs-icon-color-brand" style="--icon-src: url('/assets/icons/star.svg');" aria-hidden="true"></span>
+      <span class="uif-icon docs-icon-color-brand" style="--uif-icon-src: url('/assets/icons/star.svg');" aria-hidden="true"></span>
     </div>
     <div class="docs-guideline-body">
       <p class="docs-guideline-label">Do</p>
@@ -180,7 +188,7 @@ needed.
   </div>
   <div class="docs-guideline-item" data-type="dont">
     <div class="docs-guideline-preview">
-      <span class="icon docs-dont-custom-color" style="--icon-src: url('/assets/icons/star.svg');" aria-hidden="true"></span>
+      <span class="uif-icon docs-dont-custom-color" style="--uif-icon-src: url('/assets/icons/star.svg');" aria-hidden="true"></span>
     </div>
     <div class="docs-guideline-body">
       <p class="docs-guideline-label">Don't</p>

--- a/site/patterns/index.md
+++ b/site/patterns/index.md
@@ -35,10 +35,10 @@ permalink: /patterns/
   </a>
   <a class="docs-component-card" href="/patterns/icon/">
     <div class="docs-component-card-preview">
-      <span class="icon" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
-      <span class="icon" style="--icon-src: url('/assets/icons/star.svg');" aria-hidden="true"></span>
-      <span class="icon" style="--icon-src: url('/assets/icons/menu.svg');" aria-hidden="true"></span>
-      <span class="icon" style="--icon-src: url('/assets/icons/plus.svg');" aria-hidden="true"></span>
+      <span class="uif-icon" style="--uif-icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
+      <span class="uif-icon" style="--uif-icon-src: url('/assets/icons/star.svg');" aria-hidden="true"></span>
+      <span class="uif-icon" style="--uif-icon-src: url('/assets/icons/menu.svg');" aria-hidden="true"></span>
+      <span class="uif-icon" style="--uif-icon-src: url('/assets/icons/plus.svg');" aria-hidden="true"></span>
     </div>
     <div class="docs-component-card-body">
       <h2>Icon</h2>
@@ -59,7 +59,7 @@ permalink: /patterns/
   <a class="docs-component-card" href="/patterns/label/">
     <div class="docs-component-card-preview">
       <span class="label-content">
-        <span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
+        <span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
         <span class="label-content-text">Search</span>
       </span>
     </div>

--- a/site/patterns/label.md
+++ b/site/patterns/label.md
@@ -25,7 +25,7 @@ playgroundLabel: Open Label Playground
     </div>
     <div class="docs-hero-preview-stage">
       <span class="label-content">
-        <span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
+        <span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
         <span class="label-content-text">Search</span>
       </span>
     </div>
@@ -56,7 +56,7 @@ playgroundLabel: Open Label Playground
         <span class="docs-anatomy-badge">2</span>
       </span>
       <span class="label-content">
-        <span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
+        <span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
         <span class="label-content-text">Search</span>
       </span>
     </div>
@@ -88,7 +88,7 @@ playgroundLabel: Open Label Playground
 <div class="docs-behavior-list">
   <div class="docs-behavior-item">
     <div class="docs-behavior-preview">
-      <span class="label-content"><span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span><span class="label-content-text">Search</span></span>
+      <span class="label-content"><span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span><span class="label-content-text">Search</span></span>
     </div>
     <div class="docs-behavior-body">
       <h3>Icon + text composition</h3>
@@ -97,7 +97,7 @@ playgroundLabel: Open Label Playground
   </div>
   <div class="docs-behavior-item">
     <div class="docs-behavior-preview">
-      <span class="label-content is-icon-only"><span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/menu.svg');" aria-hidden="true"></span></span>
+      <span class="label-content is-icon-only"><span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/menu.svg');" aria-hidden="true"></span></span>
     </div>
     <div class="docs-behavior-body">
       <h3>Icon-only mode</h3>

--- a/site/patterns/link.md
+++ b/site/patterns/link.md
@@ -59,7 +59,7 @@ breadcrumb:
         <span class="docs-anatomy-badge">3</span>
         <span class="docs-anatomy-callout-line"></span>
       </span>
-      <a class="link" href="#"><span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/target-blank.svg');" aria-hidden="true"></span>External link<span class="icon" data-slot="end" style="--icon-src: url('/assets/icons/target-blank.svg');" aria-hidden="true"></span></a>
+      <a class="link" href="#"><span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/target-blank.svg');" aria-hidden="true"></span>External link<span class="uif-icon" data-slot="end" style="--uif-icon-src: url('/assets/icons/target-blank.svg');" aria-hidden="true"></span></a>
     </div>
   </div>
   <ol class="docs-anatomy-footnotes">

--- a/src/elements/ui-badge.js
+++ b/src/elements/ui-badge.js
@@ -26,7 +26,7 @@ class UIBadge extends UIElement {
 
     let inner = "";
     if (startIcon) {
-      inner += `<span class="icon" style="--icon-src: url('/assets/icons/${startIcon}.svg')" aria-hidden="true"></span>`;
+      inner += `<span class="uif-icon" style="--uif-icon-src: url('/assets/icons/${startIcon}.svg')" aria-hidden="true"></span>`;
     }
     if (text) {
       inner += `<span class="badge-text">${text}</span>`;

--- a/src/elements/ui-button.js
+++ b/src/elements/ui-button.js
@@ -38,7 +38,7 @@ class UIButton extends UIElement {
     let inner = "";
 
     if (startIcon) {
-      inner += `<span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/${startIcon}.svg')" aria-hidden="true"></span>`;
+      inner += `<span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/${startIcon}.svg')" aria-hidden="true"></span>`;
     }
 
     if (!iconOnly && text) {
@@ -46,7 +46,7 @@ class UIButton extends UIElement {
     }
 
     if (endIcon && !iconOnly) {
-      inner += `<span class="icon" data-slot="end" style="--icon-src: url('/assets/icons/${endIcon}.svg')" aria-hidden="true"></span>`;
+      inner += `<span class="uif-icon" data-slot="end" style="--uif-icon-src: url('/assets/icons/${endIcon}.svg')" aria-hidden="true"></span>`;
     }
 
     const btnAttrs = [

--- a/src/elements/ui-icon.js
+++ b/src/elements/ui-icon.js
@@ -29,13 +29,13 @@ class UIIcon extends UIElement {
 
     const iconUrl = src || new URL(`../assets/${folder}/${name}.svg`, import.meta.url).href;
 
-    const classes = ["icon"];
+    const classes = ["uif-icon"];
     const extraClass = this.getAttr("class");
     if (extraClass) classes.push(extraClass);
 
     const attrs = [
       `class="${classes.join(" ")}"`,
-      `style="--icon-src: url('${iconUrl}')"`,
+      `style="--uif-icon-src: url('${iconUrl}')"`,
     ];
 
     if (decorative) {

--- a/src/elements/ui-input.js
+++ b/src/elements/ui-input.js
@@ -57,12 +57,12 @@ class UIInput extends UIElement {
     const TEXT_TYPES = ["text", "email", "search", "url", "tel"];
 
     if (TEXT_TYPES.includes(type)) {
-      controlHTML = `<button type="button" aria-label="Clear input" tabindex="-1"><span class="icon" style="--icon-src: url('/assets/icons/cross-circled.svg')" aria-hidden="true"></span></button>`;
+      controlHTML = `<button type="button" aria-label="Clear input" tabindex="-1"><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/cross-circled.svg')" aria-hidden="true"></span></button>`;
     } else if (type === "number") {
-      controlHTML = `<button type="button" aria-label="Decrease value"><span class="icon" style="--icon-src: url('/assets/icons/minus-circled.svg')" aria-hidden="true"></span></button>
-      <button type="button" aria-label="Increase value"><span class="icon" style="--icon-src: url('/assets/icons/plus-circled.svg')" aria-hidden="true"></span></button>`;
+      controlHTML = `<button type="button" aria-label="Decrease value"><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/minus-circled.svg')" aria-hidden="true"></span></button>
+      <button type="button" aria-label="Increase value"><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/plus-circled.svg')" aria-hidden="true"></span></button>`;
     } else if (type === "password") {
-      controlHTML = `<button type="button" aria-label="Toggle password visibility"><span class="icon" style="--icon-src: url('/assets/icons/view.svg')" aria-hidden="true"></span></button>`;
+      controlHTML = `<button type="button" aria-label="Toggle password visibility"><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/view.svg')" aria-hidden="true"></span></button>`;
     }
 
     this.innerHTML = `<div class="${wrapperClasses.join(" ")}">

--- a/src/elements/ui-label.js
+++ b/src/elements/ui-label.js
@@ -24,7 +24,7 @@ class UIFieldLabel extends UIElement {
 
     let iconHtml = "";
     if (startIcon) {
-      iconHtml = `<span class="icon" data-slot="start" style="--icon-src: url('/assets/icons/${startIcon}.svg')" aria-hidden="true"></span>`;
+      iconHtml = `<span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/${startIcon}.svg')" aria-hidden="true"></span>`;
     }
 
     let requiredHtml = "";

--- a/src/elements/ui-link.js
+++ b/src/elements/ui-link.js
@@ -33,11 +33,11 @@ class UILink extends UIElement {
 
     let inner = "";
     if (startIcon) {
-      inner += `<span class="icon" style="--icon-src: url('/assets/icons/${startIcon}.svg')" aria-hidden="true"></span> `;
+      inner += `<span class="uif-icon" style="--uif-icon-src: url('/assets/icons/${startIcon}.svg')" aria-hidden="true"></span> `;
     }
     inner += text;
     if (endIcon) {
-      inner += ` <span class="icon" style="--icon-src: url('/assets/icons/${endIcon}.svg')" aria-hidden="true"></span>`;
+      inner += ` <span class="uif-icon" style="--uif-icon-src: url('/assets/icons/${endIcon}.svg')" aria-hidden="true"></span>`;
     }
 
     this.innerHTML = `<a ${attrs.join(" ")}>${inner}</a>`;

--- a/src/ui/patterns/badge.css
+++ b/src/ui/patterns/badge.css
@@ -56,7 +56,7 @@
 
   /* ── Icon slot ── */
 
-  .badge > .icon {
+  .badge > :is(.uif-icon, .icon) {
     flex: 0 0 auto;
   }
 

--- a/src/ui/patterns/button.css
+++ b/src/ui/patterns/button.css
@@ -30,7 +30,7 @@
   }
 
   :is(.uif-button, .button) .label-content-text,
-  :is(.uif-button, .button) .icon {
+  :is(.uif-button, .button) :is(.uif-icon, .icon) {
     color: inherit;
     -webkit-text-fill-color: currentColor;
   }

--- a/src/ui/patterns/icon.css
+++ b/src/ui/patterns/icon.css
@@ -1,5 +1,9 @@
 @layer components {
-  .icon {
+  /*
+   * `.icon` is a deprecated v1.x compatibility selector.
+   * UIF-owned emitters use `.uif-icon`; remove the alias no earlier than v2.0.
+   */
+  :is(.uif-icon, .icon) {
     display: inline-block;
     inline-size: 1em;
     block-size: 1em;
@@ -7,8 +11,8 @@
     block-size: 1lh;
     line-height: inherit;
     background-color: currentColor;
-    -webkit-mask-image: var(--icon-src);
-    mask-image: var(--icon-src);
+    -webkit-mask-image: var(--uif-icon-src);
+    mask-image: var(--uif-icon-src);
     -webkit-mask-repeat: no-repeat;
     mask-repeat: no-repeat;
     -webkit-mask-position: center;

--- a/src/ui/patterns/input.css
+++ b/src/ui/patterns/input.css
@@ -109,7 +109,7 @@
     color: var(--input-text-color-hover);
   }
 
-  .input-field-control .icon {
+  .input-field-control :is(.uif-icon, .icon) {
     font-size: 1.5rem;
   }
 

--- a/src/ui/patterns/label.css
+++ b/src/ui/patterns/label.css
@@ -6,7 +6,7 @@
     line-height: inherit;
   }
 
-  .label-content > .icon[data-slot] {
+  .label-content > :is(.uif-icon, .icon)[data-slot] {
     display: inline-flex;
     align-items: center;
     line-height: inherit;

--- a/src/ui/patterns/link.css
+++ b/src/ui/patterns/link.css
@@ -56,7 +56,7 @@
 
   /* ── Icon slot ── */
 
-  .link > .icon {
+  .link > :is(.uif-icon, .icon) {
     flex: 0 0 auto;
   }
 }

--- a/tests/icon-naming-migration.test.mjs
+++ b/tests/icon-naming-migration.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("Icon CSS exposes canonical UIF naming with only the v1 class alias", async () => {
+  const css = await read("src/ui/patterns/icon.css");
+
+  assert.match(css, /:is\(\.uif-icon, \.icon\)/);
+  assert.match(css, /var\(--uif-icon-src\)/);
+  assert.doesNotMatch(css, /var\(--icon-src\)/);
+  assert.doesNotMatch(css, /\.uif-icon(?:__|--)/);
+});
+
+test("Icon-owned emitters produce only the canonical public API", async () => {
+  const sources = await Promise.all([
+    read("src/elements/ui-icon.js"),
+    read("site/_includes/macros/ui.njk"),
+    read("site/_includes/macros/calendar.njk"),
+    read("site/assets/playground/renderers.js"),
+    read("schemas/web-icon.figma.ts"),
+    read("schemas/web-link.figma.ts"),
+    read("packages/mcp-server/src/resources/components.ts"),
+  ]);
+
+  for (const source of sources) {
+    assert.match(source, /uif-icon/);
+    assert.doesNotMatch(source, /--icon-src/);
+    assert.doesNotMatch(source, /class="icon(?:\s|")/);
+  }
+});
+
+test("the MCP pattern generator resolves canonical selectors before legacy aliases", async () => {
+  const generator = await read("packages/mcp-server/src/resources/components.ts");
+
+  assert.match(generator, /const canonicalClassName = `uif-\$\{componentName\}`/);
+  assert.match(generator, /cssContent\.includes\(`\.\$\{canonicalClassName\}`\)/);
+  assert.match(generator, /--uif-icon-src/);
+});
+
+test("shared pattern selectors accept canonical and legacy Icon classes", async () => {
+  const patterns = await Promise.all(
+    ["badge", "button", "input", "label", "link"].map((name) =>
+      read(`src/ui/patterns/${name}.css`),
+    ),
+  );
+
+  for (const css of patterns) {
+    assert.match(css, /:is\(\.uif-icon, \.icon\)/);
+  }
+});
+
+test("the namespaced runtime input remains code-only rather than a Figma token", async () => {
+  const [validator, tokenExport, documentation] = await Promise.all([
+    read("scripts/validate-token-usage.mjs"),
+    read("figma/exports/Patterns (UI).tokens.json"),
+    read("site/patterns/icon.md"),
+  ]);
+
+  assert.match(validator, /"--uif-icon-src"/);
+  assert.doesNotMatch(validator, /"--icon-src"/);
+  assert.doesNotMatch(tokenExport, /--uif-icon-src/);
+  assert.match(documentation, /legacy\s+`--icon-src` custom property has no library-owned alias/);
+});


### PR DESCRIPTION
## Summary

- migrate the Icon public class to `.uif-icon` while retaining `.icon` as the v1.x selector alias
- migrate the runtime image-source input to `--uif-icon-src` with no library-owned legacy custom-property alias or fallback
- update retained Web Component internals, Nunjucks macros, playground emitters, shared consumers, schemas, MCP output, examples, and documentation
- add focused regression coverage for canonical output, selector compatibility, the runtime-only token boundary, and MCP canonical selector resolution

## Figma/token boundary

A live Figma audit found no Icon-owned visual-token family. `--uif-icon-src` is a runtime URL input rather than a visual design token, so no Figma variable or generated token was invented. Input, Badge, and Select variables containing “Icon” remain scoped to their own component migrations.

This PR does not rename the `<ui-icon>` Custom Element; that public namespace migration remains separate.

## Consumer impact

Consumers should rename `.icon` to `.uif-icon` and `--icon-src` to `--uif-icon-src` together. The legacy class selector remains supported through v1.x; the legacy custom property has no compatibility alias. Wave 4 class-alias removal remains deferred to v2.0 or later.

## Validation

- `npm run lint`
- `npm run test:unit` — 95 passing
- `npm run ci:check`
- regenerated and inspected `dist/`; canonical names are present and generated files were not edited directly

Closes #161