### PR TITLE
Migration: Adopt UIF-prefixed naming for Input

### DIFF
--- a/docs/adr/adr-density-responsive-strategy.md
+++ b/docs/adr/adr-density-responsive-strategy.md
@@ -44,7 +44,7 @@ Density (maps semantic roles to different Core steps per density)
   ↑
 Semantics (Size/Spacing Tight, Size/Spacing Component, etc.)
   ↑
-Components (`--uif-button-padding-inline`, `--input-gap`, etc.)
+Components (`--uif-button-padding-inline`, `--uif-input-gap`, etc.)
 ```
 
 ### Implementation in Figma

--- a/docs/foundations/foundation-013-class-naming.md
+++ b/docs/foundations/foundation-013-class-naming.md
@@ -69,7 +69,7 @@ namespace prefixes.
 
 ### Migration Note
 
-Some runtime artifacts still use bare classes such as `.input` and `.select`.
+Some runtime artifacts still use bare classes such as `.select` and `.checkbox`.
 Button emitters now use `.uif-button`; `.button` remains a
 deprecated CSS-only compatibility selector through v1.x. Runtime validation
 should warn with migration guidance rather than fail existing artifacts without

--- a/figma/exports/Patterns (UI).tokens.json
+++ b/figma/exports/Patterns (UI).tokens.json
@@ -1301,7 +1301,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-text-color-default)"
+            "WEB": "var(--uif-input-text-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:326",
@@ -1323,7 +1323,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-text-color-hover)"
+            "WEB": "var(--uif-input-text-color-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:340",
@@ -1345,7 +1345,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-text-color-active)"
+            "WEB": "var(--uif-input-text-color-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:326",
@@ -1367,7 +1367,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-text-color-disabled)"
+            "WEB": "var(--uif-input-text-color-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:328",
@@ -1389,7 +1389,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-text-color-placeholder)"
+            "WEB": "var(--uif-input-text-color-placeholder)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:341",
@@ -1413,7 +1413,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-color-default)"
+            "WEB": "var(--uif-input-border-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:342",
@@ -1435,7 +1435,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-color-hover)"
+            "WEB": "var(--uif-input-border-color-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:345",
@@ -1457,7 +1457,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-color-active)"
+            "WEB": "var(--uif-input-border-color-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:345",
@@ -1479,7 +1479,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-color-focus)"
+            "WEB": "var(--uif-input-border-color-focus)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:345",
@@ -1501,7 +1501,7 @@
             "STROKE_FLOAT"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-size-default)"
+            "WEB": "var(--uif-input-border-size-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:7",
@@ -1523,7 +1523,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-size-hover)"
+            "WEB": "var(--uif-input-border-size-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:7",
@@ -1545,7 +1545,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-size-active)"
+            "WEB": "var(--uif-input-border-size-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:8",
@@ -1567,7 +1567,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-radius)"
+            "WEB": "var(--uif-input-border-radius)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2028:335",
@@ -1589,7 +1589,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-color-disabled)"
+            "WEB": "var(--uif-input-border-color-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:346",
@@ -1611,7 +1611,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-color-invalid)"
+            "WEB": "var(--uif-input-border-color-invalid)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:356",
@@ -1633,7 +1633,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-border-color-valid)"
+            "WEB": "var(--uif-input-border-color-valid)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:344",
@@ -1656,7 +1656,7 @@
           "FONT_FAMILY"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--input-font-family)"
+          "WEB": "var(--uif-input-font-family)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:2006:213",
@@ -1678,7 +1678,7 @@
           "FONT_STYLE"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--input-font-weight)"
+          "WEB": "var(--uif-input-font-weight)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3014:12",
@@ -1700,7 +1700,7 @@
           "FONT_SIZE"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--input-font-size)"
+          "WEB": "var(--uif-input-font-size)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3014:9",
@@ -1722,7 +1722,7 @@
           "LINE_HEIGHT"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--input-line-height)"
+          "WEB": "var(--uif-input-line-height)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3014:14",
@@ -1745,7 +1745,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-container-background-default)"
+            "WEB": "var(--uif-input-container-background-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:329",
@@ -1767,7 +1767,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-container-background-hover)"
+            "WEB": "var(--uif-input-container-background-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:329",
@@ -1789,7 +1789,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-container-background-focus)"
+            "WEB": "var(--uif-input-container-background-focus)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:329",
@@ -1811,7 +1811,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-container-background-active)"
+            "WEB": "var(--uif-input-container-background-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:329",
@@ -1833,7 +1833,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--input-container-background-disabled)"
+            "WEB": "var(--uif-input-container-background-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:330",
@@ -1856,7 +1856,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--input-padding-inline)"
+          "WEB": "var(--uif-input-padding-inline)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:3",
@@ -1878,7 +1878,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--input-padding-inline-icon-only)"
+          "WEB": "var(--uif-input-padding-inline-icon-only)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:3",
@@ -1900,7 +1900,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--input-padding-block)"
+          "WEB": "var(--uif-input-padding-block)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:3",
@@ -1922,7 +1922,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--input-gap)"
+          "WEB": "var(--uif-input-gap)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:3",
@@ -1944,7 +1944,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--input-overlay-hover)"
+          "WEB": "var(--uif-input-overlay-hover)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:2006:195",
@@ -1966,7 +1966,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--input-overlay-active)"
+          "WEB": "var(--uif-input-overlay-active)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:2006:195",
@@ -1988,7 +1988,7 @@
           "WIDTH_HEIGHT"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--input-height)"
+          "WEB": "var(--uif-input-height)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3020:2",
@@ -2010,7 +2010,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--input-height-min)"
+          "WEB": "var(--uif-input-height-min)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3020:2",

--- a/schemas/web-form.figma.ts
+++ b/schemas/web-form.figma.ts
@@ -26,7 +26,7 @@ figma.connect(
         </span>
       </label>
       <input
-        class="input"
+        class="uif-input"
         id="form-field-input"
         type="text"
         placeholder="Enter value"

--- a/schemas/web-input.figma.ts
+++ b/schemas/web-input.figma.ts
@@ -5,7 +5,7 @@ figma.connect(
   {
     props: {
       wrapperClassName: figma.className([
-        "input-field",
+        "uif-input-field",
         figma.enum("State", {
           Default: undefined,
           Hover: "is-hover",
@@ -30,13 +30,13 @@ figma.connect(
     },
     example: ({ wrapperClassName, disabled, type, readonlyAttr, placeholder }) => html`<div class="${wrapperClassName}">
   <input
