### PR TITLE
Migration: Adopt UIF-prefixed naming for Accordion

### DIFF
--- a/figma/exports/Patterns (UI).tokens.json
+++ b/figma/exports/Patterns (UI).tokens.json
@@ -5215,7 +5215,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--accordion-border-color-default)"
+            "WEB": "var(--uif-accordion-border-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:342",
@@ -5237,7 +5237,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--accordion-border-size-default)"
+            "WEB": "var(--uif-accordion-border-size-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:7",
@@ -5259,7 +5259,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--accordion-border-radius)"
+            "WEB": "var(--uif-accordion-border-radius)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3032:2244",
@@ -5283,7 +5283,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--accordion-text-color-default)"
+            "WEB": "var(--uif-accordion-text-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:326",
@@ -5305,7 +5305,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--accordion-text-color-disabled)"
+            "WEB": "var(--uif-accordion-text-color-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:328",
@@ -5328,7 +5328,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--accordion-padding-inline)"
+          "WEB": "var(--uif-accordion-padding-inline)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:5",
@@ -5350,7 +5350,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--accordion-padding-block)"
+          "WEB": "var(--uif-accordion-padding-block)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:4",
@@ -5372,7 +5372,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--accordion-gap)"
+          "WEB": "var(--uif-accordion-gap)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:3",

--- a/schemas/web-accordion.figma.ts
+++ b/schemas/web-accordion.figma.ts
@@ -9,9 +9,9 @@ figma.connect(
       title: figma.string("Title"),
     },
     example: ({ open, title }: AccordionItemProps) =>
-      html`<details class="accordion-item" ${open}>
+      html`<details class="uif-accordion-item" ${open}>
   <summary>${title}</summary>
-  <div class="accordion-item-content">
+  <div class="uif-accordion-item-content">
     <p>Content</p>
   </div>
 </details>`,

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -181,17 +181,17 @@
 {%- endmacro %}
 
 {% macro accordion(className='') -%}
-{%- set classes = "accordion" -%}
+{%- set classes = "uif-accordion" -%}
 {%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
 <div class="{{ classes }}">{{ caller() }}</div>
 {%- endmacro %}
 
 {% macro accordionItem(title='', open=false, disabled=false) -%}
-{%- set classes = "accordion-item" -%}
+{%- set classes = "uif-accordion-item" -%}
 {%- if disabled -%}{%- set classes = classes + " is-disabled" -%}{%- endif -%}
 <details class="{{ classes }}"{% if open %} open{% endif %}>
   <summary>{{ title }}</summary>
-  <div class="accordion-item-content">{{ caller() }}</div>
+  <div class="uif-accordion-item-content">{{ caller() }}</div>
 </details>
 {%- endmacro %}
 

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -668,25 +668,25 @@
     const openIndex = Number(props.openIndex || 0);
 
     const wrapper = document.createElement("div");
-    wrapper.className = "accordion";
+    wrapper.className = "uif-accordion";
 
-    let codeLines = ['<div class="accordion">'];
+    let codeLines = ['<div class="uif-accordion">'];
     for (let i = 0; i < items; i++) {
       const details = document.createElement("details");
-      details.className = "accordion-item";
+      details.className = "uif-accordion-item";
       if (i === openIndex) details.open = true;
       const summary = document.createElement("summary");
       summary.textContent = `Item ${i + 1}`;
       const content = document.createElement("div");
-      content.className = "accordion-item-content";
+      content.className = "uif-accordion-item-content";
       content.innerHTML = `<p>Content for item ${i + 1}</p>`;
       details.append(summary, content);
       wrapper.append(details);
 
       const openAttr = i === openIndex ? " open" : "";
-      codeLines.push(`  <details class="accordion-item"${openAttr}>`);
+      codeLines.push(`  <details class="uif-accordion-item"${openAttr}>`);
       codeLines.push(`    <summary>Item ${i + 1}</summary>`);
-      codeLines.push(`    <div class="accordion-item-content"><p>Content for item ${i + 1}</p></div>`);
+      codeLines.push(`    <div class="uif-accordion-item-content"><p>Content for item ${i + 1}</p></div>`);
       codeLines.push(`  </details>`);
     }
     codeLines.push("</div>");

--- a/site/patterns/accordion.md
+++ b/site/patterns/accordion.md
@@ -44,6 +44,14 @@ playgroundLabel: Open Accordion Playground
   </div>
 </div>
 
+### v1 naming migration
+
+Use `.uif-accordion`, `.uif-accordion-item`, and
+`.uif-accordion-item-content` with `--uif-accordion-*` tokens. Unprefixed
+Accordion selectors remain compatible throughout v1.x, but legacy
+`--accordion-*` token aliases are not provided. Wave 4 selector removal remains
+v2.0-or-later work.
+
 <h2 id="anatomy">Anatomy</h2>
 
 <div class="docs-anatomy">
@@ -105,5 +113,5 @@ playgroundLabel: Open Accordion Playground
 <div class="docs-checklist">
   <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>All brand/mode contexts</strong><span>Works across light and dark modes.</span></div></div>
   <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Keyboard interactions</strong><span>Native details/summary behavior.</span></div></div>
-  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Design tokens</strong><span>Component-scoped tokens (<code>--accordion-*</code>).</span></div></div>
+  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Design tokens</strong><span>Component-scoped tokens (<code>--uif-accordion-*</code>).</span></div></div>
 </div>

--- a/src/elements/ui-accordion.js
+++ b/src/elements/ui-accordion.js
@@ -10,7 +10,7 @@ class UIAccordion extends UIElement {
   render() {
     // Wrap children in accordion container, preserving inner content
     const children = this.innerHTML;
-    this.innerHTML = `<div class="accordion">${children}</div>`;
+    this.innerHTML = `<div class="uif-accordion">${children}</div>`;
   }
 }
 
@@ -36,7 +36,7 @@ class UIAccordionItem extends UIElement {
     const disabled = this.getBool("disabled");
     const content = this.innerHTML;
 
-    const classes = ["accordion-item"];
+    const classes = ["uif-accordion-item"];
     if (disabled) classes.push("is-disabled");
 
     const detailsAttrs = [`class="${classes.join(" ")}"`];
@@ -44,7 +44,7 @@ class UIAccordionItem extends UIElement {
 
     this.innerHTML = `<details ${detailsAttrs.join(" ")}>
   <summary>${title}</summary>
