### PR TITLE
Migration: Adopt UIF-prefixed naming for Link

### DIFF
--- a/docs/foundations/foundation-012-minimal-markup-and-composition.md
+++ b/docs/foundations/foundation-012-minimal-markup-and-composition.md
@@ -13,7 +13,7 @@ Keep component markup as flat and simple as possible. Complexity in HTML structu
 ## Rules
 
 1. Start with the flattest possible markup.
-   - A link with an icon is `<a class="link"><span class="uif-icon">...</span> Text</a>`, not three nested wrappers.
+   - A link with an icon is `<a class="uif-link"><span class="uif-icon">...</span> Text</a>`, not three nested wrappers.
    - Add structure only when layout or behavior requires it.
 
 2. Use CSS on the component root for layout.

--- a/docs/foundations/foundation-013-class-naming.md
+++ b/docs/foundations/foundation-013-class-naming.md
@@ -69,7 +69,7 @@ namespace prefixes.
 
 ### Migration Note
 
-Some runtime artifacts still use bare classes such as `.input` and `.link`.
+Some runtime artifacts still use bare classes such as `.input` and `.select`.
 Button emitters now use `.uif-button`; `.button` remains a
 deprecated CSS-only compatibility selector through v1.x. Runtime validation
 should warn with migration guidance rather than fail existing artifacts without

--- a/figma/exports/Patterns (UI).tokens.json
+++ b/figma/exports/Patterns (UI).tokens.json
@@ -4623,7 +4623,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--link-text-color-default)"
+            "WEB": "var(--uif-link-text-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:340",
@@ -4645,7 +4645,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--link-text-color-hover)"
+            "WEB": "var(--uif-link-text-color-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:355",
@@ -4667,7 +4667,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--link-text-color-active)"
+            "WEB": "var(--uif-link-text-color-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:355",
@@ -4689,7 +4689,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--link-text-color-visited)"
+            "WEB": "var(--uif-link-text-color-visited)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:341",
@@ -4711,7 +4711,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--link-text-color-disabled)"
+            "WEB": "var(--uif-link-text-color-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:328",
@@ -4731,7 +4731,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--link-text-decoration-default)"
+            "WEB": "var(--uif-link-text-decoration-default)"
           }
         }
       },
@@ -4744,7 +4744,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--link-text-decoration-hover)"
+            "WEB": "var(--uif-link-text-decoration-hover)"
           }
         }
       }
@@ -4760,7 +4760,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--link-font-family)"
+          "WEB": "var(--uif-link-font-family)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:2006:213",
@@ -4782,7 +4782,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--link-font-weight)"
+          "WEB": "var(--uif-link-font-weight)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3014:12",
@@ -4804,7 +4804,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--link-gap)"
+          "WEB": "var(--uif-link-gap)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:2",
@@ -4824,7 +4824,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--link-font-size)"
+          "WEB": "var(--uif-link-font-size)"
         }
       }
     },
@@ -4837,7 +4837,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--link-line-height)"
+          "WEB": "var(--uif-link-line-height)"
         }
       }
     }

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -135,7 +135,7 @@
 {%- endmacro %}
 
 {% macro link(text, href='#', startIcon='', endIcon='', state='', disabled=false) -%}
-{%- set classes = "link" -%}
+{%- set classes = "uif-link" -%}
 {%- if state -%}{%- set classes = classes + " is-" + state -%}{%- endif -%}
 {%- if disabled -%}{%- set classes = classes + " is-disabled" -%}{%- endif -%}
 <a class="{{ classes }}" href="{{ href }}"{% if disabled %} aria-disabled="true"{% endif %}>

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -986,7 +986,7 @@
       previewState === "disabled" || asBoolean(props.disabled);
 
     const element = document.createElement("a");
-    const classes = ["link"];
+    const classes = ["uif-link"];
 
     if (previewState === "hover") classes.push("is-hover");
     if (previewState === "active") classes.push("is-active");

--- a/site/foundations/class-naming.md
+++ b/site/foundations/class-naming.md
@@ -63,7 +63,7 @@ The examples below illustrate the consumed contract. They are not source rules.
 
 ## Migration
 
-Some runtime artifacts still use bare classes such as `.input` and `.link`.
+Some runtime artifacts still use bare classes such as `.input` and `.select`.
 Button emitters now use `.uif-button`; `.button` remains a
 deprecated CSS-only compatibility selector through v1.x. Runtime validation
 warns with migration guidance while the migration is in progress.