-    class="input"
+    class="uif-input"
     type="${type}"
     placeholder="${placeholder}"
     readonly="${readonlyAttr}"
     disabled="${disabled}"
   />
-  <span class="input-field-control">
+  <span class="uif-input-field-control">
     <!-- Control buttons rendered by type -->
   </span>
 </div>`,

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -19,15 +19,15 @@
 {%- endmacro %}
 
 {% macro input(type='text', placeholder='', value='', state='default', disabled=false, className='', id='', name='', dataPlaygroundControl=false, dataProp='', dataSource='', dataValueType='', dataQueryParam='') -%}
-{%- set wrapperClasses = "input-field" -%}
+{%- set wrapperClasses = "uif-input-field" -%}
 {%- if state == "hover" -%}{%- set wrapperClasses = wrapperClasses + " is-hover" -%}{%- endif -%}
 {%- if state == "active" -%}{%- set wrapperClasses = wrapperClasses + " is-active" -%}{%- endif -%}
 {%- if state == "focus" -%}{%- set wrapperClasses = wrapperClasses + " is-focus-visible" -%}{%- endif -%}
 {%- if state == "disabled" or disabled -%}{%- set wrapperClasses = wrapperClasses + " is-disabled" -%}{%- endif -%}
 {%- if className -%}{%- set wrapperClasses = wrapperClasses + " " + className -%}{%- endif -%}
 <div class="{{ wrapperClasses }}">
-  <input class="input" type="{{ type }}"{% if id %} id="{{ id }}"{% endif %}{% if name %} name="{{ name }}"{% endif %}{% if placeholder %} placeholder="{{ placeholder }}"{% endif %}{% if value %} value="{{ value }}"{% endif %}{% if dataPlaygroundControl %} data-playground-control{% endif %}{% if dataProp %} data-prop="{{ dataProp }}"{% endif %}{% if dataSource %} data-source="{{ dataSource }}"{% endif %}{% if dataValueType %} data-value-type="{{ dataValueType }}"{% endif %}{% if dataQueryParam %} data-query-param="{{ dataQueryParam }}"{% endif %}{% if disabled or state == "disabled" %} disabled{% endif %} />
-  <span class="input-field-control">
+  <input class="uif-input" type="{{ type }}"{% if id %} id="{{ id }}"{% endif %}{% if name %} name="{{ name }}"{% endif %}{% if placeholder %} placeholder="{{ placeholder }}"{% endif %}{% if value %} value="{{ value }}"{% endif %}{% if dataPlaygroundControl %} data-playground-control{% endif %}{% if dataProp %} data-prop="{{ dataProp }}"{% endif %}{% if dataSource %} data-source="{{ dataSource }}"{% endif %}{% if dataValueType %} data-value-type="{{ dataValueType }}"{% endif %}{% if dataQueryParam %} data-query-param="{{ dataQueryParam }}"{% endif %}{% if disabled or state == "disabled" %} disabled{% endif %} />
+  <span class="uif-input-field-control">
     {%- if type == "text" or type == "email" or type == "search" or type == "url" or type == "tel" -%}
     <button type="button" aria-label="Clear input" tabindex="-1"><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/cross-circled.svg');" aria-hidden="true"></span></button>
     {%- elif type == "number" -%}

--- a/site/assets/docs.css
+++ b/site/assets/docs.css
@@ -599,7 +599,7 @@ details[open] > .docs-nav-group-toggle::before {
   font-weight: 700;
 }
 
-.playground-field input:not(.input),
+.playground-field input:not(.uif-input):not(.input),
 .playground-field select {
   border-radius: 10px;
   border: 1px solid var(--docs-border);

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -281,9 +281,9 @@
     const isDisabled = previewState === "disabled" || Boolean(props.disabled);
     const isReadonly = previewState === "readonly";
 
-    // Always render as .input-field wrapper
+    // Always render as the UIF Input field wrapper
     const wrapper = document.createElement("div");
-    const wrapperClasses = ["input-field"];
+    const wrapperClasses = ["uif-input-field"];
     if (previewState === "hover") wrapperClasses.push("is-hover");
     if (previewState === "active") wrapperClasses.push("is-active");
     if (previewState === "focus") wrapperClasses.push("is-focus-visible");
@@ -293,7 +293,7 @@
     wrapper.className = wrapperClasses.join(" ");
 
     const input = document.createElement("input");
-    input.className = "input";
+    input.className = "uif-input";
     input.type = type;
     input.placeholder = placeholder;
     input.value = value;
@@ -302,7 +302,7 @@
     wrapper.appendChild(input);
 
     const control = document.createElement("span");
-    control.className = "input-field-control";
+    control.className = "uif-input-field-control";
 
     let controlIcons = [];
     if (type === "number") {
@@ -341,7 +341,7 @@
     wrapper.appendChild(control);
 
     // Generate code
-    const inputAttrs = [`class="input"`, `type="${quoteAttr(type)}"`];
+    const inputAttrs = [`class="uif-input"`, `type="${quoteAttr(type)}"`];
     if (placeholder) inputAttrs.push(`placeholder="${quoteAttr(placeholder)}"`);
     if (value) inputAttrs.push(`value="${quoteAttr(value)}"`);
     if (isDisabled) inputAttrs.push("disabled");
@@ -359,7 +359,7 @@
 
     const code = `<div class="${quoteAttr(wrapper.className)}">
   <input ${inputAttrs.join(" ")} />
