### PR TITLE
Migration: Adopt UIF-prefixed naming for Calendar

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -39,7 +39,7 @@ Rules: Components reference only Semantic or Core. Never hardcode values.
 
 Examples:
 - `--button-solid-container-background-hover`
-- `--calendar-cell-text-color-disabled`
+- `--uif-calendar-cell-text-color-disabled`
 
 States always last: `default`, `hover`, `active`, `focus`, `disabled`
 

--- a/docs/foundations/foundation-013-class-naming.md
+++ b/docs/foundations/foundation-013-class-naming.md
@@ -53,8 +53,8 @@ namespace prefixes.
 .uif-form-field { }
 
 /* Example: invalid */
-.calendar__header { }       /* no double-underscore */
-.calendar-cell--selected { } /* no BEM modifier */
+.uif-calendar__header { }       /* no double-underscore */
+.uif-calendar-cell--selected { } /* no BEM modifier */
 .ui-calendar { }            /* no non-Vault namespace */
 .uif-button--ghost { }      /* use multi-class */
 ```
@@ -69,8 +69,8 @@ namespace prefixes.
 
 ### Migration Note
 
-Some runtime artifacts still use bare classes such as `.input` and
-`.calendar-cell`. Button emitters now use `.uif-button`; `.button` remains a
+Some runtime artifacts still use bare classes such as `.input` and `.link`.
+Button emitters now use `.uif-button`; `.button` remains a
 deprecated CSS-only compatibility selector through v1.x. Runtime validation
 should warn with migration guidance rather than fail existing artifacts without
 context.

--- a/docs/migrations/react-to-web-components.md
+++ b/docs/migrations/react-to-web-components.md
@@ -41,7 +41,7 @@ The module paths below are the component-specific alternatives. Import
 
 `Calendar` was available only from the removed aggregate React entry. There is
 no Calendar Custom Element entry point. Use the documented Calendar semantic
-HTML and `.calendar*` CSS pattern until Calendar receives an approved Custom
+HTML and `.uif-calendar*` CSS pattern until Calendar receives an approved Custom
 Element API. `LabelContent` is likewise a composition helper: author the
 documented uif-label-content markup or use the Nunjucks macro instead of inventing
 a Custom Element.

--- a/figma/exports/Patterns (UI).tokens.json
+++ b/figma/exports/Patterns (UI).tokens.json
@@ -6377,7 +6377,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-container-padding)"
+            "WEB": "var(--uif-calendar-container-padding)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:3",
@@ -6399,7 +6399,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-container-border-radius)"
+            "WEB": "var(--uif-calendar-container-border-radius)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:1:250",
@@ -6421,7 +6421,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-container-border-color)"
+            "WEB": "var(--uif-calendar-container-border-color)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:343",
@@ -6443,7 +6443,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-container-border-size)"
+            "WEB": "var(--uif-calendar-container-border-size)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:7",
@@ -6465,7 +6465,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-container-background)"
+            "WEB": "var(--uif-calendar-container-background)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:329",
@@ -6487,7 +6487,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-container-gap)"
+            "WEB": "var(--uif-calendar-container-gap)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:3",
@@ -6511,7 +6511,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-cell-gap)"
+            "WEB": "var(--uif-calendar-cell-gap)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2983:462",
@@ -6533,7 +6533,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-cell-min-size)"
+            "WEB": "var(--uif-calendar-cell-min-size)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3020:2",
@@ -6555,7 +6555,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-cell-border-radius)"
+            "WEB": "var(--uif-calendar-cell-border-radius)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:1:251",
@@ -6577,7 +6577,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-cell-text-color-default)"
+            "WEB": "var(--uif-calendar-cell-text-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:326",
@@ -6599,7 +6599,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-cell-text-color-active)"
+            "WEB": "var(--uif-calendar-cell-text-color-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2616:6",
@@ -6621,7 +6621,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-cell-text-color-disabled)"
+            "WEB": "var(--uif-calendar-cell-text-color-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:328",
@@ -6643,7 +6643,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-cell-background-active)"
+            "WEB": "var(--uif-calendar-cell-background-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:339",
@@ -6665,7 +6665,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-cell-background-hover)"
+            "WEB": "var(--uif-calendar-cell-background-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2016:1881",
@@ -6687,7 +6687,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-cell-range-border-color)"
+            "WEB": "var(--uif-calendar-cell-range-border-color)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:345",
@@ -6709,7 +6709,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-cell-range-border-size)"
+            "WEB": "var(--uif-calendar-cell-range-border-size)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:7",
@@ -6731,7 +6731,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-cell-range-border-radius)"
+            "WEB": "var(--uif-calendar-cell-range-border-radius)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:1:251",
@@ -6755,7 +6755,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-weekday-text-color)"
+            "WEB": "var(--uif-calendar-weekday-text-color)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:341",
@@ -6777,7 +6777,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-weekday-font-size)"
+            "WEB": "var(--uif-calendar-weekday-font-size)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:1:205",
@@ -6797,7 +6797,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-weekday-height)"
+            "WEB": "var(--uif-calendar-weekday-height)"
           }
         }
       }
@@ -6814,7 +6814,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--calendar-header-gap)"
+            "WEB": "var(--uif-calendar-header-gap)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:3",

--- a/scripts/validate-token-usage.mjs
+++ b/scripts/validate-token-usage.mjs
@@ -25,13 +25,6 @@ const ALLOWLIST = new Set([
   "--uif-field-label-line-height",
   "--uif-field-label-required-color",
   "--uif-icon-src",
-  // Calendar component extension points (pending Figma export)
-  "--calendar-cell-background-selected",
-  "--calendar-cell-background-range",
-  "--calendar-cell-text-color-default",
-  "--calendar-cell-text-color-selected",
-  "--calendar-cell-border-color-today",
-  "--calendar-cell-text-color-outside",
 ]);
 
 function getDefinedTokens() {

--- a/site/_includes/macros/calendar.njk
+++ b/site/_includes/macros/calendar.njk
@@ -15,7 +15,7 @@
 {%- endmacro %}
 
 {% macro calendarDay(label='1', selected=false, today=false, disabled=false, outsideMonth=false, hover=false, focus=false, rangeStart=false, rangeMiddle=false, rangeEnd=false, tabindex='-1') -%}
-{%- set cellClasses = "calendar-cell" -%}
+{%- set cellClasses = "uif-calendar-cell" -%}
 {%- if hover -%}{%- set cellClasses = cellClasses + " is-hover" -%}{%- endif -%}
 {%- if focus -%}{%- set cellClasses = cellClasses + " is-focus-visible" -%}{%- endif -%}
 {%- if selected -%}{%- set cellClasses = cellClasses + " is-selected" -%}{%- endif -%}
@@ -30,7 +30,7 @@
 {%- endmacro %}
 
 {% macro calendar(month='2026-07', selectedDate='', todayDate='', state='default', disabled=false, container=true, className='', id='', rangeStart='', rangeEnd='') -%}
-{%- set calendarClasses = "calendar" -%}
+{%- set calendarClasses = "uif-calendar" -%}
 {%- if container -%}{%- set calendarClasses = calendarClasses + " has-container" -%}{%- endif -%}
 {%- if className -%}{%- set calendarClasses = calendarClasses + " " + className -%}{%- endif -%}
 
@@ -46,19 +46,19 @@
 {%- endfor -%}
 
 <div class="{{ calendarClasses }}"{% if id %} id="{{ id }}"{% endif %}>
-  <div class="calendar-header">
-    <button type="button" class="button ghost" aria-label="Previous month"{{ " disabled" if disabled }}>
+  <div class="uif-calendar-header">
+    <button type="button" class="uif-button ghost" aria-label="Previous month"{{ " disabled" if disabled }}>
       {{ calendarIcon('chevron--left') }}
     </button>
-    <span class="calendar-selectors">
-      {{ calendarSelect(options=monthOptions, value='6', disabled=disabled, className='calendar-header-select', name='month') }}
-      {{ calendarSelect(options=yearOptions, value='2026', disabled=disabled, className='calendar-header-select', name='year') }}
+    <span class="uif-calendar-selectors">
+      {{ calendarSelect(options=monthOptions, value='6', disabled=disabled, className='uif-calendar-header-select', name='month') }}
+      {{ calendarSelect(options=yearOptions, value='2026', disabled=disabled, className='uif-calendar-header-select', name='year') }}
     </span>
-    <button type="button" class="button ghost" aria-label="Next month"{{ " disabled" if disabled }}>
+    <button type="button" class="uif-button ghost" aria-label="Next month"{{ " disabled" if disabled }}>
       {{ calendarIcon('chevron') }}
     </button>
   </div>
-  <table class="calendar-table" role="grid" aria-label="{{ month }}">
+  <table class="uif-calendar-table" role="grid" aria-label="{{ month }}">
     <thead>
       <tr>
         {%- for day in weekdays %}
@@ -101,7 +101,7 @@
 {# ─── Range Calendar (two months side by side) ─────────────────── #}
 
 {% macro rangeCalendar(month='2026-07', disabled=false, container=true, className='', id='') -%}
-{%- set calendarClasses = "calendar range-view" -%}
+{%- set calendarClasses = "uif-calendar range-view" -%}
 {%- if container -%}{%- set calendarClasses = calendarClasses + " has-container" -%}{%- endif -%}
 {%- if className -%}{%- set calendarClasses = calendarClasses + " " + className -%}{%- endif -%}
 
@@ -117,40 +117,40 @@
 {%- endfor -%}
 
 <div class="{{ calendarClasses }}"{% if id %} id="{{ id }}"{% endif %}>
-  <div class="calendar-header">
-    <button type="button" class="button ghost" aria-label="Previous month"{{ " disabled" if disabled }}>
+  <div class="uif-calendar-header">
+    <button type="button" class="uif-button ghost" aria-label="Previous month"{{ " disabled" if disabled }}>
       {{ calendarIcon('chevron--left') }}
     </button>
-    <span class="calendar-selectors">
-      {{ calendarSelect(options=monthOptions, value='6', disabled=disabled, className='calendar-header-select', name='month') }}
-      {{ calendarSelect(options=yearOptions, value='2026', disabled=disabled, className='calendar-header-select', name='year') }}
+    <span class="uif-calendar-selectors">
+      {{ calendarSelect(options=monthOptions, value='6', disabled=disabled, className='uif-calendar-header-select', name='month') }}
+      {{ calendarSelect(options=yearOptions, value='2026', disabled=disabled, className='uif-calendar-header-select', name='year') }}
     </span>
-    <button type="button" class="button ghost" aria-label="Next month"{{ " disabled" if disabled }}>
+    <button type="button" class="uif-button ghost" aria-label="Next month"{{ " disabled" if disabled }}>
       {{ calendarIcon('chevron') }}
     </button>
   </div>
 
   {# Left month #}
-  <div class="calendar-month-panel" data-panel="left">
-    <span class="calendar-month-label">July 2026</span>
-    <table class="calendar-table" role="grid" aria-label="July 2026">
+  <div class="uif-calendar-month-panel" data-panel="left">
+    <span class="uif-calendar-month-label">July 2026</span>
+    <table class="uif-calendar-table" role="grid" aria-label="July 2026">
       <thead><tr>{%- for day in weekdays %}<th scope="col" abbr="{{ day }}">{{ day }}</th>{%- endfor %}</tr></thead>
       <tbody>
         {%- for week in range(0, 5) %}
-        <tr>{%- for dow in range(0, 7) %}{%- set i = week * 7 + dow + 1 -%}{%- if i <= 31 %}<td><button type="button" class="calendar-cell" aria-selected="false" tabindex="{{ 0 if i == 1 else -1 }}">{{ i }}</button></td>{%- else %}<td></td>{%- endif %}{%- endfor %}</tr>
+        <tr>{%- for dow in range(0, 7) %}{%- set i = week * 7 + dow + 1 -%}{%- if i <= 31 %}<td><button type="button" class="uif-calendar-cell" aria-selected="false" tabindex="{{ 0 if i == 1 else -1 }}">{{ i }}</button></td>{%- else %}<td></td>{%- endif %}{%- endfor %}</tr>
         {%- endfor %}
       </tbody>
     </table>
   </div>
 
   {# Right month #}
-  <div class="calendar-month-panel" data-panel="right">
-    <span class="calendar-month-label">August 2026</span>
-    <table class="calendar-table" role="grid" aria-label="August 2026">
+  <div class="uif-calendar-month-panel" data-panel="right">
+    <span class="uif-calendar-month-label">August 2026</span>
+    <table class="uif-calendar-table" role="grid" aria-label="August 2026">
       <thead><tr>{%- for day in weekdays %}<th scope="col" abbr="{{ day }}">{{ day }}</th>{%- endfor %}</tr></thead>
       <tbody>
         {%- for week in range(0, 5) %}
-        <tr>{%- for dow in range(0, 7) %}{%- set i = week * 7 + dow + 1 -%}{%- if i <= 31 %}<td><button type="button" class="calendar-cell" aria-selected="false" tabindex="-1">{{ i }}</button></td>{%- else %}<td></td>{%- endif %}{%- endfor %}</tr>
+        <tr>{%- for dow in range(0, 7) %}{%- set i = week * 7 + dow + 1 -%}{%- if i <= 31 %}<td><button type="button" class="uif-calendar-cell" aria-selected="false" tabindex="-1">{{ i }}</button></td>{%- else %}<td></td>{%- endif %}{%- endfor %}</tr>
         {%- endfor %}
       </tbody>
     </table>

--- a/site/assets/docs.css
+++ b/site/assets/docs.css
@@ -443,7 +443,7 @@ details[open] > .docs-nav-group-toggle::before {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: var(--calendar-cell-gap);
+  padding: var(--uif-calendar-cell-gap);
   min-inline-size: 48px;
 }
 
@@ -485,7 +485,7 @@ details[open] > .docs-nav-group-toggle::before {
   inset-inline-start: calc(50% - 20px);
   inline-size: 40px;
   block-size: 40px;
-  border-radius: var(--calendar-cell-border-radius);
+  border-radius: var(--uif-calendar-cell-border-radius);
 }
 
 .docs-calendar-anatomy-callout--container {

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -1054,16 +1054,16 @@
     const disabledAttr = disabled ? " disabled" : "";
 
     // Build header with selects
-    let headerHtml = `<div class="calendar-header">`;
-    headerHtml += `<button type="button" class="button ghost" aria-label="Previous month"${disabledAttr}><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/chevron--left.svg');" aria-hidden="true"></span></button>`;
-    headerHtml += `<span class="calendar-selectors">`;
-    headerHtml += `<select class="select calendar-header-select" name="month" aria-label="Month"${disabledAttr}>`;
+    let headerHtml = `<div class="uif-calendar-header">`;
+    headerHtml += `<button type="button" class="uif-button ghost" aria-label="Previous month"${disabledAttr}><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/chevron--left.svg');" aria-hidden="true"></span></button>`;
+    headerHtml += `<span class="uif-calendar-selectors">`;
+    headerHtml += `<select class="select uif-calendar-header-select" name="month" aria-label="Month"${disabledAttr}>`;
     months.forEach((m, i) => { headerHtml += `<option value="${i}"${i === selectedMonth ? " selected" : ""}>${m}</option>`; });
     headerHtml += `</select>`;