--- a/site/getting-started.md
+++ b/site/getting-started.md
@@ -67,7 +67,7 @@ generation, and framework-agnostic Custom Elements.
 ```html
 <button class="uif-button solid" type="button">Label</button>
 <input class="input" type="text" placeholder="Email" />
-<a href="/page" class="link">Go to page</a>
+<a href="/page" class="uif-link">Go to page</a>
 ```
 
 ### Nunjucks Macros

--- a/site/patterns/index.md
+++ b/site/patterns/index.md
@@ -108,7 +108,7 @@ permalink: /patterns/
   </a>
   <a class="docs-component-card" href="/patterns/link/">
     <div class="docs-component-card-preview">
-      <span class="link">Learn more</span>
+      <span class="uif-link">Learn more</span>
     </div>
     <div class="docs-component-card-body">
       <h2>Link</h2>

--- a/site/patterns/link.md
+++ b/site/patterns/link.md
@@ -30,7 +30,7 @@ breadcrumb:
       </span>
     </div>
     <div class="docs-hero-preview-stage">
-      <a class="link" href="#">Learn more</a>
+      <a class="uif-link" href="#">Learn more</a>
     </div>
   </div>
   <div class="docs-hero-meta">
@@ -40,6 +40,13 @@ breadcrumb:
     {% endif %}
   </div>
 </div>
+
+### v1 naming migration
+
+Use `.uif-link` and `--uif-link-*` tokens in new and migrated markup. The
+unprefixed `.link` selector remains compatible throughout v1.x, but legacy
+`--link-*` token aliases are not provided. Consumers must migrate classes and
+tokens together. Legacy selector removal remains Wave 4 work for v2.0 or later.
 
 <h2 id="anatomy">Anatomy</h2>
 
@@ -59,7 +66,7 @@ breadcrumb:
         <span class="docs-anatomy-badge">3</span>
         <span class="docs-anatomy-callout-line"></span>
       </span>
-      <a class="link" href="#"><span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/target-blank.svg');" aria-hidden="true"></span>External link<span class="uif-icon" data-slot="end" style="--uif-icon-src: url('/assets/icons/target-blank.svg');" aria-hidden="true"></span></a>
+      <a class="uif-link" href="#"><span class="uif-icon" data-slot="start" style="--uif-icon-src: url('/assets/icons/target-blank.svg');" aria-hidden="true"></span>External link<span class="uif-icon" data-slot="end" style="--uif-icon-src: url('/assets/icons/target-blank.svg');" aria-hidden="true"></span></a>
     </div>
   </div>
   <ol class="docs-anatomy-footnotes">
@@ -75,23 +82,23 @@ breadcrumb:
 
 <div class="docs-states-grid" style="--docs-states-cols: 5">
   <div class="docs-states-grid-item">
-    <div class="docs-states-grid-item-preview"><a class="link" href="#">Default</a></div>
+    <div class="docs-states-grid-item-preview"><a class="uif-link" href="#">Default</a></div>
     <span class="docs-states-grid-item-label">Default</span>
   </div>
   <div class="docs-states-grid-item">
-    <div class="docs-states-grid-item-preview"><a class="link is-hover" href="#">Hover</a></div>
+    <div class="docs-states-grid-item-preview"><a class="uif-link is-hover" href="#">Hover</a></div>
     <span class="docs-states-grid-item-label">Hover</span>
   </div>
   <div class="docs-states-grid-item">
-    <div class="docs-states-grid-item-preview"><a class="link is-active" href="#">Active</a></div>
+    <div class="docs-states-grid-item-preview"><a class="uif-link is-active" href="#">Active</a></div>
     <span class="docs-states-grid-item-label">Active</span>
   </div>
   <div class="docs-states-grid-item">
-    <div class="docs-states-grid-item-preview"><a class="link is-visited" href="#">Visited</a></div>
+    <div class="docs-states-grid-item-preview"><a class="uif-link is-visited" href="#">Visited</a></div>
     <span class="docs-states-grid-item-label">Visited</span>
   </div>
   <div class="docs-states-grid-item">
-    <div class="docs-states-grid-item-preview"><a class="link is-disabled" aria-disabled="true" tabindex="-1">Disabled</a></div>
+    <div class="docs-states-grid-item-preview"><a class="uif-link is-disabled" aria-disabled="true" tabindex="-1">Disabled</a></div>
     <span class="docs-states-grid-item-label">Disabled</span>
   </div>
 </div>
@@ -115,7 +122,7 @@ breadcrumb:
 <div class="docs-behavior-list">
   <div class="docs-behavior-item">
     <div class="docs-behavior-preview">