-  <span class="input-field-control">
+  <span class="uif-input-field-control">
     ${controlCode}
   </span>
 </div>`;
@@ -787,7 +787,7 @@
     label1.innerHTML = '<span class="uif-label-content"><span class="uif-label-content-text">Email</span></span><span class="uif-field-label-required" aria-hidden="true">*</span>';
 
     const input1 = document.createElement("input");
-    input1.className = "input";
+    input1.className = "uif-input";
     input1.type = "email";
     input1.placeholder = "you@example.com";
 
@@ -822,7 +822,7 @@
     label2.innerHTML = '<span class="uif-label-content"><span class="uif-label-content-text">Password</span></span>';
 
     const input2 = document.createElement("input");
-    input2.className = "input";
+    input2.className = "uif-input";
     input2.type = "password";
 
     if (labelPosition === "side") {
@@ -854,11 +854,11 @@
     const code = `<form class="${formClasses.join(" ")}" novalidate>
   <div class="form-field${inv}"${lp}>
     <label class="uif-field-label"><span class="uif-label-content"><span class="uif-label-content-text">Email</span></span><span class="uif-field-label-required" aria-hidden="true">*</span></label>
-    <input class="input" type="email" placeholder="you@example.com" />${helperCode}
+    <input class="uif-input" type="email" placeholder="you@example.com" />${helperCode}
   </div>
   <div class="form-field"${lp}>
     <label class="uif-field-label"><span class="uif-label-content"><span class="uif-label-content-text">Password</span></span></label>
-    <input class="input" type="password" />
+    <input class="uif-input" type="password" />
   </div>
   <div class="form-actions"${alignAttr}>
     <button class="uif-button solid" type="submit"><span class="uif-label-content"><span class="uif-label-content-text">Sign in</span></span></button>
@@ -1132,7 +1132,7 @@
     const monthNames = ["January","February","March","April","May","June","July","August","September","October","November","December"];
     const weekdayNames = ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"];
 
-    const rootClasses = ["input-field", "date"];
+    const rootClasses = ["uif-input-field", "date"];
     if (isOpen) rootClasses.push("is-open");
 
     let html = `<div class="form-field date-picker-field">`;
@@ -1145,7 +1145,7 @@
     html += `<span class="date-separator">/</span>`;
     html += `<input class="date-segment year" id="date-picker-playground-year" type="text" inputmode="numeric" maxlength="4" placeholder="YYYY" aria-label="Year" value="${quoteAttr(year)}"${disabledAttr}>`;
     html += `</div>`;
-    html += `<span class="input-field-control">`;
+    html += `<span class="uif-input-field-control">`;
     html += `<button type="button" aria-label="Open calendar" aria-expanded="${isOpen}" aria-haspopup="grid" aria-controls="date-picker-playground-calendar"${disabledAttr}>`;
     html += `<span class="uif-icon" style="--uif-icon-src: url('/assets/icons/calendar.svg');" aria-hidden="true"></span>`;
     html += `</button></span>`;

--- a/site/components/date-picker.md
+++ b/site/components/date-picker.md
@@ -31,7 +31,7 @@ playgroundLabel: Open Date Picker Playground
             <span class="uif-label-content-text">Travel date</span>
           </span>
         </label>
-        <div class="input-field date" id="date-input-demo" role="group" aria-labelledby="date-input-demo-label">
+        <div class="uif-input-field date" id="date-input-demo" role="group" aria-labelledby="date-input-demo-label">
           <div class="date-segments">
             <input class="date-segment day" id="date-input-demo-day" type="text" inputmode="numeric" maxlength="2" placeholder="DD" aria-label="Day">
             <span class="date-separator">/</span>
@@ -39,7 +39,7 @@ playgroundLabel: Open Date Picker Playground
             <span class="date-separator">/</span>
             <input class="date-segment year" id="date-input-demo-year" type="text" inputmode="numeric" maxlength="4" placeholder="YYYY" aria-label="Year">
           </div>