-    headerHtml += `<select class="select calendar-header-select" name="year" aria-label="Year"${disabledAttr}>`;
+    headerHtml += `<select class="select uif-calendar-header-select" name="year" aria-label="Year"${disabledAttr}>`;
     for (let y = 2020; y <= 2030; y++) { headerHtml += `<option value="${y}"${y === selectedYear ? " selected" : ""}>${y}</option>`; }
     headerHtml += `</select></span>`;
-    headerHtml += `<button type="button" class="button ghost" aria-label="Next month"${disabledAttr}><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/chevron.svg');" aria-hidden="true"></span></button>`;
+    headerHtml += `<button type="button" class="uif-button ghost" aria-label="Next month"${disabledAttr}><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/chevron.svg');" aria-hidden="true"></span></button>`;
     headerHtml += `</div>`;
 
     // Build table
@@ -1075,7 +1075,7 @@
       tbodyHtml += "<tr>";
       for (let dow = 0; dow < 7; dow++) {
         if (day <= 31) {
-          const classes = ["calendar-cell"];
+          const classes = ["uif-calendar-cell"];
           if (previewState === "hover" && day === 15) classes.push("is-hover");
           if (previewState === "focus" && day === 15) classes.push("is-focus-visible");
           if (selectedDate === String(day)) classes.push("is-selected");
@@ -1097,9 +1097,9 @@
     }
     tbodyHtml += "</tbody>";
 
-    const calendarClasses = ["calendar"];
+    const calendarClasses = ["uif-calendar"];
     if (hasContainer) calendarClasses.push("has-container");
-    const html = `<div class="${calendarClasses.join(" ")}">${headerHtml}<table class="calendar-table" role="grid" aria-label="${quoteAttr(month)}">${theadHtml}${tbodyHtml}</table></div>`;
+    const html = `<div class="${calendarClasses.join(" ")}">${headerHtml}<table class="uif-calendar-table" role="grid" aria-label="${quoteAttr(month)}">${theadHtml}${tbodyHtml}</table></div>`;
 
     const wrapper = document.createElement("div");
     wrapper.innerHTML = html;
@@ -1149,16 +1149,16 @@
     html += `<button type="button" aria-label="Open calendar" aria-expanded="${isOpen}" aria-haspopup="grid" aria-controls="date-picker-playground-calendar"${disabledAttr}>`;
     html += `<span class="uif-icon" style="--uif-icon-src: url('/assets/icons/calendar.svg');" aria-hidden="true"></span>`;
     html += `</button></span>`;
-    html += `<div class="calendar" id="date-picker-playground-calendar"><div class="calendar-header">`;
-    html += `<button type="button" class="button ghost" aria-label="Previous month"><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/chevron--left.svg');" aria-hidden="true"></span></button>`;
-    html += `<span class="calendar-selectors"><select class="select calendar-header-select" name="month" aria-label="Month">`;
+    html += `<div class="uif-calendar" id="date-picker-playground-calendar"><div class="uif-calendar-header">`;
+    html += `<button type="button" class="uif-button ghost" aria-label="Previous month"><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/chevron--left.svg');" aria-hidden="true"></span></button>`;
+    html += `<span class="uif-calendar-selectors"><select class="select uif-calendar-header-select" name="month" aria-label="Month">`;
     monthNames.forEach((m, i) => { html += `<option value="${i}"${i === visibleMonth ? " selected" : ""}>${m}</option>`; });
-    html += `</select><select class="select calendar-header-select" name="year" aria-label="Year">`;
+    html += `</select><select class="select uif-calendar-header-select" name="year" aria-label="Year">`;
     for (let y = 2020; y <= 2030; y++) { html += `<option value="${y}"${y === visibleYear ? " selected" : ""}>${y}</option>`; }
     html += `</select></span>`;
-    html += `<button type="button" class="button ghost" aria-label="Next month"><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/chevron.svg');" aria-hidden="true"></span></button>`;
+    html += `<button type="button" class="uif-button ghost" aria-label="Next month"><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/chevron.svg');" aria-hidden="true"></span></button>`;
     const monthLabel = `${monthNames[visibleMonth]} ${visibleYear}`;
-    html += `</div><table class="calendar-table" role="grid" aria-label="${monthLabel}"><thead><tr>`;
+    html += `</div><table class="uif-calendar-table" role="grid" aria-label="${monthLabel}"><thead><tr>`;
     weekdayNames.forEach((d) => { html += `<th scope="col">${d}</th>`; });
     html += `</tr></thead><tbody>`;
     const firstDay = new Date(visibleYear, visibleMonth, 1);
@@ -1175,7 +1175,7 @@
         } else if (d <= daysInMonth) {
           started = true;
           const date = new Date(visibleYear, visibleMonth, d);
-          const classes = ["calendar-cell"];
+          const classes = ["uif-calendar-cell"];
           const isSelected = selectedDay === d && selectedMonth === visibleMonth + 1 && selectedYear === visibleYear;
           const isToday = date.toDateString() === today.toDateString();
           if (isSelected) classes.push("is-selected");

--- a/site/components/date-picker.md
+++ b/site/components/date-picker.md
@@ -74,9 +74,9 @@ Together they form a component that can be opened, navigated, and dismissed — 
     ├── .input-field-control
     │   └── button [aria-label="Open calendar", aria-expanded, aria-controls]
     │       └── span.uif-icon (calendar icon)
-    └── .calendar [hidden until opened]
-        ├── .calendar-header
-        └── table.calendar-table [role="grid"]
+    └── .uif-calendar [hidden until opened]
+        ├── .uif-calendar-header
+        └── table.uif-calendar-table [role="grid"]
 ```
 
 ## Patterns Used
@@ -133,7 +133,7 @@ Together they form a component that can be opened, navigated, and dismissed — 
 Reuses tokens from the composed patterns:
 - Input tokens (`--input-*`)
 - Input control button behavior from `.input-field-control`
-- Calendar tokens (`--calendar-cell-*`)
+- Calendar tokens (`--uif-calendar-cell-*`)
 
 No additional component-specific tokens needed — the composition inherits from its parts.
 
@@ -173,7 +173,7 @@ The Date Picker requires `src/ui/components/date-input.js` for:
   document.querySelectorAll('.input-field.date').forEach(function(root) {
     var segments = root.querySelectorAll('.date-segment');
     var trigger = root.querySelector("[aria-label='Open calendar']");
-    var calendar = root.querySelector('.calendar');
+    var calendar = root.querySelector('.uif-calendar');
     var field = root.closest('.date-picker-field');
     var label = field && field.querySelector('.uif-field-label');
     var isOpen = false;
@@ -314,7 +314,7 @@ The Date Picker requires `src/ui/components/date-input.js` for:
 
         if (monthSelect) monthSelect.value = currentMonth;
         if (yearSelect) yearSelect.value = currentYear;
-        var table = calendar.querySelector('.calendar-table');
+        var table = calendar.querySelector('.uif-calendar-table');
         if (table) {
           var label = new Intl.DateTimeFormat('en-GB', { month: 'long', year: 'numeric' }).format(firstDay);
           table.setAttribute('aria-label', label);
@@ -378,9 +378,9 @@ The Date Picker requires `src/ui/components/date-input.js` for:
 
       // Keyboard navigation in the grid (roving tabindex)
       calendar.addEventListener('keydown', function(e) {
-        var btn = e.target.closest('button.calendar-cell');
+        var btn = e.target.closest('button.uif-calendar-cell');
         if (!btn) return;
-        var cells = Array.from(calendar.querySelectorAll('button.calendar-cell'));
+        var cells = Array.from(calendar.querySelectorAll('button.uif-calendar-cell'));
         var idx = cells.indexOf(btn);
         if (idx === -1) return;
 
@@ -418,9 +418,9 @@ The Date Picker requires `src/ui/components/date-input.js` for:
       });
 
       calendar.addEventListener('click', function(e) {
-        var btn = e.target.closest('button.calendar-cell');
+        var btn = e.target.closest('button.uif-calendar-cell');
         if (!btn || btn.disabled) return;
-        calendar.querySelectorAll('.calendar-cell').forEach(function(c) {
+        calendar.querySelectorAll('.uif-calendar-cell').forEach(function(c) {
           c.classList.remove('is-selected');
           c.setAttribute('aria-selected', 'false');
         });

--- a/site/foundations/class-naming.md
+++ b/site/foundations/class-naming.md
@@ -47,8 +47,8 @@ The examples below illustrate the consumed contract. They are not source rules.
 .uif-input-field { }
 
 /* Example: invalid */
-.calendar__header { }        /* no double-underscore */
-.calendar-cell--selected { } /* no BEM modifier */
+.uif-calendar__header { }        /* no double-underscore */
+.uif-calendar-cell--selected { } /* no BEM modifier */
 .ui-calendar { }             /* no non-Vault namespace */
 .uif-button--ghost { }       /* use multi-class */
 ```
@@ -63,7 +63,7 @@ The examples below illustrate the consumed contract. They are not source rules.
 
 ## Migration
 
-Some runtime artifacts still use bare classes such as `.input` and
-`.calendar-cell`. Button emitters now use `.uif-button`; `.button` remains a
+Some runtime artifacts still use bare classes such as `.input` and `.link`.
+Button emitters now use `.uif-button`; `.button` remains a
 deprecated CSS-only compatibility selector through v1.x. Runtime validation
 warns with migration guidance while the migration is in progress.

--- a/site/patterns/calendar.md
+++ b/site/patterns/calendar.md
@@ -37,6 +37,14 @@ playgroundLabel: Open Calendar Playground
   </div>
 </div>
 
+### v1 naming migration
+
+Use `.uif-calendar` and the `.uif-calendar-*` part classes with
+`--uif-calendar-*` tokens in new and migrated markup. Unprefixed Calendar class
+selectors remain compatible throughout v1.x, but legacy `--calendar-*` token
+aliases are not provided. Consumers must migrate classes and tokens together.
+Legacy selector removal remains Wave 4 work for v2.0 or later.
+
 <h2 id="usage">Usage</h2>
 
 The Calendar component enables date selection in forms, filters, and booking flows. It supports single date selection and date range selection.
@@ -210,27 +218,27 @@ The Calendar component enables date selection in forms, filters, and booking flo
       <tr><th>Token</th><th>Purpose</th></tr>
     </thead>
     <tbody>
-      <tr><td><code>--calendar-container-padding</code></td><td>Container padding</td></tr>
-      <tr><td><code>--calendar-container-border-radius</code></td><td>Container border radius</td></tr>
-      <tr><td><code>--calendar-container-border-color</code></td><td>Container border color</td></tr>
-      <tr><td><code>--calendar-container-border-size</code></td><td>Container border width</td></tr>
-      <tr><td><code>--calendar-container-background</code></td><td>Container background</td></tr>
-      <tr><td><code>--calendar-container-gap</code></td><td>Vertical gap between calendar sections</td></tr>
-      <tr><td><code>--calendar-header-gap</code></td><td>Gap between header controls</td></tr>
-      <tr><td><code>--calendar-weekday-text-color</code></td><td>Weekday label color</td></tr>
-      <tr><td><code>--calendar-weekday-font-size</code></td><td>Weekday label font size</td></tr>
-      <tr><td><code>--calendar-weekday-height</code></td><td>Weekday label row height</td></tr>
-      <tr><td><code>--calendar-cell-gap</code></td><td>Spacing around day cells</td></tr>
-      <tr><td><code>--calendar-cell-min-size</code></td><td>Minimum day cell touch target</td></tr>
-      <tr><td><code>--calendar-cell-border-radius</code></td><td>Day cell radius</td></tr>
-      <tr><td><code>--calendar-cell-text-color-default</code></td><td>Default day cell text</td></tr>
-      <tr><td><code>--calendar-cell-text-color-active</code></td><td>Selected day cell text</td></tr>
-      <tr><td><code>--calendar-cell-text-color-disabled</code></td><td>Disabled and outside-month text</td></tr>
-      <tr><td><code>--calendar-cell-background-active</code></td><td>Selected day cell background</td></tr>
-      <tr><td><code>--calendar-cell-background-hover</code></td><td>Hover state</td></tr>
-      <tr><td><code>--calendar-cell-range-border-color</code></td><td>Range and today indicator border color</td></tr>
-      <tr><td><code>--calendar-cell-range-border-size</code></td><td>Range and today indicator border width</td></tr>
-      <tr><td><code>--calendar-cell-range-border-radius</code></td><td>Range start/end radius</td></tr>
+      <tr><td><code>--uif-calendar-container-padding</code></td><td>Container padding</td></tr>
+      <tr><td><code>--uif-calendar-container-border-radius</code></td><td>Container border radius</td></tr>
+      <tr><td><code>--uif-calendar-container-border-color</code></td><td>Container border color</td></tr>
+      <tr><td><code>--uif-calendar-container-border-size</code></td><td>Container border width</td></tr>
+      <tr><td><code>--uif-calendar-container-background</code></td><td>Container background</td></tr>
+      <tr><td><code>--uif-calendar-container-gap</code></td><td>Vertical gap between calendar sections</td></tr>
+      <tr><td><code>--uif-calendar-header-gap</code></td><td>Gap between header controls</td></tr>
+      <tr><td><code>--uif-calendar-weekday-text-color</code></td><td>Weekday label color</td></tr>
+      <tr><td><code>--uif-calendar-weekday-font-size</code></td><td>Weekday label font size</td></tr>
+      <tr><td><code>--uif-calendar-weekday-height</code></td><td>Weekday label row height</td></tr>
+      <tr><td><code>--uif-calendar-cell-gap</code></td><td>Spacing around day cells</td></tr>
+      <tr><td><code>--uif-calendar-cell-min-size</code></td><td>Minimum day cell touch target</td></tr>
+      <tr><td><code>--uif-calendar-cell-border-radius</code></td><td>Day cell radius</td></tr>
+      <tr><td><code>--uif-calendar-cell-text-color-default</code></td><td>Default day cell text</td></tr>
+      <tr><td><code>--uif-calendar-cell-text-color-active</code></td><td>Selected day cell text</td></tr>
+      <tr><td><code>--uif-calendar-cell-text-color-disabled</code></td><td>Disabled and outside-month text</td></tr>
+      <tr><td><code>--uif-calendar-cell-background-active</code></td><td>Selected day cell background</td></tr>
+      <tr><td><code>--uif-calendar-cell-background-hover</code></td><td>Hover state</td></tr>
+      <tr><td><code>--uif-calendar-cell-range-border-color</code></td><td>Range and today indicator border color</td></tr>
+      <tr><td><code>--uif-calendar-cell-range-border-size</code></td><td>Range and today indicator border width</td></tr>
+      <tr><td><code>--uif-calendar-cell-range-border-radius</code></td><td>Range start/end radius</td></tr>
     </tbody>
   </table>
 </div>

--- a/src/ui/components/calendar.js
+++ b/src/ui/components/calendar.js
@@ -1,7 +1,7 @@
 /**
  * Calendar — Progressive Enhancement
  *
- * Enhances a static `.calendar` element with:
+ * Enhances a static `.uif-calendar` element with:
  * - Month navigation (prev/next buttons rebuild the grid)
  * - Keyboard navigation (arrow keys, Home/End, PageUp/PageDown)
  * - Date selection (click/Enter updates aria-selected)
@@ -9,12 +9,17 @@
  *
  * Usage:
  *   import { Calendar } from './components/calendar.js';
- *   document.querySelectorAll('.calendar').forEach(el => new Calendar(el));
+ *   document.querySelectorAll('.uif-calendar').forEach(el => new Calendar(el));
  */
+
+const CALENDAR_ROOT_SELECTOR = ":is(.uif-calendar, .calendar)";
+const CALENDAR_TITLE_SELECTOR = ":is(.uif-calendar-title, .calendar-title)";
+const CALENDAR_TABLE_SELECTOR = ":is(.uif-calendar-table, .calendar-table)";
+const CALENDAR_CELL_SELECTOR = "button:is(.uif-calendar-cell, .calendar-cell)";
 
 export class Calendar {
   /**
-   * @param {HTMLElement} root - The .calendar element to enhance
+   * @param {HTMLElement} root - The .uif-calendar element to enhance
    * @param {object} [options]
    * @param {string} [options.locale] - Intl locale (default: "en-GB")
    * @param {Date} [options.min] - Earliest selectable date
@@ -36,8 +41,8 @@ export class Calendar {
     this.selectedDate = null;
 
     // Cache DOM references
-    this.titleEl = root.querySelector(".calendar-title");
-    this.tableBody = root.querySelector(".calendar-table tbody");
+    this.titleEl = root.querySelector(CALENDAR_TITLE_SELECTOR);
+    this.tableBody = root.querySelector(`${CALENDAR_TABLE_SELECTOR} tbody`);
     this.prevBtn = root.querySelector("[aria-label='Previous month']");
     this.nextBtn = root.querySelector("[aria-label='Next month']");
 
@@ -66,7 +71,7 @@ export class Calendar {
   // ─── Selection ──────────────────────────────────────────────────
 
   _handleCellClick(e) {
-    const btn = e.target.closest("button.calendar-cell");
+    const btn = e.target.closest(CALENDAR_CELL_SELECTOR);
     if (!btn || btn.disabled) return;
 
     const date = this._dateFromCell(btn);
@@ -90,10 +95,10 @@ export class Calendar {
   // ─── Keyboard ───────────────────────────────────────────────────
 
   _handleKeyDown(e) {
-    const btn = e.target.closest("button.calendar-cell");
+    const btn = e.target.closest(CALENDAR_CELL_SELECTOR);
     if (!btn) return;
 
-    const cells = [...this.tableBody.querySelectorAll("button.calendar-cell")];
+    const cells = [...this.tableBody.querySelectorAll(CALENDAR_CELL_SELECTOR)];
     const index = cells.indexOf(btn);
     if (index === -1) return;
 
@@ -201,7 +206,7 @@ export class Calendar {
       html += "<tr>";
       for (let j = i; j < i + 7 && j < cells.length; j++) {
         const cell = cells[j];
-        const classes = ["calendar-cell"];
+        const classes = ["uif-calendar-cell"];
         const isSelected = this._isSameDay(cell.date, this.selectedDate);
         const isToday = this._isSameDay(cell.date, this.today);
         const isDisabled = this._isDisabled(cell.date);
@@ -232,7 +237,7 @@ export class Calendar {
   // ─── Helpers ────────────────────────────────────────────────────
 
   _parseInitialMonth() {
-    const titleEl = this.root.querySelector(".calendar-title");
+    const titleEl = this.root.querySelector(CALENDAR_TITLE_SELECTOR);
     if (titleEl) {
       const parsed = new Date(titleEl.textContent);
       if (!isNaN(parsed.getTime())) return parsed;
@@ -258,11 +263,11 @@ export class Calendar {
   }
 }
 
-// Auto-init: enhance all .calendar elements on DOMContentLoaded
+// Auto-init: enhance all .uif-calendar elements on DOMContentLoaded
 if (typeof document !== "undefined") {
   document.addEventListener("DOMContentLoaded", () => {
     document
-      .querySelectorAll(".calendar:not([data-enhanced])")
+      .querySelectorAll(`${CALENDAR_ROOT_SELECTOR}:not([data-enhanced])`)
       .forEach((el) => {
         el.setAttribute("data-enhanced", "");
         new Calendar(el);

--- a/src/ui/components/date-input.js
+++ b/src/ui/components/date-input.js
@@ -18,7 +18,7 @@
  *       input.date-segment.year [maxlength=4, inputmode=numeric]
  *     .input-field-control
  *       button (calendar trigger)
- *     .calendar (dropdown)
+ *     .uif-calendar (dropdown)
  */
 
 import { Calendar } from "./calendar.js";
@@ -37,7 +37,7 @@ export class DateInput {
 
     // Calendar
     this.trigger = root.querySelector("[aria-label='Open calendar']");
-    this.calendarEl = root.querySelector(".calendar");
+    this.calendarEl = root.querySelector(":is(.uif-calendar, .calendar)");
     this.isOpen = false;
 
     if (this.calendarEl) {

--- a/src/ui/patterns/calendar.css
+++ b/src/ui/patterns/calendar.css
@@ -1,46 +1,52 @@
 @layer components {
   /* ─── Calendar ─────────────────────────────────────────────────── */
 
-  .calendar {
+  /*
+   * Unprefixed Calendar classes are deprecated v1.x compatibility selectors.
+   * UIF-owned emitters use canonical `.uif-calendar*` names; remove aliases no
+   * earlier than v2.0.
+   */
+
+  :is(.uif-calendar, .calendar) {
     display: flex;
     flex-direction: column;
-    gap: var(--calendar-container-gap);
+    gap: var(--uif-calendar-container-gap);
     inline-size: fit-content;
   }
 
   /* Container variant: bordered card */
-  .calendar.has-container {
-    padding: var(--calendar-container-padding);
-    background: var(--calendar-container-background);
-    border: var(--calendar-container-border-size) solid var(--calendar-container-border-color);
-    border-radius: var(--calendar-container-border-radius);
+  :is(.uif-calendar, .calendar).has-container {
+    padding: var(--uif-calendar-container-padding);
+    background: var(--uif-calendar-container-background);
+    border: var(--uif-calendar-container-border-size) solid var(--uif-calendar-container-border-color);
+    border-radius: var(--uif-calendar-container-border-radius);
   }
 
   /* ─── Header ─────────────────────────────────────────────────── */
 
-  .calendar-header {
+  :is(.uif-calendar-header, .calendar-header) {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: var(--calendar-header-gap);
+    gap: var(--uif-calendar-header-gap);
     min-inline-size: 0;
   }
 
-  .calendar-selectors {
+  :is(.uif-calendar-selectors, .calendar-selectors) {
     display: flex;
     align-items: center;
-    gap: var(--calendar-header-gap);
+    gap: var(--uif-calendar-header-gap);
     flex: 0 1 auto;
     min-inline-size: 0;
   }
 
-  .calendar-nav {
+  :is(.uif-calendar-nav, .calendar-nav) {
     display: flex;
-    gap: var(--calendar-header-gap);
+    gap: var(--uif-calendar-header-gap);
   }
 
   /* Header selects: reuse Select pattern with calendar-specific overrides (no border, transparent) */
-  .calendar-header .select.calendar-header-select {
+  :is(.uif-calendar-header, .calendar-header) .select:is(.uif-calendar-header-select, .calendar-header-select) {
     flex: 0 0 auto;
     inline-size: auto;
     border-color: transparent;
@@ -49,52 +55,52 @@
     padding-block: 0;
   }
 
-  .calendar-header .select.calendar-header-select[name="month"] {
+  :is(.uif-calendar-header, .calendar-header) .select:is(.uif-calendar-header-select, .calendar-header-select)[name="month"] {
     min-inline-size: 12ch;
   }
 
-  .calendar-header .select.calendar-header-select[name="year"] {
+  :is(.uif-calendar-header, .calendar-header) .select:is(.uif-calendar-header-select, .calendar-header-select)[name="year"] {
     min-inline-size: 7ch;
   }
 
-  .calendar-header .select.calendar-header-select:hover {
-    background: var(--calendar-cell-background-hover);
+  :is(.uif-calendar-header, .calendar-header) .select:is(.uif-calendar-header-select, .calendar-header-select):hover {
+    background: var(--uif-calendar-cell-background-hover);
   }
 
   /* ─── Weekday Header ─────────────────────────────────────────── */
 
-  .calendar-table {
+  :is(.uif-calendar-table, .calendar-table) {
     border-collapse: separate;
     border-spacing: 0;
     inline-size: 100%;
   }
 
-  .calendar-table th {
-    block-size: var(--calendar-weekday-height);
-    font-size: var(--calendar-weekday-font-size);
+  :is(.uif-calendar-table, .calendar-table) th {
+    block-size: var(--uif-calendar-weekday-height);
+    font-size: var(--uif-calendar-weekday-font-size);
     font-weight: normal;
-    color: var(--calendar-weekday-text-color);
+    color: var(--uif-calendar-weekday-text-color);
     text-align: center;
     vertical-align: middle;
   }
 
   /* ─── Day Cells ──────────────────────────────────────────────── */
 
-  .calendar-table td {
-    padding: var(--calendar-cell-gap);
+  :is(.uif-calendar-table, .calendar-table) td {
+    padding: var(--uif-calendar-cell-gap);
     text-align: center;
   }
 
-  .calendar-cell {
+  :is(.uif-calendar-cell, .calendar-cell) {
     display: flex;
     align-items: center;
     justify-content: center;
-    min-inline-size: var(--calendar-cell-min-size);
-    min-block-size: var(--calendar-cell-min-size);
-    border-radius: var(--calendar-cell-border-radius);
-    border: var(--calendar-cell-range-border-size) solid transparent;
+    min-inline-size: var(--uif-calendar-cell-min-size);
+    min-block-size: var(--uif-calendar-cell-min-size);
+    border-radius: var(--uif-calendar-cell-border-radius);
+    border: var(--uif-calendar-cell-range-border-size) solid transparent;
     background: transparent;
-    color: var(--calendar-cell-text-color-default);
+    color: var(--uif-calendar-cell-text-color-default);
     font-family: var(--typography-label-font-family);
     font-size: var(--typography-label-font-size);
     font-weight: var(--typography-label-font-weight);
@@ -104,101 +110,101 @@
   }
 
   /* Hover */
-  .calendar-cell:hover,
-  .calendar-cell.is-hover {
-    background: var(--calendar-cell-background-hover);
+  :is(.uif-calendar-cell, .calendar-cell):hover,
+  :is(.uif-calendar-cell, .calendar-cell).is-hover {
+    background: var(--uif-calendar-cell-background-hover);
   }
 
   /* Focus */
-  .calendar-cell:focus-visible,
-  .calendar-cell.is-focus-visible {
+  :is(.uif-calendar-cell, .calendar-cell):focus-visible,
+  :is(.uif-calendar-cell, .calendar-cell).is-focus-visible {
     outline: none;
     box-shadow: 0 0 0 var(--shadow-focus, 0) var(--color-focus, transparent);
   }
 
   /* Selected (single day) */
-  .calendar-cell[aria-selected="true"],
-  .calendar-cell.is-selected {
-    background: var(--calendar-cell-background-active);
-    color: var(--calendar-cell-text-color-active);
+  :is(.uif-calendar-cell, .calendar-cell)[aria-selected="true"],
+  :is(.uif-calendar-cell, .calendar-cell).is-selected {
+    background: var(--uif-calendar-cell-background-active);
+    color: var(--uif-calendar-cell-text-color-active);
   }
 
   /* Today marker */
-  .calendar-cell.is-today {
-    border-color: var(--calendar-cell-range-border-color);
+  :is(.uif-calendar-cell, .calendar-cell).is-today {
+    border-color: var(--uif-calendar-cell-range-border-color);
   }
 
   /* Disabled / outside month */
-  .calendar-cell:disabled,
-  .calendar-cell.is-disabled,
-  .calendar-cell.is-outside-month {
-    color: var(--calendar-cell-text-color-disabled);
+  :is(.uif-calendar-cell, .calendar-cell):disabled,
+  :is(.uif-calendar-cell, .calendar-cell).is-disabled,
+  :is(.uif-calendar-cell, .calendar-cell).is-outside-month {
+    color: var(--uif-calendar-cell-text-color-disabled);
     cursor: default;
   }
 
-  .calendar-cell:disabled:hover,
-  .calendar-cell.is-disabled:hover {
+  :is(.uif-calendar-cell, .calendar-cell):disabled:hover,
+  :is(.uif-calendar-cell, .calendar-cell).is-disabled:hover {
     background: transparent;
   }
 
   /* ─── Range Selection ────────────────────────────────────────── */
 
   /* Range start */
-  .calendar-cell.is-range-start {
-    background: var(--calendar-cell-background-active);
-    color: var(--calendar-cell-text-color-active);
-    border-color: var(--calendar-cell-range-border-color);
-    border-start-start-radius: var(--calendar-cell-range-border-radius);
-    border-end-start-radius: var(--calendar-cell-range-border-radius);
+  :is(.uif-calendar-cell, .calendar-cell).is-range-start {
+    background: var(--uif-calendar-cell-background-active);
+    color: var(--uif-calendar-cell-text-color-active);
+    border-color: var(--uif-calendar-cell-range-border-color);
+    border-start-start-radius: var(--uif-calendar-cell-range-border-radius);
+    border-end-start-radius: var(--uif-calendar-cell-range-border-radius);
     border-start-end-radius: 0;
     border-end-end-radius: 0;
   }
 
   /* Range middle */
-  .calendar-cell.is-range-middle {
+  :is(.uif-calendar-cell, .calendar-cell).is-range-middle {
     background: transparent;
-    color: var(--calendar-cell-text-color-default);
-    border-color: var(--calendar-cell-range-border-color);
+    color: var(--uif-calendar-cell-text-color-default);
+    border-color: var(--uif-calendar-cell-range-border-color);
     border-radius: 0;
     border-inline-start: none;
     border-inline-end: none;
   }
 
   /* Range end */
-  .calendar-cell.is-range-end {
-    background: var(--calendar-cell-background-active);
-    color: var(--calendar-cell-text-color-active);
-    border-color: var(--calendar-cell-range-border-color);
+  :is(.uif-calendar-cell, .calendar-cell).is-range-end {
+    background: var(--uif-calendar-cell-background-active);
+    color: var(--uif-calendar-cell-text-color-active);
+    border-color: var(--uif-calendar-cell-range-border-color);
     border-start-start-radius: 0;
     border-end-start-radius: 0;
-    border-start-end-radius: var(--calendar-cell-range-border-radius);
-    border-end-end-radius: var(--calendar-cell-range-border-radius);
+    border-start-end-radius: var(--uif-calendar-cell-range-border-radius);
+    border-end-end-radius: var(--uif-calendar-cell-range-border-radius);
   }
 
   /* ─── Range View (two-column) ────────────────────────────────── */
 
-  .calendar.range-view {
+  :is(.uif-calendar, .calendar).range-view {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: var(--calendar-container-gap);
+    gap: var(--uif-calendar-container-gap);
   }
 
-  .calendar.range-view .calendar-header {
+  :is(.uif-calendar, .calendar).range-view :is(.uif-calendar-header, .calendar-header) {
     grid-column: 1 / -1;
   }
 
-  .calendar-month-panel {
+  :is(.uif-calendar-month-panel, .calendar-month-panel) {
     display: flex;
     flex-direction: column;
-    gap: var(--calendar-container-gap);
+    gap: var(--uif-calendar-container-gap);
   }
 
-  .calendar-month-label {
+  :is(.uif-calendar-month-label, .calendar-month-label) {
     font-family: var(--typography-label-font-family);
     font-size: var(--typography-label-font-size);
     font-weight: var(--typography-label-font-weight);
     line-height: var(--typography-label-line-height);
-    color: var(--calendar-cell-text-color-default);
+    color: var(--uif-calendar-cell-text-color-default);
     text-align: center;
   }
 }

--- a/src/ui/patterns/date-input.css
+++ b/src/ui/patterns/date-input.css
@@ -1,7 +1,7 @@
 @layer components {
   /* ─── Date Input ───────────────────────────────────────────────── */
   /* Variant of .input-field with segmented DD/MM/YYYY fields         */
-  /* Composes: .input-field + .calendar                               */
+  /* Composes: .input-field + Calendar                              */
 
   .input-field.date {
     position: relative;
@@ -52,7 +52,7 @@
   }
 
   /* Calendar dropdown positioning */
-  .input-field.date .calendar {
+  .input-field.date :is(.uif-calendar, .calendar) {
     display: none;
     position: absolute;
     inset-block-start: 100%;
@@ -67,7 +67,7 @@
   }
 
   /* Open state */
-  .input-field.date.is-open .calendar {
+  .input-field.date.is-open :is(.uif-calendar, .calendar) {
     display: grid;
   }
 }

--- a/tests/calendar-naming-migration.test.mjs
+++ b/tests/calendar-naming-migration.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("Calendar CSS exposes canonical UIF naming with v1 class aliases", async () => {
+  const css = await read("src/ui/patterns/calendar.css");
+
+  for (const className of [
+    "calendar",
+    "calendar-header",
+    "calendar-selectors",
+    "calendar-nav",
+    "calendar-header-select",
+    "calendar-table",
+    "calendar-cell",
+    "calendar-month-panel",
+    "calendar-month-label",
+  ]) {
+    assert.match(css, new RegExp(`:is\\(\\.uif-${className}, \\.${className}\\)`));
+  }
+
+  assert.match(css, /var\(--uif-calendar-/);
+  assert.doesNotMatch(css, /var\(--calendar-/);
+  assert.doesNotMatch(css, /\.uif-calendar(?:__|--)/);
+});
+
+test("Calendar Figma export contains all canonical tokens without legacy aliases", async () => {
+  const tokenExport = await read("figma/exports/Patterns (UI).tokens.json");
+  const canonical = tokenExport.match(/var\(--uif-calendar-/g) ?? [];
+
+  assert.equal(canonical.length, 21);
+  assert.doesNotMatch(tokenExport, /var\(--calendar-/);
+});
+
+test("Calendar-owned emitters produce canonical classes and shared dependencies", async () => {
+  const [macro, renderer] = await Promise.all([
+    read("site/_includes/macros/calendar.njk"),
+    read("site/assets/playground/renderers.js"),
+  ]);
+
+  for (const source of [macro, renderer]) {
+    assert.match(source, /uif-calendar/);
+    assert.match(source, /uif-button/);
+    assert.match(source, /uif-icon/);
+    assert.doesNotMatch(source, /class="calendar(?:[\s-"])/);
+    assert.doesNotMatch(source, /class="button ghost"/);
+  }
+
+  assert.match(macro, /set cellClasses = "uif-calendar-cell"/);
+  assert.match(renderer, /const classes = \["uif-calendar-cell"\]/);
+});
+
+test("Calendar behavior accepts legacy markup but renders canonical cells", async () => {
+  const [calendar, dateInput, dateInputCss] = await Promise.all([
+    read("src/ui/components/calendar.js"),
+    read("src/ui/components/date-input.js"),
+    read("src/ui/patterns/date-input.css"),
+  ]);
+
+  assert.match(calendar, /:is\(\.uif-calendar, \.calendar\)/);
+  assert.match(calendar, /button:is\(\.uif-calendar-cell, \.calendar-cell\)/);
+  assert.match(calendar, /const classes = \["uif-calendar-cell"\]/);
+  assert.match(dateInput, /querySelector\(":is\(\.uif-calendar, \.calendar\)"\)/);
+  assert.match(dateInputCss, /:is\(\.uif-calendar, \.calendar\)/);
+});
+
+test("Calendar no longer relies on pending-export token exceptions", async () => {
+  const [validator, documentation] = await Promise.all([
+    read("scripts/validate-token-usage.mjs"),
+    read("site/patterns/calendar.md"),
+  ]);
+
+  assert.doesNotMatch(validator, /calendar-cell-background-selected/);
+  assert.doesNotMatch(validator, /calendar-cell-text-color-selected/);
+  assert.match(documentation, /legacy `--calendar-\*` token\s+aliases are not provided/);
+});


### PR DESCRIPTION
## Summary

- migrate Calendar-owned public classes to canonical `.uif-calendar*` names
- migrate all 21 Calendar token slots to canonical `--uif-calendar-*` names, with their Figma `codeSyntax.WEB` values updated directly and the repository export synchronized
- retain unprefixed Calendar classes as CSS/behavior compatibility selectors through v1.x, without library-owned legacy token aliases
- update Calendar emitters, shared Button/Icon dependencies, behavior selectors, documentation, examples, and generated package output
- add explicit consumer migration guidance; Wave 4 alias removal remains v2.0-or-later work

## Validation

- `npm run lint`
- `npm run test:unit` (105 passing)
- `npm run ci:check`
- regenerated and inspected `dist/`; no generated files were edited directly

Closes #165