### PR TITLE
Migration: Adopt UIF-prefixed naming for Label composition

### DIFF
--- a/docs/foundations/foundation-012-minimal-markup-and-composition.md
+++ b/docs/foundations/foundation-012-minimal-markup-and-composition.md
@@ -20,7 +20,7 @@ Keep component markup as flat and simple as possible. Complexity in HTML structu
    - `inline-flex`, `gap`, `align-items` on the component class itself.
    - Avoid wrapper elements whose only purpose is layout.
 
-3. Composition patterns (like `label-content`) are opt-in, not default.
+3. Composition patterns (like `uif-label-content`) are opt-in, not default.
    - Use them only when the component genuinely needs slot management, reordering, or icon-only modes.
    - A simple text + icon combination does not need a composition wrapper.
 

--- a/docs/migrations/react-to-web-components.md
+++ b/docs/migrations/react-to-web-components.md
@@ -43,7 +43,7 @@ The module paths below are the component-specific alternatives. Import
 no Calendar Custom Element entry point. Use the documented Calendar semantic
 HTML and `.calendar*` CSS pattern until Calendar receives an approved Custom
 Element API. `LabelContent` is likewise a composition helper: author the
-documented label-content markup or use the Nunjucks macro instead of inventing
+documented uif-label-content markup or use the Nunjucks macro instead of inventing
 a Custom Element.
 
 The approved v1 public namespace is `<uif-*>`. At the time this removal was

--- a/packages/mcp-server/src/resources/components.ts
+++ b/packages/mcp-server/src/resources/components.ts
@@ -167,7 +167,7 @@ function generateHtmlPattern(componentName: string, cssContent: string): string 
     return `<span class="${className}" style="--uif-icon-src: url('/assets/icons/name.svg');" aria-hidden="true"></span>`;
   }
   if (componentName === 'label') {
-    return `<span class="label-content"><span class="label-content__text">Label</span></span>`;
+    return `<span class="uif-label-content"><span class="uif-label-content-text">Label</span></span>`;
   }
 
   return `<div class="${className}">Content</div>`;