-          <span class="input-field-control">
+          <span class="uif-input-field-control">
             <button type="button" aria-label="Open calendar" aria-expanded="false" aria-haspopup="grid" aria-controls="date-input-demo-calendar">
               <span class="uif-icon" style="--uif-icon-src: url('/assets/icons/calendar.svg');" aria-hidden="true"></span>
             </button>
@@ -64,14 +64,14 @@ Together they form a component that can be opened, navigated, and dismissed — 
 ```
 .form-field.date-picker-field
 ├── label.uif-field-label [for="date-day"]
-└── .input-field.date [role="group", aria-labelledby]
+└── .uif-input-field.date [role="group", aria-labelledby]
     ├── .date-segments
     │   ├── input.date-segment.day [maxlength=2, inputmode=numeric, aria-label="Day"]
     │   ├── span.date-separator  "/"
     │   ├── input.date-segment.month [maxlength=2, inputmode=numeric, aria-label="Month"]
     │   ├── span.date-separator  "/"
     │   └── input.date-segment.year [maxlength=4, aria-label="Year"]
-    ├── .input-field-control
+    ├── .uif-input-field-control
     │   └── button [aria-label="Open calendar", aria-expanded, aria-controls]
     │       └── span.uif-icon (calendar icon)
     └── .uif-calendar [hidden until opened]
@@ -131,8 +131,8 @@ Together they form a component that can be opened, navigated, and dismissed — 
 ## Tokens
 
 Reuses tokens from the composed patterns:
-- Input tokens (`--input-*`)
-- Input control button behavior from `.input-field-control`
+- Input tokens (`--uif-input-*`)
+- Input control button behavior from `.uif-input-field-control`
 - Calendar tokens (`--uif-calendar-cell-*`)
 
 No additional component-specific tokens needed — the composition inherits from its parts.
@@ -170,7 +170,7 @@ The Date Picker requires `src/ui/components/date-input.js` for:
 
 <script>
 (function() {
-  document.querySelectorAll('.input-field.date').forEach(function(root) {
+  document.querySelectorAll('.uif-input-field.date').forEach(function(root) {
     var segments = root.querySelectorAll('.date-segment');
     var trigger = root.querySelector("[aria-label='Open calendar']");
     var calendar = root.querySelector('.uif-calendar');

--- a/site/examples/vanilla-starter.md
+++ b/site/examples/vanilla-starter.md
@@ -40,7 +40,7 @@ import "ui-foundations/tokens/components.css";
 
 ## 3. Render an example page
 
-Use package classes like `.uif-button`, `.input`, `.uif-field-label`, and `.checkbox`.
+Use package classes like `.uif-button`, `.uif-input`, `.uif-field-label`, and `.checkbox`.
 
 ```js
 document.querySelector("#app").innerHTML = `
@@ -52,7 +52,7 @@ document.querySelector("#app").innerHTML = `
         <span class="uif-label-content-text">Email</span>
       </span>
     </label>
-    <input class="input" id="email" type="email" placeholder="name@example.com" />
+    <input class="uif-input" id="email" type="email" placeholder="name@example.com" />
 
     <div style="height: 0.75rem"></div>
     <button class="uif-button solid" type="button">

--- a/site/foundations/class-naming.md
+++ b/site/foundations/class-naming.md
@@ -63,7 +63,7 @@ The examples below illustrate the consumed contract. They are not source rules.
 
 ## Migration
 
-Some runtime artifacts still use bare classes such as `.input` and `.select`.
+Some runtime artifacts still use bare classes such as `.select` and `.checkbox`.
 Button emitters now use `.uif-button`; `.button` remains a
 deprecated CSS-only compatibility selector through v1.x. Runtime validation
 warns with migration guidance while the migration is in progress.

--- a/site/getting-started.md
+++ b/site/getting-started.md
@@ -66,7 +66,7 @@ generation, and framework-agnostic Custom Elements.
 
 ```html
 <button class="uif-button solid" type="button">Label</button>
-<input class="input" type="text" placeholder="Email" />
+<input class="uif-input" type="text" placeholder="Email" />
 <a href="/page" class="uif-link">Go to page</a>
 ```
 

--- a/site/patterns/input.md
+++ b/site/patterns/input.md
@@ -39,6 +39,14 @@ playgroundLabel: Open Input Playground
   </div>
 </div>
 
+### v1 naming migration
+
+Use `.uif-input`, `.uif-input-field`, and `.uif-input-field-control` with
+`--uif-input-*` tokens in new and migrated markup. The unprefixed Input class
+selectors remain compatible throughout v1.x, but legacy `--input-*` token
+aliases are not provided. Consumers must migrate classes and tokens together.
+Legacy selector removal remains Wave 4 work for v2.0 or later.
+
 <h2 id="anatomy">Anatomy</h2>
 
 <div class="docs-anatomy">

--- a/src/elements/ui-input.js
+++ b/src/elements/ui-input.js
@@ -37,10 +37,10 @@ class UIInput extends UIElement {
       this.warnDev("[ui-foundations] <ui-input> should have an id, aria-label, or aria-labelledby.");
     }
 
-    const wrapperClasses = ["input-field"];
+    const wrapperClasses = ["uif-input-field"];
     if (disabled) wrapperClasses.push("is-disabled");
 
-    const inputAttrs = ['class="input"', `type="${type}"`];
+    const inputAttrs = ['class="uif-input"', `type="${type}"`];
     if (placeholder) inputAttrs.push(`placeholder="${placeholder}"`);
     if (value) inputAttrs.push(`value="${value}"`);
     if (disabled) inputAttrs.push("disabled");