-      <a class="link" href="#">Inline link</a> within body text.
+      <a class="uif-link" href="#">Inline link</a> within body text.
     </div>
     <div class="docs-behavior-body">
       <h3>Inline usage</h3>
@@ -124,7 +131,7 @@ breadcrumb:
   </div>
   <div class="docs-behavior-item">
     <div class="docs-behavior-preview">
-      <a class="link is-disabled" aria-disabled="true" tabindex="-1">Disabled link</a>
+      <a class="uif-link is-disabled" aria-disabled="true" tabindex="-1">Disabled link</a>
     </div>
     <div class="docs-behavior-body">
       <h3>Disabled state</h3>
@@ -140,7 +147,7 @@ breadcrumb:
 <div class="docs-guideline">
   <div class="docs-guideline-item" data-type="do">
     <div class="docs-guideline-preview">
-      <a class="link" href="/settings">Account settings</a>
+      <a class="uif-link" href="/settings">Account settings</a>
     </div>
     <div class="docs-guideline-body">
       <p class="docs-guideline-label">Do</p>
@@ -149,7 +156,7 @@ breadcrumb:
   </div>
   <div class="docs-guideline-item" data-type="dont">
     <div class="docs-guideline-preview">
-      <a class="link" href="#">Submit form</a>
+      <a class="uif-link" href="#">Submit form</a>
     </div>
     <div class="docs-guideline-body">
       <p class="docs-guideline-label">Don't</p>
@@ -163,7 +170,7 @@ breadcrumb:
 <div class="docs-guideline">
   <div class="docs-guideline-item" data-type="do">
     <div class="docs-guideline-preview">
-      <a class="link" href="#">View booking details</a>
+      <a class="uif-link" href="#">View booking details</a>
     </div>
     <div class="docs-guideline-body">
       <p class="docs-guideline-label">Do</p>
@@ -172,7 +179,7 @@ breadcrumb:
   </div>
   <div class="docs-guideline-item" data-type="dont">
     <div class="docs-guideline-preview">
-      <a class="link" href="#">Click here</a>
+      <a class="uif-link" href="#">Click here</a>
     </div>
     <div class="docs-guideline-body">
       <p class="docs-guideline-label">Don't</p>