--- a/schemas/web-button.figma.ts
+++ b/schemas/web-button.figma.ts
@@ -39,8 +39,8 @@ figma.connect(
       disabled="${disabled}"
       aria-label="${ariaLabel}"
     >
-      <span class="label-content">
-        <span class="label-content-text">${text}</span>
+      <span class="uif-label-content">
+        <span class="uif-label-content-text">${text}</span>
       </span>
     </button>`,
   },

--- a/schemas/web-form.figma.ts
+++ b/schemas/web-form.figma.ts
@@ -20,9 +20,9 @@ figma.connect(
       class="form-field"
       data-state="${state}"
     >
-      <label class="field-label" for="form-field-input" style="line-height: 24px;">
-        <span class="label-content">
-          <span class="label-content-text">Field label</span>
+      <label class="uif-field-label" for="form-field-input" style="line-height: 24px;">
+        <span class="uif-label-content">
+          <span class="uif-label-content-text">Field label</span>
         </span>
       </label>
       <input

--- a/schemas/web-label.figma.ts
+++ b/schemas/web-label.figma.ts
@@ -6,14 +6,14 @@ figma.connect(
   {
     props: {
       className: figma.className([
-        "label-content",
+        "uif-label-content",
         figma.boolean("Has Text", { true: undefined, false: "is-icon-only" }),
       ]),
       text: figma.string("Text"),
     },
     example: ({ className, text }: LabelProps) => html`<span style="line-height: 24px;">
       <span class="${className}">
-        <span class="label-content-text">${text}</span>
+        <span class="uif-label-content-text">${text}</span>
       </span>
     </span>`,
   },

--- a/scripts/validate-token-usage.mjs
+++ b/scripts/validate-token-usage.mjs
@@ -21,9 +21,9 @@ const TOKENS_CSS_DIR = path.join(REPO_ROOT, "dist", "tokens", "css");
 // Tokens that are intentionally code-only (set dynamically or use CSS fallbacks)
 const ALLOWLIST = new Set([
   "--divider-color",
-  "--field-label-gap",
-  "--field-label-line-height",
-  "--field-label-required-color",
+  "--uif-field-label-gap",
+  "--uif-field-label-line-height",
+  "--uif-field-label-required-color",
   "--uif-icon-src",
   // Calendar component extension points (pending Figma export)
   "--calendar-cell-background-selected",

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -114,22 +114,22 @@
 {%- endmacro %}
 
 {% macro labelContent(text='', startIcon='', endIcon='', iconOnly=false) -%}
-<span class="label-content{% if iconOnly %} is-icon-only{% endif %}">
+<span class="uif-label-content{% if iconOnly %} is-icon-only{% endif %}">
   {%- if startIcon %}<span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/{{ startIcon }}.svg');" aria-hidden="true"></span>{% endif -%}
-  {%- if not iconOnly %}<span class="label-content-text">{{ text }}</span>{% endif -%}
+  {%- if not iconOnly %}<span class="uif-label-content-text">{{ text }}</span>{% endif -%}
   {%- if endIcon %}<span class="uif-icon" data-slot="end" style="--uif-icon-src: url('/assets/icons/{{ endIcon }}.svg');" aria-hidden="true"></span>{% endif -%}
 </span>
 {%- endmacro %}
 
 {% macro fieldLabel(text, htmlFor='', required=false, startIcon='') -%}
-<label class="field-label"{% if htmlFor %} for="{{ htmlFor }}"{% endif %}>
-  <span class="label-content">
+<label class="uif-field-label"{% if htmlFor %} for="{{ htmlFor }}"{% endif %}>
+  <span class="uif-label-content">
     {%- if startIcon %}<span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/{{ startIcon }}.svg');" aria-hidden="true"></span>{% endif -%}
-    <span class="label-content-text">{{ text }}</span>
+    <span class="uif-label-content-text">{{ text }}</span>
   </span>
   {%- if required %}
-  <span class="field-label-required" aria-hidden="true">*</span>
-  <span class="field-label-required-text"> (required)</span>
+  <span class="uif-field-label-required" aria-hidden="true">*</span>
+  <span class="uif-field-label-required-text"> (required)</span>
   {%- endif %}
 </label>
 {%- endmacro %}

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -117,7 +117,7 @@
     }
 
     const content = document.createElement("span");
-    const contentClasses = ["label-content"];
+    const contentClasses = ["uif-label-content"];
     if (resolvedIconOnly) contentClasses.push("is-icon-only");
     content.className = contentClasses.join(" ");
 
@@ -126,7 +126,7 @@
 
     if (!resolvedIconOnly && hasText) {
       const textNode = document.createElement("span");
-      textNode.className = "label-content-text";
+      textNode.className = "uif-label-content-text";
       textNode.textContent = rawLabel;
       content.append(textNode);
     }
@@ -148,14 +148,14 @@
     const codeContent = [
       labelIconCode(iconStart, "start"),
       !resolvedIconOnly && hasText
-        ? `<span class="label-content-text">${quoteAttr(rawLabel)}</span>`
+        ? `<span class="uif-label-content-text">${quoteAttr(rawLabel)}</span>`
         : "",
       labelIconCode(iconEnd, "end"),
     ]
       .filter(Boolean)
       .join("");
 
-    const codeContentClasses = ["label-content"];
+    const codeContentClasses = ["uif-label-content"];
     if (resolvedIconOnly) codeContentClasses.push("is-icon-only");
 
     const code = `<button ${attrs.join(" ")}><span class="${quoteAttr(codeContentClasses.join(" "))}">${codeContent}</span></button>`;
@@ -204,14 +204,14 @@
 
     const host = document.createElement(mode === "field" ? "label" : "span");
     if (mode === "field") {
-      host.className = "field-label";
+      host.className = "uif-field-label";
       host.setAttribute("for", forId);
     }
     host.style.lineHeight = lineHeight;
     if (color) host.style.color = color;
 
     const labelContent = document.createElement("span");
-    labelContent.className = "label-content";
+    labelContent.className = "uif-label-content";
 
     const hasText = text.trim().length > 0;
     if (iconOnly || !hasText) {
@@ -223,7 +223,7 @@
 
     if (!iconOnly && hasText) {
       const textElement = document.createElement("span");
-      textElement.className = "label-content-text";
+      textElement.className = "uif-label-content-text";
       textElement.textContent = text;
       labelContent.append(textElement);
     }
@@ -235,13 +235,13 @@
 
     if (mode === "field" && required) {
       const requiredMarker = document.createElement("span");
-      requiredMarker.className = "field-label-required";
+      requiredMarker.className = "uif-field-label-required";
       requiredMarker.setAttribute("aria-hidden", "true");
       requiredMarker.textContent = "*";
       host.append(requiredMarker);
 
       const requiredText = document.createElement("span");
-      requiredText.className = "field-label-required-text";
+      requiredText.className = "uif-field-label-required-text";
       requiredText.textContent = " (required)";
       host.append(requiredText);
     }
@@ -249,12 +249,12 @@
     const hostStyleEntries = [`line-height: ${lineHeight}`];
     if (color) hostStyleEntries.push(`color: ${color}`);
 
-    const contentClasses = ["label-content"];
+    const contentClasses = ["uif-label-content"];
     if (iconOnly || !hasText) contentClasses.push("is-icon-only");
     const contentMarkup = [
       labelIconCode(iconStart, "start"),
       !iconOnly && hasText
-        ? `<span class="label-content-text">${quoteAttr(text)}</span>`
+        ? `<span class="uif-label-content-text">${quoteAttr(text)}</span>`
         : "",
       labelIconCode(iconEnd, "end"),
     ]
@@ -263,9 +263,9 @@
 
     if (mode === "field") {
       const requiredMarkup = required
-        ? '<span class="field-label-required" aria-hidden="true">*</span><span class="field-label-required-text"> (required)</span>'
+        ? '<span class="uif-field-label-required" aria-hidden="true">*</span><span class="uif-field-label-required-text"> (required)</span>'
         : "";
-      const code = `<label for="${quoteAttr(forId)}" class="field-label" style="${quoteAttr(hostStyleEntries.join("; "))}"><span class="${quoteAttr(contentClasses.join(" "))}">${contentMarkup}</span>${requiredMarkup}</label>`;
+      const code = `<label for="${quoteAttr(forId)}" class="uif-field-label" style="${quoteAttr(hostStyleEntries.join("; "))}"><span class="${quoteAttr(contentClasses.join(" "))}">${contentMarkup}</span>${requiredMarkup}</label>`;
       return { element: host, code };
     }
 
@@ -783,8 +783,8 @@
     if (labelPosition === "side") field1.dataset.labelPosition = "side";
 
     const label1 = document.createElement("label");
-    label1.className = "field-label";
-    label1.innerHTML = '<span class="label-content"><span class="label-content-text">Email</span></span><span class="field-label-required" aria-hidden="true">*</span>';
+    label1.className = "uif-field-label";
+    label1.innerHTML = '<span class="uif-label-content"><span class="uif-label-content-text">Email</span></span><span class="uif-field-label-required" aria-hidden="true">*</span>';
 
     const input1 = document.createElement("input");
     input1.className = "input";
@@ -818,8 +818,8 @@
     if (labelPosition === "side") field2.dataset.labelPosition = "side";
 
     const label2 = document.createElement("label");
-    label2.className = "field-label";
-    label2.innerHTML = '<span class="label-content"><span class="label-content-text">Password</span></span>';
+    label2.className = "uif-field-label";
+    label2.innerHTML = '<span class="uif-label-content"><span class="uif-label-content-text">Password</span></span>';
 
     const input2 = document.createElement("input");
     input2.className = "input";
@@ -842,7 +842,7 @@
     const btn = document.createElement("button");
     btn.className = "button solid";
     btn.type = "submit";
-    btn.innerHTML = '<span class="label-content"><span class="label-content-text">Sign in</span></span>';
+    btn.innerHTML = '<span class="uif-label-content"><span class="uif-label-content-text">Sign in</span></span>';
     actions.append(btn);
 
     form.append(field1, field2, actions);
@@ -853,15 +853,15 @@
     const helperCode = invalid ? '\n    <p class="form-field-helper">Please enter a valid email address.</p>' : "";
     const code = `<form class="${formClasses.join(" ")}" novalidate>
   <div class="form-field${inv}"${lp}>
-    <label class="field-label"><span class="label-content"><span class="label-content-text">Email</span></span><span class="field-label-required" aria-hidden="true">*</span></label>
+    <label class="uif-field-label"><span class="uif-label-content"><span class="uif-label-content-text">Email</span></span><span class="uif-field-label-required" aria-hidden="true">*</span></label>
     <input class="input" type="email" placeholder="you@example.com" />${helperCode}
   </div>
   <div class="form-field"${lp}>
-    <label class="field-label"><span class="label-content"><span class="label-content-text">Password</span></span></label>
+    <label class="uif-field-label"><span class="uif-label-content"><span class="uif-label-content-text">Password</span></span></label>
     <input class="input" type="password" />
   </div>
   <div class="form-actions"${alignAttr}>
-    <button class="uif-button solid" type="submit"><span class="label-content"><span class="label-content-text">Sign in</span></span></button>
+    <button class="uif-button solid" type="submit"><span class="uif-label-content"><span class="uif-label-content-text">Sign in</span></span></button>
   </div>
 </form>`;
 
@@ -1136,7 +1136,7 @@
     if (isOpen) rootClasses.push("is-open");
 
     let html = `<div class="form-field date-picker-field">`;
-    html += `<label class="field-label" id="date-picker-playground-label" for="date-picker-playground-day"><span class="label-content"><span class="label-content-text">Travel date</span></span></label>`;
+    html += `<label class="uif-field-label" id="date-picker-playground-label" for="date-picker-playground-day"><span class="uif-label-content"><span class="uif-label-content-text">Travel date</span></span></label>`;
     html += `<div class="${rootClasses.join(" ")}" role="group" aria-labelledby="date-picker-playground-label">`;
     html += `<div class="date-segments">`;
     html += `<input class="date-segment day" id="date-picker-playground-day" type="text" inputmode="numeric" maxlength="2" placeholder="DD" aria-label="Day" value="${quoteAttr(day)}"${disabledAttr}>`;

--- a/site/components/date-picker.md
+++ b/site/components/date-picker.md
@@ -26,9 +26,9 @@ playgroundLabel: Open Date Picker Playground
     </div>
     <div class="docs-hero-preview-stage">
       <div class="form-field date-picker-field">
-        <label class="field-label" id="date-input-demo-label" for="date-input-demo-day">
-          <span class="label-content">
-            <span class="label-content-text">Travel date</span>
+        <label class="uif-field-label" id="date-input-demo-label" for="date-input-demo-day">
+          <span class="uif-label-content">
+            <span class="uif-label-content-text">Travel date</span>
           </span>
         </label>
         <div class="input-field date" id="date-input-demo" role="group" aria-labelledby="date-input-demo-label">
@@ -63,7 +63,7 @@ Together they form a component that can be opened, navigated, and dismissed — 
 
 ```
 .form-field.date-picker-field
-├── label.field-label [for="date-day"]
+├── label.uif-field-label [for="date-day"]
 └── .input-field.date [role="group", aria-labelledby]
     ├── .date-segments
     │   ├── input.date-segment.day [maxlength=2, inputmode=numeric, aria-label="Day"]
@@ -175,7 +175,7 @@ The Date Picker requires `src/ui/components/date-input.js` for:
     var trigger = root.querySelector("[aria-label='Open calendar']");
     var calendar = root.querySelector('.calendar');
     var field = root.closest('.date-picker-field');
-    var label = field && field.querySelector('.field-label');
+    var label = field && field.querySelector('.uif-field-label');
     var isOpen = false;
 
     // Auto-tab between segments

--- a/site/examples/vanilla-starter.md
+++ b/site/examples/vanilla-starter.md
@@ -40,23 +40,23 @@ import "ui-foundations/tokens/components.css";
 
 ## 3. Render an example page
 
-Use package classes like `.uif-button`, `.input`, `.field-label`, and `.checkbox`.
+Use package classes like `.uif-button`, `.input`, `.uif-field-label`, and `.checkbox`.
 
 ```js
 document.querySelector("#app").innerHTML = `
   <main style="max-width: 720px; margin: 2rem auto; padding: 0 1rem;">
     <h1>UI Foundations Vanilla Starter</h1>
 
-    <label class="field-label" for="email">
-      <span class="label-content">
-        <span class="label-content-text">Email</span>
+    <label class="uif-field-label" for="email">
+      <span class="uif-label-content">
+        <span class="uif-label-content-text">Email</span>
       </span>
     </label>
     <input class="input" id="email" type="email" placeholder="name@example.com" />
 
     <div style="height: 0.75rem"></div>
     <button class="uif-button solid" type="button">
-      <span class="label-content"><span class="label-content-text">Submit</span></span>
+      <span class="uif-label-content"><span class="uif-label-content-text">Submit</span></span>
     </button>
   </main>
 `;

--- a/site/patterns/icon.md
+++ b/site/patterns/icon.md
@@ -156,7 +156,7 @@ is deferred to Wave 4 in v2.0 or later.
 <div class="docs-guideline">
   <div class="docs-guideline-item" data-type="do">
     <div class="docs-guideline-preview">
-      <span class="label-content"><span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span><span class="label-content-text">Search</span></span>
+      <span class="uif-label-content"><span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span><span class="uif-label-content-text">Search</span></span>
     </div>
     <div class="docs-guideline-body">
       <p class="docs-guideline-label">Do</p>

--- a/site/patterns/index.md
+++ b/site/patterns/index.md
@@ -58,9 +58,9 @@ permalink: /patterns/
   </a>
   <a class="docs-component-card" href="/patterns/label/">
     <div class="docs-component-card-preview">
-      <span class="label-content">
+      <span class="uif-label-content">
         <span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
-        <span class="label-content-text">Search</span>
+        <span class="uif-label-content-text">Search</span>
       </span>
     </div>
     <div class="docs-component-card-body">

--- a/site/patterns/label.md
+++ b/site/patterns/label.md
@@ -24,9 +24,9 @@ playgroundLabel: Open Label Playground
       </span>
     </div>
     <div class="docs-hero-preview-stage">
-      <span class="label-content">
+      <span class="uif-label-content">
         <span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
-        <span class="label-content-text">Search</span>
+        <span class="uif-label-content-text">Search</span>
       </span>
     </div>
   </div>
@@ -55,9 +55,9 @@ playgroundLabel: Open Label Playground
         <span class="docs-anatomy-callout-line"></span>
         <span class="docs-anatomy-badge">2</span>
       </span>
-      <span class="label-content">
+      <span class="uif-label-content">
         <span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span>
-        <span class="label-content-text">Search</span>
+        <span class="uif-label-content-text">Search</span>
       </span>
     </div>
   </div>
@@ -83,12 +83,22 @@ playgroundLabel: Open Label Playground
   </tbody>
 </table>
 
+### v1 naming migration
+
+Use `.uif-label-content`, `.uif-label-content-text`, and the `.uif-field-label*`
+family in new and migrated markup. Their unprefixed class selectors remain
+available throughout v1.x, but the legacy `--field-label-*` custom properties
+have no library-owned aliases or fallbacks. Rename the field-label class and its
+runtime inputs together. Shared `--typography-label-*` tokens keep their
+separately governed typography namespace. Legacy class removal remains Wave 4
+work for v2.0 or later.
+
 <h2 id="behaviors">Behaviors</h2>
 
 <div class="docs-behavior-list">
   <div class="docs-behavior-item">
     <div class="docs-behavior-preview">
-      <span class="label-content"><span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span><span class="label-content-text">Search</span></span>
+      <span class="uif-label-content"><span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/search.svg');" aria-hidden="true"></span><span class="uif-label-content-text">Search</span></span>
     </div>
     <div class="docs-behavior-body">
       <h3>Icon + text composition</h3>
@@ -97,7 +107,7 @@ playgroundLabel: Open Label Playground
   </div>
   <div class="docs-behavior-item">
     <div class="docs-behavior-preview">
-      <span class="label-content is-icon-only"><span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/menu.svg');" aria-hidden="true"></span></span>
+      <span class="uif-label-content is-icon-only"><span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/menu.svg');" aria-hidden="true"></span></span>
     </div>
     <div class="docs-behavior-body">
       <h3>Icon-only mode</h3>
@@ -110,14 +120,14 @@ playgroundLabel: Open Label Playground
 
 <div class="docs-guideline">
   <div class="docs-guideline-item" data-type="do">
-    <div class="docs-guideline-preview"><code>&lt;label class="field-label"&gt;</code></div>
+    <div class="docs-guideline-preview"><code>&lt;label class="uif-field-label"&gt;</code></div>
     <div class="docs-guideline-body">
       <p class="docs-guideline-label">Do</p>
       <p>Use FieldLabel with <code>htmlFor</code> to link label and input.</p>
     </div>
   </div>
   <div class="docs-guideline-item" data-type="dont">
-    <div class="docs-guideline-preview"><code>&lt;span class="label-content"&gt;</code></div>
+    <div class="docs-guideline-preview"><code>&lt;span class="uif-label-content"&gt;</code></div>
     <div class="docs-guideline-body">
       <p class="docs-guideline-label">Don't</p>
       <p>Don't use LabelContent for form fields — no semantic link to the input.</p>

--- a/src/elements/ui-button.js
+++ b/src/elements/ui-button.js
@@ -32,7 +32,7 @@ class UIButton extends UIElement {
     if (iconOnly) classes.push("icon-only");
 
     const text = this.textContent.trim();
-    const labelContentClasses = ["label-content"];
+    const labelContentClasses = ["uif-label-content"];
     if (iconOnly) labelContentClasses.push("is-icon-only");
 
     let inner = "";
@@ -42,7 +42,7 @@ class UIButton extends UIElement {
     }
 
     if (!iconOnly && text) {
-      inner += `<span class="label-content-text">${text}</span>`;
+      inner += `<span class="uif-label-content-text">${text}</span>`;
     }
 
     if (endIcon && !iconOnly) {

--- a/src/elements/ui-label.js
+++ b/src/elements/ui-label.js
@@ -19,7 +19,7 @@ class UIFieldLabel extends UIElement {
     const startIcon = this.getAttr("start-icon");
     const text = this.textContent.trim();
 
-    const labelAttrs = ['class="field-label"'];
+    const labelAttrs = ['class="uif-field-label"'];
     if (htmlFor) labelAttrs.push(`for="${htmlFor}"`);
 
     let iconHtml = "";
@@ -29,11 +29,11 @@ class UIFieldLabel extends UIElement {
 
     let requiredHtml = "";
     if (required) {
-      requiredHtml = `<span class="field-label-required" aria-hidden="true">*</span><span class="field-label-required-text"> (required)</span>`;
+      requiredHtml = `<span class="uif-field-label-required" aria-hidden="true">*</span><span class="uif-field-label-required-text"> (required)</span>`;
     }
 
     this.innerHTML = `<label ${labelAttrs.join(" ")}>
-  <span class="label-content">${iconHtml}<span class="label-content-text">${text}</span></span>${requiredHtml}
+  <span class="uif-label-content">${iconHtml}<span class="uif-label-content-text">${text}</span></span>${requiredHtml}
 </label>`;
   }
 }

--- a/src/ui/patterns/button.css
+++ b/src/ui/patterns/button.css
@@ -23,13 +23,13 @@
     -webkit-text-fill-color: currentColor;
   }
 
-  :is(.uif-button, .button) .label-content {
+  :is(.uif-button, .button) :is(.uif-label-content, .label-content) {
     line-height: inherit;
     color: inherit;
     -webkit-text-fill-color: currentColor;
   }
 
-  :is(.uif-button, .button) .label-content-text,
+  :is(.uif-button, .button) :is(.uif-label-content-text, .label-content-text),
   :is(.uif-button, .button) :is(.uif-icon, .icon) {
     color: inherit;
     -webkit-text-fill-color: currentColor;

--- a/src/ui/patterns/form.css
+++ b/src/ui/patterns/form.css
@@ -58,7 +58,7 @@
     align-items: flex-start;
   }
 
-  .form-field[data-label-position="side"] > .field-label {
+  .form-field[data-label-position="side"] > :is(.uif-field-label, .field-label) {
     flex-shrink: 0;
     inline-size: 8rem;
     padding-block-start: var(--size-spacing-200);

--- a/src/ui/patterns/label.css
+++ b/src/ui/patterns/label.css
@@ -1,41 +1,45 @@
 @layer components {
-  .label-content {
+  /*
+   * Unprefixed Label-family classes are deprecated v1.x compatibility selectors.
+   * UIF-owned emitters use canonical `.uif-*` names; remove aliases no earlier than v2.0.
+   */
+  :is(.uif-label-content, .label-content) {
     display: inline-flex;
     align-items: center;
     gap: var(--typography-label-gap, 0.5em);
     line-height: inherit;
   }
 
-  .label-content > :is(.uif-icon, .icon)[data-slot] {
+  :is(.uif-label-content, .label-content) > :is(.uif-icon, .icon)[data-slot] {
     display: inline-flex;
     align-items: center;
     line-height: inherit;
     flex: 0 0 auto;
   }
 
-  .label-content-text {
+  :is(.uif-label-content-text, .label-content-text) {
     line-height: inherit;
   }
 
-  .label-content.is-icon-only {
+  :is(.uif-label-content, .label-content).is-icon-only {
     gap: 0;
   }
 
-  .field-label {
+  :is(.uif-field-label, .field-label) {
     position: relative;
     display: inline-flex;
     align-items: center;
-    gap: var(--field-label-gap, 0.25em);
-    line-height: var(--field-label-line-height, inherit);
+    gap: var(--uif-field-label-gap, 0.25em);
+    line-height: var(--uif-field-label-line-height, inherit);
     cursor: pointer;
   }
 
-  .field-label-required {
-    color: var(--field-label-required-color, currentColor);
+  :is(.uif-field-label-required, .field-label-required) {
+    color: var(--uif-field-label-required-color, currentColor);
     font-weight: var(--font-weight-700);
   }
 
-  .field-label-required-text {
+  :is(.uif-field-label-required-text, .field-label-required-text) {
     position: absolute;
     inline-size: 1px;
     block-size: 1px;

--- a/tests/label-naming-migration.test.mjs
+++ b/tests/label-naming-migration.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("Label CSS exposes canonical UIF naming with v1 class aliases", async () => {
+  const css = await read("src/ui/patterns/label.css");
+
+  for (const className of [
+    "label-content",
+    "label-content-text",
+    "field-label",
+    "field-label-required",
+    "field-label-required-text",
+  ]) {
+    assert.match(css, new RegExp(`:is\\(\\.uif-${className}, \\.${className}\\)`));
+  }
+
+  assert.match(css, /var\(--uif-field-label-gap, 0\.25em\)/);
+  assert.match(css, /var\(--uif-field-label-line-height, inherit\)/);
+  assert.match(css, /var\(--uif-field-label-required-color, currentColor\)/);
+  assert.doesNotMatch(css, /var\(--field-label-/);
+  assert.doesNotMatch(css, /\.uif-label-content(?:__|--)/);
+});
+
+test("Label-owned emitters produce canonical classes and runtime inputs", async () => {
+  const sources = await Promise.all([
+    read("src/elements/ui-label.js"),
+    read("src/elements/ui-button.js"),
+    read("site/_includes/macros/ui.njk"),
+    read("site/assets/playground/renderers.js"),
+    read("schemas/web-label.figma.ts"),
+    read("schemas/web-form.figma.ts"),
+    read("schemas/web-button.figma.ts"),
+    read("packages/mcp-server/src/resources/components.ts"),
+  ]);
+
+  for (const source of sources) {
+    assert.match(source, /uif-label-content/);
+    assert.doesNotMatch(source, /class="label-content(?:\s|")/);
+    assert.doesNotMatch(source, /class="field-label(?:\s|")/);
+    assert.doesNotMatch(source, /--field-label-/);
+  }
+});
+
+test("shared Button and Form selectors retain Label-family compatibility", async () => {
+  const [button, form] = await Promise.all([
+    read("src/ui/patterns/button.css"),
+    read("src/ui/patterns/form.css"),
+  ]);
+
+  assert.match(button, /:is\(\.uif-label-content, \.label-content\)/);
+  assert.match(button, /:is\(\.uif-label-content-text, \.label-content-text\)/);
+  assert.match(form, /:is\(\.uif-field-label, \.field-label\)/);
+});
+
+test("Typography Label tokens keep their separately governed namespace", async () => {
+  const tokenExport = await read("figma/exports/Patterns (UI).tokens.json");
+
+  assert.match(tokenExport, /var\(--typography-label-font-family\)/);
+  assert.match(tokenExport, /var\(--typography-label-gap\)/);
+  assert.doesNotMatch(tokenExport, /--uif-field-label-/);
+});
+
+test("Label migration guidance preserves the existing Custom Element tag", async () => {
+  const [documentation, element, declarations] = await Promise.all([
+    read("site/patterns/label.md"),
+    read("src/elements/ui-label.js"),
+    read("src/elements/index.d.ts"),
+  ]);
+
+  assert.match(documentation, /legacy `--field-label-\*` custom properties/);
+  assert.match(element, /define\("ui-field-label", UIFieldLabel\)/);
+  assert.match(declarations, /"ui-field-label": UIFieldLabel/);
+  assert.doesNotMatch(element, /ui-uif-field-label/);
+});


### PR DESCRIPTION
## Summary

- migrate Label composition and field-label classes to canonical `.uif-*` names
- retain unprefixed v1.x selector aliases at matching specificity
- migrate code-only field-label runtime inputs to `--uif-field-label-*` with no legacy custom-property aliases
- update retained Web Component internals, Nunjucks macros, playground emitters, shared Button/Form consumers, Code Connect schemas, MCP output, examples, and documentation
- add focused regression coverage and explicit consumer migration guidance

## Figma/token boundary

A live Figma audit confirmed that `Typography/Label/*` variables already use the separately governed `--typography-label-*` WEB namespace. Those shared typography tokens remain unchanged. The field-label custom properties are runtime-only extension inputs, so this PR does not invent Figma variables.

The existing `<ui-field-label>` Custom Element tag is intentionally unchanged.

## Consumer impact

Consumers should migrate Label-family classes to their `.uif-*` forms. Legacy class selectors remain through v1.x. Consumers using `--field-label-*` must rename those inputs to `--uif-field-label-*`; no legacy property alias or fallback is provided.

## Validation

- `npm run lint`
- `npm run test:unit` — 100 passing
- `npm run ci:check`
- regenerated and inspected `dist/`; generated files were not edited directly

Closes #163