@@ -67,7 +67,7 @@ class UIInput extends UIElement {
 
     this.innerHTML = `<div class="${wrapperClasses.join(" ")}">
   <input ${inputAttrs.join(" ")} />
-  <span class="input-field-control">${controlHTML}</span>
+  <span class="uif-input-field-control">${controlHTML}</span>
 </div>`;
   }
 }

--- a/src/ui/components/date-input.js
+++ b/src/ui/components/date-input.js
@@ -1,7 +1,7 @@
 /**
  * Date Input — Progressive Enhancement
  *
- * Enhances a segmented .input-field.date with:
+ * Enhances a segmented `.uif-input-field.date` with:
  * - Auto-tab between DD/MM/YYYY segments on completion
  * - Backspace navigates to previous segment
  * - Calendar dropdown toggle via trigger button
@@ -9,14 +9,14 @@
  * - Validation per segment (day 1-31, month 1-12, year 1900-2100)
  *
  * HTML structure:
- *   .input-field.date
+ *   .uif-input-field.date
  *     .date-segments
  *       input.date-segment.day [maxlength=2, inputmode=numeric]
  *       span.date-separator "/"
  *       input.date-segment.month [maxlength=2, inputmode=numeric]
  *       span.date-separator "/"
  *       input.date-segment.year [maxlength=4, inputmode=numeric]
- *     .input-field-control
+ *     .uif-input-field-control
  *       button (calendar trigger)
  *     .uif-calendar (dropdown)
  */