--- a/src/elements/ui-link.js
+++ b/src/elements/ui-link.js
@@ -21,7 +21,7 @@ class UILink extends UIElement {
     const disabled = this.getBool("disabled");
     const text = this.textContent.trim();
 
-    const classes = ["link"];
+    const classes = ["uif-link"];
     if (disabled) classes.push("is-disabled");
 
     const attrs = [`class="${classes.join(" ")}"`];

--- a/src/ui/patterns/link.css
+++ b/src/ui/patterns/link.css
@@ -1,14 +1,18 @@
 @layer components {
-  .link {
+  /*
+   * `.link` is a deprecated v1.x compatibility selector. UIF-owned emitters
+   * use `.uif-link`; remove the alias no earlier than v2.0.
+   */
+  :is(.uif-link, .link) {
     display: inline-flex;
     align-items: center;
-    gap: var(--link-gap, 0.25rem);
-    font-family: var(--link-font-family, inherit);
-    font-weight: var(--link-font-weight, inherit);
-    font-size: var(--link-font-size, inherit);
-    line-height: var(--link-line-height, inherit);
-    color: var(--link-text-color-default);
-    text-decoration: var(--link-text-decoration-default, underline);
+    gap: var(--uif-link-gap, 0.25rem);
+    font-family: var(--uif-link-font-family, inherit);
+    font-weight: var(--uif-link-font-weight, inherit);
+    font-size: var(--uif-link-font-size, inherit);
+    line-height: var(--uif-link-line-height, inherit);
+    color: var(--uif-link-text-color-default);
+    text-decoration: var(--uif-link-text-decoration-default, underline);
     cursor: pointer;
     border: none;
     background: none;
@@ -18,45 +22,45 @@
 
   /* ── States ── */
 
-  .link:hover,
-  .link.is-hover {
-    color: var(--link-text-color-hover);
-    text-decoration: var(--link-text-decoration-hover, underline);
+  :is(.uif-link, .link):hover,
+  :is(.uif-link, .link).is-hover {
+    color: var(--uif-link-text-color-hover);
+    text-decoration: var(--uif-link-text-decoration-hover, underline);
   }
 
-  .link:active,
-  .link.is-active {
-    color: var(--link-text-color-active);
+  :is(.uif-link, .link):active,
+  :is(.uif-link, .link).is-active {
+    color: var(--uif-link-text-color-active);
   }
 
-  .link:visited,
-  .link.is-visited {
-    color: var(--link-text-color-visited);
+  :is(.uif-link, .link):visited,
+  :is(.uif-link, .link).is-visited {
+    color: var(--uif-link-text-color-visited);
   }
 
-  .link:focus-visible,
-  .link.is-focus-visible {
-    color: var(--link-text-color-hover);
+  :is(.uif-link, .link):focus-visible,
+  :is(.uif-link, .link).is-focus-visible {
+    color: var(--uif-link-text-color-hover);
     outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
     border-radius: var(--size-radius-100);
   }
 
-  .link[aria-disabled="true"],
-  .link.is-disabled {
-    color: var(--link-text-color-disabled);
+  :is(.uif-link, .link)[aria-disabled="true"],
+  :is(.uif-link, .link).is-disabled {
+    color: var(--uif-link-text-color-disabled);
     cursor: not-allowed;
     text-decoration: line-through;
   }
 
-  .link[aria-disabled="true"]:hover,
-  .link.is-disabled:hover {
-    color: var(--link-text-color-disabled);
+  :is(.uif-link, .link)[aria-disabled="true"]:hover,
+  :is(.uif-link, .link).is-disabled:hover {
+    color: var(--uif-link-text-color-disabled);
   }
 
   /* ── Icon slot ── */
 
-  .link > :is(.uif-icon, .icon) {
+  :is(.uif-link, .link) > :is(.uif-icon, .icon) {
     flex: 0 0 auto;
   }
 }

--- a/tests/link-naming-migration.test.mjs
+++ b/tests/link-naming-migration.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("Link CSS exposes canonical UIF naming with the v1 class alias", async () => {
+  const css = await read("src/ui/patterns/link.css");
+
+  assert.match(css, /:is\(\.uif-link, \.link\)/);
+  assert.match(css, /var\(--uif-link-/);
+  assert.doesNotMatch(css, /var\(--link-/);
+  assert.doesNotMatch(css, /\.uif-link(?:__|--)/);
+});
+
+test("Link Figma export contains all canonical tokens without legacy aliases", async () => {
+  const tokenExport = await read("figma/exports/Patterns (UI).tokens.json");
+  const canonical = tokenExport.match(/var\(--uif-link-/g) ?? [];
+
+  assert.equal(canonical.length, 12);
+  assert.doesNotMatch(tokenExport, /var\(--link-/);
+});
+
+test("Link-owned emitters produce the canonical class and shared Icon class", async () => {
+  const sources = await Promise.all([
+    read("src/elements/ui-link.js"),
+    read("site/_includes/macros/ui.njk"),
+    read("site/assets/playground/renderers.js"),
+  ]);
+
+  for (const source of sources) {
+    assert.match(source, /uif-link/);
+    assert.match(source, /uif-icon/);
+  }
+
+  assert.match(sources[0], /const classes = \["uif-link"\]/);
+  assert.match(sources[1], /set classes = "uif-link"/);
+  assert.match(sources[2], /const classes = \["uif-link"\]/);
+});
+
+test("Link retains Icon and legacy class compatibility without token aliases", async () => {
+  const css = await read("src/ui/patterns/link.css");
+
+  assert.match(css, /:is\(\.uif-link, \.link\) > :is\(\.uif-icon, \.icon\)/);
+  assert.doesNotMatch(css, /--link-[\w-]+\s*:/);
+});
+
+test("Link documentation explains the v1 boundary while element registration stays stable", async () => {
+  const [documentation, element] = await Promise.all([
+    read("site/patterns/link.md"),
+    read("src/elements/ui-link.js"),
+  ]);
+
+  assert.match(documentation, /legacy\s+`--link-\*` token aliases are not provided/);
+  assert.match(documentation, /class="uif-link/);
+  assert.doesNotMatch(documentation, /class="link(?:[\s"])/);
+  assert.match(element, /define\("ui-link", UILink\)/);
+});


### PR DESCRIPTION
## Summary

- migrate Link-owned output to canonical `.uif-link` while retaining `.link` as a v1.x compatibility selector
- update all 12 Link variables directly in Figma to canonical `--uif-link-*` `codeSyntax.WEB` values and synchronize the export
- preserve Link states, specificity, disabled semantics, shared canonical Icon output, package exports, and the existing Custom Element registration boundary
- update macros, playground output, docs, examples, migration guidance, tests, and generated package output
- add no library-owned legacy token aliases; Wave 4 selector removal remains v2.0-or-later work

## Validation

- `npm run lint`
- `npm run test:unit` (110 passing)
- `npm run ci:check`
- regenerated and inspected `dist/`; generated files were not edited directly

Closes #167