-  <div class="accordion-item-content">${content}</div>
+  <div class="uif-accordion-item-content">${content}</div>
 </details>`;
   }
 }

--- a/src/ui/patterns/accordion.css
+++ b/src/ui/patterns/accordion.css
@@ -1,41 +1,42 @@
 @layer components {
-  .accordion {
+  /* Unprefixed Accordion classes are deprecated v1.x compatibility selectors. */
+  :is(.uif-accordion, .accordion) {
     display: flex;
     flex-direction: column;
-    border: var(--accordion-border-size-default) solid var(--accordion-border-color-default);
-    border-radius: var(--accordion-border-radius);
+    border: var(--uif-accordion-border-size-default) solid var(--uif-accordion-border-color-default);
+    border-radius: var(--uif-accordion-border-radius);
     overflow: hidden;
   }
 
-  .accordion-item {
-    border-block-start: var(--accordion-border-size-default) solid var(--accordion-border-color-default);
+  :is(.uif-accordion-item, .accordion-item) {
+    border-block-start: var(--uif-accordion-border-size-default) solid var(--uif-accordion-border-color-default);
   }
 
-  .accordion-item:first-child {
+  :is(.uif-accordion-item, .accordion-item):first-child {
     border-block-start: none;
   }
 
-  .accordion-item > summary {
+  :is(.uif-accordion-item, .accordion-item) > summary {
     display: flex;
     align-items: center;
-    gap: var(--accordion-gap);
-    padding-inline: var(--accordion-padding-inline);
-    padding-block: var(--accordion-padding-block);
+    gap: var(--uif-accordion-gap);
+    padding-inline: var(--uif-accordion-padding-inline);
+    padding-block: var(--uif-accordion-padding-block);
     font-family: var(--font-family-sans);
     font-size: var(--font-size-md);
     font-weight: var(--font-weight-600);
     line-height: var(--line-height-md);
-    color: var(--accordion-text-color-default);
+    color: var(--uif-accordion-text-color-default);
     cursor: pointer;
     list-style: none;
     user-select: none;
   }
 
-  .accordion-item > summary::-webkit-details-marker {
+  :is(.uif-accordion-item, .accordion-item) > summary::-webkit-details-marker {
     display: none;
   }
 
-  .accordion-item > summary::before {
+  :is(.uif-accordion-item, .accordion-item) > summary::before {
     content: "";
     display: inline-block;
     inline-size: 0.5rem;
@@ -47,34 +48,34 @@
     flex-shrink: 0;
   }
 
-  .accordion-item[open] > summary::before {
+  :is(.uif-accordion-item, .accordion-item)[open] > summary::before {
     transform: rotate(45deg);
   }
 
-  .accordion-item > summary:hover,
-  .accordion-item > summary.is-hover {
+  :is(.uif-accordion-item, .accordion-item) > summary:hover,
+  :is(.uif-accordion-item, .accordion-item) > summary.is-hover {
     background: var(--color-fill-hover);
   }
 
-  .accordion-item > summary:focus-visible,
-  .accordion-item > summary.is-focus-visible {
+  :is(.uif-accordion-item, .accordion-item) > summary:focus-visible,
+  :is(.uif-accordion-item, .accordion-item) > summary.is-focus-visible {
     outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
-  .accordion-item-content {
-    padding-inline: var(--accordion-padding-inline);
-    padding-block: var(--accordion-padding-block);
+  :is(.uif-accordion-item-content, .accordion-item-content) {
+    padding-inline: var(--uif-accordion-padding-inline);
+    padding-block: var(--uif-accordion-padding-block);
     font-family: var(--font-family-sans);
     font-size: var(--font-size-md);
     line-height: var(--line-height-md);
-    color: var(--accordion-text-color-default);
+    color: var(--uif-accordion-text-color-default);
   }
 
   /* ── Disabled ── */
 
-  .accordion-item.is-disabled > summary {
-    color: var(--accordion-text-color-disabled);
+  :is(.uif-accordion-item, .accordion-item).is-disabled > summary {
+    color: var(--uif-accordion-text-color-disabled);
     cursor: not-allowed;
     pointer-events: none;
   }

--- a/tests/accordion-naming-migration.test.mjs
+++ b/tests/accordion-naming-migration.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("Accordion CSS exposes canonical UIF naming with v1 class aliases", async () => {
+  const css = await read("src/ui/patterns/accordion.css");
+
+  for (const className of ["accordion", "accordion-item", "accordion-item-content"]) {
+    assert.match(css, new RegExp(`:is\\(\\.uif-${className}, \\.${className}\\)`));
+  }
+  assert.match(css, /var\(--uif-accordion-/);
+  assert.doesNotMatch(css, /var\(--accordion-/);
+  assert.doesNotMatch(css, /\.uif-accordion(?:__|--)/);
+});
+
+test("Accordion Figma export contains canonical tokens without legacy aliases", async () => {
+  const tokenExport = await read("figma/exports/Patterns (UI).tokens.json");
+  const canonical = tokenExport.match(/var\(--uif-accordion-/g) ?? [];
+
+  assert.equal(canonical.length, 8);
+  assert.doesNotMatch(tokenExport, /var\(--accordion-/);
+});
+
+test("Accordion-owned emitters produce canonical classes", async () => {
+  const sources = await Promise.all([
+    read("src/elements/ui-accordion.js"),
+    read("site/_includes/macros/ui.njk"),
+    read("site/assets/playground/renderers.js"),
+    read("schemas/web-accordion.figma.ts"),
+  ]);
+
+  for (const source of sources) {
+    assert.match(source, /uif-accordion/);
+  }
+  assert.doesNotMatch(sources[0], /class="accordion(?:[\s"])/);
+  assert.doesNotMatch(sources[3], /class="accordion(?:[\s"])/);
+});
+
+test("Accordion documentation explains migration while registrations stay stable", async () => {
+  const [documentation, element] = await Promise.all([
+    read("site/patterns/accordion.md"),
+    read("src/elements/ui-accordion.js"),
+  ]);
+
+  assert.match(documentation, /legacy\s+`--accordion-\*` token aliases are not provided/);
+  assert.match(element, /define\("ui-accordion", UIAccordion\)/);
+  assert.match(element, /define\("ui-accordion-item", UIAccordionItem\)/);
+});


### PR DESCRIPTION
## Summary

- migrate Accordion classes to `.uif-accordion`, `.uif-accordion-item`, and `.uif-accordion-item-content`
- update all 8 Accordion Figma variables directly to canonical `--uif-accordion-*` WEB syntax and synchronize the export
- retain unprefixed class compatibility through v1.x without legacy token aliases
- update the existing Custom Element’s rendered output, Nunjucks, playground, Code Connect, docs, tests, and generated package output
- preserve native details/summary behavior, accessibility, states, specificity, registration, and package exports

## Validation

- `npm run lint`
- `npm run test:unit` (119 passing)
- `npm run ci:check`
- regenerated and inspected `dist/`; generated files were not edited directly

Closes #171