@@ -235,7 +235,7 @@ export class DateInput {
 if (typeof document !== "undefined") {
   document.addEventListener("DOMContentLoaded", () => {
     document
-      .querySelectorAll(".input-field.date:not([data-enhanced])")
+      .querySelectorAll(":is(.uif-input-field, .input-field).date:not([data-enhanced])")
       .forEach((el) => {
         el.setAttribute("data-enhanced", "");
         new DateInput(el);

--- a/src/ui/components/input-field.js
+++ b/src/ui/components/input-field.js
@@ -1,7 +1,7 @@
 /**
  * Input Field — Progressive Enhancement
  *
- * Activates control buttons inside .input-field elements:
+ * Activates control buttons inside `.uif-input-field` elements:
  * - Clear (text/email/search/url/tel): clears the input value
  * - Increment/Decrement (number): steps the value up/down
  * - Toggle visibility (password): switches between password and text type
@@ -9,12 +9,16 @@
  *
  * Usage:
  *   import { enhanceInputFields } from 'ui-foundations/ui/components/input-field.js';
- *   enhanceInputFields();           // enhances all .input-field on the page
+ *   enhanceInputFields();           // enhances all .uif-input-field on the page
  *   enhanceInputFields(container);  // enhances only within a container
  */
 
+const INPUT_FIELD_SELECTOR = ":is(.uif-input-field, .input-field)";
+const INPUT_SELECTOR = "input:is(.uif-input, .input)";
+const INPUT_CONTROL_SELECTOR = ":is(.uif-input-field-control, .input-field-control)";
+
 function getInput(field) {
-  return field.querySelector("input.input");
+  return field.querySelector(INPUT_SELECTOR);
 }
 
 function getStep(input) {
@@ -69,7 +73,7 @@ function handleToggleVisibility(field) {
   if (!input || input.disabled) return;
 
   const button = field.querySelector(
-    '.input-field-control button[aria-label="Toggle password visibility"]',
+    `${INPUT_CONTROL_SELECTOR} button[aria-label="Toggle password visibility"]`,
   );
   const isRevealed = input.type === "text";
 
@@ -98,7 +102,7 @@ function enhanceField(field) {
   if (field.dataset.enhanced) return;
   field.dataset.enhanced = "true";
 
-  const control = field.querySelector(".input-field-control");
+  const control = field.querySelector(INPUT_CONTROL_SELECTOR);
   if (!control) return;
 
   // Set aria-pressed on password toggle buttons during enhancement
@@ -130,17 +134,17 @@ function enhanceField(field) {
 }
 
 /**
- * Enhance all .input-field elements within a root.
+ * Enhance all `.uif-input-field` elements within a root.
  * @param {Element|Document} [root=document] - Container to search within
  */
 export function enhanceInputFields(root) {
   const container = root || document;
-  const fields = container.querySelectorAll(".input-field");
+  const fields = container.querySelectorAll(INPUT_FIELD_SELECTOR);
   fields.forEach(enhanceField);
 }
 
 /**
- * Observe a root for dynamically added .input-field elements.
+ * Observe a root for dynamically added `.uif-input-field` elements.
  * @param {Element|Document} [root=document.body]
  */
 export function observeInputFields(root) {
@@ -149,11 +153,11 @@ export function observeInputFields(root) {
     for (const mutation of mutations) {
       for (const node of mutation.addedNodes) {
         if (node.nodeType !== 1) continue;
-        if (node.matches && node.matches(".input-field")) {
+        if (node.matches && node.matches(INPUT_FIELD_SELECTOR)) {
           enhanceField(node);
         }
         if (node.querySelectorAll) {
-          node.querySelectorAll(".input-field").forEach(enhanceField);
+          node.querySelectorAll(INPUT_FIELD_SELECTOR).forEach(enhanceField);
         }
       }
     }

--- a/src/ui/patterns/date-input.css
+++ b/src/ui/patterns/date-input.css
@@ -1,9 +1,9 @@
 @layer components {
   /* ─── Date Input ───────────────────────────────────────────────── */
-  /* Variant of .input-field with segmented DD/MM/YYYY fields         */
-  /* Composes: .input-field + Calendar                              */
+  /* Variant of Input field with segmented DD/MM/YYYY fields         */
+  /* Composes: Input field + Calendar                                */
 
-  .input-field.date {
+  :is(.uif-input-field, .input-field).date {
     position: relative;
   }
 
@@ -52,7 +52,7 @@
   }
 
   /* Calendar dropdown positioning */
-  .input-field.date :is(.uif-calendar, .calendar) {
+  :is(.uif-input-field, .input-field).date :is(.uif-calendar, .calendar) {
     display: none;
     position: absolute;
     inset-block-start: 100%;
@@ -67,7 +67,7 @@
   }
 
   /* Open state */
-  .input-field.date.is-open :is(.uif-calendar, .calendar) {
+  :is(.uif-input-field, .input-field).date.is-open :is(.uif-calendar, .calendar) {
     display: grid;
   }
 }

--- a/src/ui/patterns/input.css
+++ b/src/ui/patterns/input.css
@@ -1,7 +1,8 @@
 @layer components {
-  /* --- .input: internal primitive (the <input> element itself) --- */
+  /* --- Input primitive (the <input> element itself) --- */
+  /* Unprefixed Input classes are deprecated v1.x compatibility selectors. */
 
-  .input {
+  :is(.uif-input, .input) {
     display: block;
     inline-size: 100%;
     block-size: auto;
@@ -17,81 +18,84 @@
     line-height: inherit;
   }
 
-  .input::placeholder {
-    color: var(--input-text-color-placeholder);
+  :is(.uif-input, .input)::placeholder {
+    color: var(--uif-input-text-color-placeholder);
   }
 
-  .input:focus-visible {
+  :is(.uif-input, .input):focus-visible {
     outline: 2px solid transparent;
     box-shadow: none;
   }
 
-  .input:disabled {
+  :is(.uif-input, .input):disabled {
     cursor: not-allowed;
   }
 
   /* Hide native number spinners (we use custom controls) */
 
-  .input[type="number"]::-webkit-inner-spin-button,
-  .input[type="number"]::-webkit-outer-spin-button {
+  :is(.uif-input, .input)[type="number"]::-webkit-inner-spin-button,
+  :is(.uif-input, .input)[type="number"]::-webkit-outer-spin-button {
     -webkit-appearance: none;
     margin: 0;
   }
 
-  .input[type="number"] {
+  :is(.uif-input, .input)[type="number"] {
     appearance: textfield;
     -moz-appearance: textfield;
   }
 
-  /* --- .input-field: the composed pattern (container + input + control) --- */
+  /* --- Input field: the composed pattern (container + input + control) --- */
 
-  .input-field {
+  :is(.uif-input-field, .input-field) {
     position: relative;
     display: flex;
     align-items: center;
-    gap: var(--input-gap);
+    gap: var(--uif-input-gap);
     inline-size: 100%;
-    block-size: var(--input-height, var(--size-spacing-800));
-    font-family: var(--input-font-family);
-    font-weight: var(--input-font-weight);
-    font-size: var(--input-font-size);
-    line-height: var(--input-line-height, var(--typography-body-line-height));
-    color: var(--input-text-color-default);
-    background: var(--input-container-background-default);
+    block-size: var(--uif-input-height, var(--size-spacing-800));
+    font-family: var(--uif-input-font-family);
+    font-weight: var(--uif-input-font-weight);
+    font-size: var(--uif-input-font-size);
+    line-height: var(--uif-input-line-height, var(--typography-body-line-height));
+    color: var(--uif-input-text-color-default);
+    background: var(--uif-input-container-background-default);
     border-style: solid;
-    border-width: var(--input-border-size-default);
-    border-color: var(--input-border-color-default);
-    border-radius: var(--input-border-radius);
-    padding-inline: var(--input-padding-inline);
-    padding-block: var(--input-padding-block);
+    border-width: var(--uif-input-border-size-default);
+    border-color: var(--uif-input-border-color-default);
+    border-radius: var(--uif-input-border-radius);
+    padding-inline: var(--uif-input-padding-inline);
+    padding-block: var(--uif-input-padding-block);
   }
 
   /* --- Control slot --- */
 
-  .input-field-control {
+  :is(.uif-input-field-control, .input-field-control) {
     display: flex;
     align-items: center;
-    gap: var(--input-gap);
+    gap: var(--uif-input-gap);
     flex-shrink: 0;
-    color: var(--input-text-color-default);
+    color: var(--uif-input-text-color-default);
   }
 
-  .input-field-control:empty {
+  :is(.uif-input-field-control, .input-field-control):empty {
     display: none;
   }
 
   /* Hide controls when input is empty (showing placeholder) */
-  .input-field:has(.input:placeholder-shown) .input-field-control {
+  :is(.uif-input-field, .input-field):has(:is(.uif-input, .input):placeholder-shown)
+    :is(.uif-input-field-control, .input-field-control) {
     visibility: hidden;
   }
 
   /* Hide controls when disabled */
-  .input-field:has(.input:disabled) .input-field-control,
-  .input-field.is-disabled .input-field-control {
+  :is(.uif-input-field, .input-field):has(:is(.uif-input, .input):disabled)
+    :is(.uif-input-field-control, .input-field-control),
+  :is(.uif-input-field, .input-field).is-disabled
+    :is(.uif-input-field-control, .input-field-control) {
     visibility: hidden;
   }
 
-  .input-field-control button {
+  :is(.uif-input-field-control, .input-field-control) button {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -105,99 +109,101 @@
     line-height: 1;
   }
 
-  .input-field-control button:hover {
-    color: var(--input-text-color-hover);
+  :is(.uif-input-field-control, .input-field-control) button:hover {
+    color: var(--uif-input-text-color-hover);
   }
 
-  .input-field-control :is(.uif-icon, .icon) {
+  :is(.uif-input-field-control, .input-field-control) :is(.uif-icon, .icon) {
     font-size: 1.5rem;
   }
 
   /* --- State: hover --- */
 
-  .input-field:hover,
-  .input-field.is-hover {
+  :is(.uif-input-field, .input-field):hover,
+  :is(.uif-input-field, .input-field).is-hover {
     background:
-      linear-gradient(0deg, var(--input-overlay-hover), var(--input-overlay-hover)),
-      var(--input-container-background-default);
-    border-width: var(--input-border-size-hover);
+      linear-gradient(0deg, var(--uif-input-overlay-hover), var(--uif-input-overlay-hover)),
+      var(--uif-input-container-background-default);
+    border-width: var(--uif-input-border-size-hover);
     padding-inline: calc(
-      var(--input-padding-inline) + var(--input-border-size-default) -
-        var(--input-border-size-hover)
+      var(--uif-input-padding-inline) + var(--uif-input-border-size-default) -
+        var(--uif-input-border-size-hover)
     );
     padding-block: calc(
-      var(--input-padding-block) + var(--input-border-size-default) -
-        var(--input-border-size-hover)
+      var(--uif-input-padding-block) + var(--uif-input-border-size-default) -
+        var(--uif-input-border-size-hover)
     );
-    border-color: var(--input-border-color-hover);
-    color: var(--input-text-color-hover);
+    border-color: var(--uif-input-border-color-hover);
+    color: var(--uif-input-text-color-hover);
   }
 
   /* --- State: focus-within --- */
 
-  .input-field:focus-within,
-  .input-field.is-focus-visible {
-    background: var(--input-container-background-focus);
-    border-color: var(--input-border-color-focus);
+  :is(.uif-input-field, .input-field):focus-within,
+  :is(.uif-input-field, .input-field).is-focus-visible {
+    background: var(--uif-input-container-background-focus);
+    border-color: var(--uif-input-border-color-focus);
     outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
   /* --- State: active --- */
 
-  .input-field:has(.input:active),
-  .input-field.is-active {
+  :is(.uif-input-field, .input-field):has(:is(.uif-input, .input):active),
+  :is(.uif-input-field, .input-field).is-active {
     background:
-      linear-gradient(0deg, var(--input-overlay-active), var(--input-overlay-active)),
-      var(--input-container-background-default);
-    border-width: var(--input-border-size-active);
+      linear-gradient(0deg, var(--uif-input-overlay-active), var(--uif-input-overlay-active)),
+      var(--uif-input-container-background-default);
+    border-width: var(--uif-input-border-size-active);
     padding-inline: calc(
-      var(--input-padding-inline) + var(--input-border-size-default) -
-        var(--input-border-size-active)
+      var(--uif-input-padding-inline) + var(--uif-input-border-size-default) -
+        var(--uif-input-border-size-active)
     );
     padding-block: calc(
-      var(--input-padding-block) + var(--input-border-size-default) -
-        var(--input-border-size-active)
+      var(--uif-input-padding-block) + var(--uif-input-border-size-default) -
+        var(--uif-input-border-size-active)
     );
-    border-color: var(--input-border-color-active);
-    color: var(--input-text-color-active);
+    border-color: var(--uif-input-border-color-active);
+    color: var(--uif-input-text-color-active);
   }
 
   /* --- State: disabled --- */
 
-  .input-field:has(.input:disabled),
-  .input-field.is-disabled {
+  :is(.uif-input-field, .input-field):has(:is(.uif-input, .input):disabled),
+  :is(.uif-input-field, .input-field).is-disabled {
     cursor: not-allowed;
-    color: var(--input-text-color-disabled);
-    background: var(--input-container-background-disabled);
-    border-color: var(--input-border-color-disabled);
+    color: var(--uif-input-text-color-disabled);
+    background: var(--uif-input-container-background-disabled);
+    border-color: var(--uif-input-border-color-disabled);
   }
 
   /* --- State: readonly --- */
 
-  .input-field:has(.input:read-only),
-  .input-field.is-readonly {
+  :is(.uif-input-field, .input-field):has(:is(.uif-input, .input):read-only),
+  :is(.uif-input-field, .input-field).is-readonly {
     border-style: dashed;
   }
 
-  .input-field:has(.input:read-only) .input-field-control button,
-  .input-field.is-readonly .input-field-control button {
+  :is(.uif-input-field, .input-field):has(:is(.uif-input, .input):read-only)
+    :is(.uif-input-field-control, .input-field-control) button,
+  :is(.uif-input-field, .input-field).is-readonly
+    :is(.uif-input-field-control, .input-field-control) button {
     pointer-events: none;
     opacity: 0.4;
   }
 
   /* --- State: invalid --- */
 
-  .input-field.is-invalid,
-  .input-field:has(.input[aria-invalid="true"]) {
-    border-color: var(--input-border-color-invalid);
+  :is(.uif-input-field, .input-field).is-invalid,
+  :is(.uif-input-field, .input-field):has(:is(.uif-input, .input)[aria-invalid="true"]) {
+    border-color: var(--uif-input-border-color-invalid);
   }
 
-  .input-field.is-invalid:focus-within,
-  .input-field:has(.input[aria-invalid="true"]):focus-within,
-  .input-field.is-invalid.is-focus-visible,
-  .input-field:has(.input[aria-invalid="true"]).is-focus-visible {
-    border-color: var(--input-border-color-invalid);
-    box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--input-border-color-invalid);
+  :is(.uif-input-field, .input-field).is-invalid:focus-within,
+  :is(.uif-input-field, .input-field):has(:is(.uif-input, .input)[aria-invalid="true"]):focus-within,
+  :is(.uif-input-field, .input-field).is-invalid.is-focus-visible,
+  :is(.uif-input-field, .input-field):has(:is(.uif-input, .input)[aria-invalid="true"]).is-focus-visible {
+    border-color: var(--uif-input-border-color-invalid);
+    box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--uif-input-border-color-invalid);
   }
 }

--- a/tests/input-naming-migration.test.mjs
+++ b/tests/input-naming-migration.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("Input CSS exposes canonical UIF naming with v1 class aliases", async () => {
+  const css = await read("src/ui/patterns/input.css");
+
+  for (const className of ["input", "input-field", "input-field-control"]) {
+    assert.match(css, new RegExp(`:is\\(\\.uif-${className}, \\.${className}\\)`));
+  }
+
+  assert.match(css, /var\(--uif-input-/);
+  assert.doesNotMatch(css, /var\(--input-/);
+  assert.doesNotMatch(css, /\.uif-input(?:__|--)/);
+});
+
+test("Input Figma export contains all canonical tokens without legacy aliases", async () => {
+  const tokenExport = await read("figma/exports/Patterns (UI).tokens.json");
+  const canonical = tokenExport.match(/var\(--uif-input-/g) ?? [];
+
+  assert.equal(canonical.length, 33);
+  assert.doesNotMatch(tokenExport, /var\(--input-/);
+});
+
+test("Input-owned emitters produce canonical Input, Icon, and Label classes", async () => {
+  const sources = await Promise.all([
+    read("src/elements/ui-input.js"),
+    read("site/_includes/macros/ui.njk"),
+    read("site/assets/playground/renderers.js"),
+    read("schemas/web-input.figma.ts"),
+    read("schemas/web-form.figma.ts"),
+  ]);
+
+  for (const source of sources) {
+    assert.match(source, /uif-input/);
+  }
+
+  assert.match(sources[0], /uif-icon/);
+  assert.match(sources[1], /uif-icon/);
+  assert.match(sources[2], /uif-field-label/);
+  assert.doesNotMatch(sources[3], /class="input(?:[\s"])/);
+  assert.doesNotMatch(sources[4], /class="input(?:[\s"])/);
+});
+
+test("Input behavior and Date Input accept canonical and legacy Input markup", async () => {
+  const [behavior, dateBehavior, dateCss] = await Promise.all([
+    read("src/ui/components/input-field.js"),
+    read("src/ui/components/date-input.js"),
+    read("src/ui/patterns/date-input.css"),
+  ]);
+
+  assert.match(behavior, /:is\(\.uif-input-field, \.input-field\)/);
+  assert.match(behavior, /input:is\(\.uif-input, \.input\)/);
+  assert.match(behavior, /:is\(\.uif-input-field-control, \.input-field-control\)/);
+  assert.match(dateBehavior, /:is\(\.uif-input-field, \.input-field\)\.date/);
+  assert.match(dateCss, /:is\(\.uif-input-field, \.input-field\)\.date/);
+});
+
+test("Input documentation explains the v1 boundary while element registration stays stable", async () => {
+  const [documentation, element] = await Promise.all([
+    read("site/patterns/input.md"),
+    read("src/elements/ui-input.js"),
+  ]);
+
+  assert.match(documentation, /legacy `--input-\*` token\s+aliases are not provided/);
+  assert.match(documentation, /\.uif-input-field-control/);
+  assert.match(element, /define\("ui-input", UIInput\)/);
+});


### PR DESCRIPTION
## Summary

- migrate Input-owned public classes to `.uif-input`, `.uif-input-field`, and `.uif-input-field-control`
- update all 33 Input variables directly in Figma to canonical `--uif-input-*` `codeSyntax.WEB` values and synchronize the export
- retain unprefixed Input classes as v1.x CSS and behavior compatibility selectors, without library-owned legacy token aliases
- update Nunjucks, playgrounds, existing Custom Element light-DOM output, Code Connect, Date Picker composition, documentation, examples, tests, and package output
- preserve controls, disabled/readonly/validation states, accessibility semantics, selector specificity, Custom Element registration, and package exports

## Validation

- `npm run lint`
- `npm run test:unit` (115 passing)
- `npm run ci:check`
- regenerated and inspected `dist/`; generated files were not edited directly

Closes #169