### PR TITLE
Migration: Adopt UIF-prefixed naming for Avatar

### DIFF
--- a/figma/exports/Patterns (UI).tokens.json
+++ b/figma/exports/Patterns (UI).tokens.json
@@ -5719,7 +5719,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--avatar-container-background-default)"
+            "WEB": "var(--uif-avatar-container-background-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:338",
@@ -5743,7 +5743,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--avatar-text-color-default)"
+            "WEB": "var(--uif-avatar-text-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:326",
@@ -5767,7 +5767,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--avatar-border-radius)"
+            "WEB": "var(--uif-avatar-border-radius)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:1:251",

--- a/schemas/web-avatar.figma.ts
+++ b/schemas/web-avatar.figma.ts
@@ -6,7 +6,7 @@ figma.connect(
   {
     props: {
       className: figma.className([
-        "avatar",
+        "uif-avatar",
         figma.enum("Size", {
           xs: "xs",
           sm: "sm",
@@ -18,6 +18,6 @@ figma.connect(
       initials: figma.string("Initials"),
     },
     example: ({ className, initials }: AvatarProps) =>
-      html`<span class="${className}" role="img" aria-label="${initials}"><span class="avatar-initials">${initials}</span></span>`,
+      html`<span class="${className}" role="img" aria-label="${initials}"><span class="uif-avatar-initials">${initials}</span></span>`,
   },
 );

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -172,11 +172,11 @@
 {%- endmacro %}
 
 {% macro avatar(src='', alt='', initials='', size='', className='') -%}
-{%- set classes = "avatar" -%}
+{%- set classes = "uif-avatar" -%}
 {%- if size and size != "md" -%}{%- set classes = classes + " " + size -%}{%- endif -%}
 {%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
 <span class="{{ classes }}" role="img" aria-label="{{ alt or initials }}">
-  {%- if src -%}<img src="{{ src }}" alt="{{ alt }}" />{%- else -%}<span class="avatar-initials">{{ initials }}</span>{%- endif -%}
+  {%- if src -%}<img src="{{ src }}" alt="{{ alt }}" />{%- else -%}<span class="uif-avatar-initials">{{ initials }}</span>{%- endif -%}
 </span>
 {%- endmacro %}
 

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -636,7 +636,7 @@
     const src = String(props.src || "");
 
     const element = document.createElement("span");
-    const classes = ["avatar"];
+    const classes = ["uif-avatar"];
     if (size && size !== "md") classes.push(size);
     element.className = classes.join(" ");
     element.setAttribute("role", "img");
@@ -649,7 +649,7 @@
       element.append(img);
     } else {
       const span = document.createElement("span");
-      span.className = "avatar-initials";
+      span.className = "uif-avatar-initials";
       span.textContent = initials;
       element.append(span);
     }
@@ -657,7 +657,7 @@
     const codeClasses = classes.join(" ");
     const inner = src
       ? `<img src="${quoteAttr(src)}" alt="${quoteAttr(initials)}" />`
-      : `<span class="avatar-initials">${quoteAttr(initials)}</span>`;
+      : `<span class="uif-avatar-initials">${quoteAttr(initials)}</span>`;
     const code = `<span class="${codeClasses}" role="img" aria-label="${quoteAttr(initials)}">${inner}</span>`;
 
     return { element, code };

--- a/site/patterns/avatar.md
+++ b/site/patterns/avatar.md
@@ -114,10 +114,14 @@ playgroundLabel: Open Avatar Playground
 - Image avatars include `alt` text on the `<img>` element.
 - Initials are decorative — the `aria-label` on the container provides the accessible name.
 
+<h2 id="v1-naming-migration">v1 naming migration</h2>
+
+Avatar emitters now produce the canonical `.uif-avatar` and `.uif-avatar-initials` classes. The legacy `.avatar` and `.avatar-initials` selectors remain supported during the v1 compatibility period. Component token slots are now `--uif-avatar-*`; library-owned legacy `--avatar-*` token aliases are not provided. The existing `<ui-avatar>` registration and package export remain unchanged by this component-family migration.
+
 <h2 id="design-checklist">Design checklist</h2>
 
 <div class="docs-checklist">
   <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>All brand/mode contexts</strong><span>Works across light and dark modes.</span></div></div>
   <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Defined options</strong><span>Sizes and content types documented.</span></div></div>
-  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Design tokens</strong><span>Component-scoped tokens (<code>--avatar-*</code>).</span></div></div>
+  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Design tokens</strong><span>Component-scoped tokens (<code>--uif-avatar-*</code>).</span></div></div>
 </div>

--- a/src/elements/ui-avatar.js
+++ b/src/elements/ui-avatar.js
@@ -21,13 +21,13 @@ class UIAvatar extends UIElement {
     const initials = this.getAttr("initials");
     const size = this.getAttr("size", "md");
 
-    const classes = ["avatar"];
+    const classes = ["uif-avatar"];
     if (size && size !== "md") classes.push(size);
 
     const label = alt || initials;
     const inner = src
       ? `<img src="${src}" alt="${alt}" />`
-      : `<span class="avatar-initials">${initials}</span>`;
+      : `<span class="uif-avatar-initials">${initials}</span>`;
 
     this.innerHTML = `<span class="${classes.join(" ")}" role="img" aria-label="${label}">${inner}</span>`;
   }

--- a/src/ui/patterns/avatar.css
+++ b/src/ui/patterns/avatar.css
@@ -1,12 +1,12 @@
 @layer components {
-  .avatar {
+  :is(.uif-avatar, .avatar) {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border-radius: var(--avatar-border-radius);
+    border-radius: var(--uif-avatar-border-radius);
     overflow: hidden;
-    background: var(--avatar-container-background-default);
-    color: var(--avatar-text-color-default);
+    background: var(--uif-avatar-container-background-default);
+    color: var(--uif-avatar-text-color-default);
     font-family: var(--font-family-sans);
     font-weight: var(--font-weight-600);
     inline-size: 2.5rem;
@@ -16,25 +16,25 @@
 
   /* ── Sizes ── */
 
-  .avatar.xs {
+  :is(.uif-avatar, .avatar).xs {
     inline-size: 1.5rem;
     block-size: 1.5rem;
     font-size: var(--font-size-xs);
   }
 
-  .avatar.sm {
+  :is(.uif-avatar, .avatar).sm {
     inline-size: 2rem;
     block-size: 2rem;
     font-size: var(--font-size-xs);
   }
 
-  .avatar.lg {
+  :is(.uif-avatar, .avatar).lg {
     inline-size: 3rem;
     block-size: 3rem;
     font-size: var(--font-size-md);
   }
 
-  .avatar.xl {
+  :is(.uif-avatar, .avatar).xl {
     inline-size: 4rem;
     block-size: 4rem;
     font-size: var(--font-size-lg);
@@ -42,7 +42,7 @@
 
   /* ── Image ── */
 
-  .avatar > img {
+  :is(.uif-avatar, .avatar) > img {
     inline-size: 100%;
     block-size: 100%;
     object-fit: cover;
@@ -50,7 +50,7 @@
 
   /* ── Initials ── */
 
-  .avatar-initials {
+  :is(.uif-avatar-initials, .avatar-initials) {
     user-select: none;
     text-transform: uppercase;
   }

--- a/tests/avatar-naming-migration.test.mjs
+++ b/tests/avatar-naming-migration.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("Avatar CSS exposes canonical UIF naming with v1 class aliases", async () => {
+  const css = await read("src/ui/patterns/avatar.css");
+
+  for (const className of ["avatar", "avatar-initials"]) {
+    assert.match(css, new RegExp(`:is\\(\\.uif-${className}, \\.${className}\\)`));
+  }
+  assert.match(css, /var\(--uif-avatar-/);
+  assert.doesNotMatch(css, /var\(--avatar-/);
+  assert.doesNotMatch(css, /\.uif-avatar(?:__|--)/);
+});
+
+test("Avatar Figma export contains canonical tokens without legacy aliases", async () => {
+  const tokenExport = await read("figma/exports/Patterns (UI).tokens.json");
+  const canonical = tokenExport.match(/var\(--uif-avatar-/g) ?? [];
+
+  assert.equal(canonical.length, 3);
+  assert.doesNotMatch(tokenExport, /var\(--avatar-/);
+});
+
+test("Avatar-owned emitters produce canonical classes", async () => {
+  const sources = await Promise.all([
+    read("src/elements/ui-avatar.js"),
+    read("site/_includes/macros/ui.njk"),
+    read("site/assets/playground/renderers.js"),
+    read("schemas/web-avatar.figma.ts"),
+  ]);
+
+  for (const source of sources) assert.match(source, /uif-avatar/);
+  assert.doesNotMatch(sources[0], /class="avatar(?:[\s"])/);
+  assert.doesNotMatch(sources[3], /["']avatar["']/);
+});
+
+test("Avatar documentation explains migration while registration stays stable", async () => {
+  const [documentation, element] = await Promise.all([
+    read("site/patterns/avatar.md"),
+    read("src/elements/ui-avatar.js"),
+  ]);
+
+  assert.match(documentation, /legacy `--avatar-\*` token aliases are not provided/);
+  assert.match(element, /define\("ui-avatar", UIAvatar\)/);
+});


### PR DESCRIPTION
Closes #173

Wave 3 Avatar migration under #156.

- updates all three Avatar Figma WEB token mappings and the checked-in export to `--uif-avatar-*`
- emits `.uif-avatar` and `.uif-avatar-initials` from UIF-owned runtime, macro, playground, and Code Connect surfaces
- retains `.avatar` and `.avatar-initials` as v1 compatibility selectors without legacy token aliases
- documents the consumer migration boundary while keeping `<ui-avatar>` and package exports stable
- adds focused canonical-output and compatibility coverage
- regenerates and inspects package output

Validation:
- `npm run lint`
- `npm run test:unit` (123 tests)
- `npm run ci:check`