### PR TITLE
Migration: Adopt UIF-prefixed naming for Divider

### DIFF
--- a/schemas/web-divider.figma.ts
+++ b/schemas/web-divider.figma.ts
@@ -5,9 +5,7 @@ figma.connect(
   "https://www.figma.com/design/uqMsy8fV1fPbQdAzgwlmBA/UI-Foundations?node-id=2528-272&m=dev",
   {
     props: {
-      className: figma.className([
-        "divider",
-      ]),
+      className: figma.className(["uif-divider"]),
       orientation: figma.enum("Orientation", {
         horizontal: undefined,
         vertical: "vertical",

--- a/scripts/validate-token-usage.mjs
+++ b/scripts/validate-token-usage.mjs
@@ -20,7 +20,7 @@ const TOKENS_CSS_DIR = path.join(REPO_ROOT, "dist", "tokens", "css");
 
 // Tokens that are intentionally code-only (set dynamically or use CSS fallbacks)
 const ALLOWLIST = new Set([
-  "--divider-color",
+  "--uif-divider-color",
   "--uif-field-label-gap",
   "--uif-field-label-line-height",
   "--uif-field-label-required-color",

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -156,7 +156,7 @@
 {%- endmacro %}
 
 {% macro divider(orientation='horizontal', variant='', className='') -%}
-{%- set classes = "divider" -%}
+{%- set classes = "uif-divider" -%}
 {%- if variant -%}{%- set classes = classes + " " + variant -%}{%- endif -%}
 {%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
 <hr class="{{ classes }}"{% if orientation == "vertical" %} aria-orientation="vertical"{% endif %} />

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -746,7 +746,7 @@
     const orientation = String(props.orientation || "horizontal");
 
     const element = document.createElement("hr");
-    element.className = "divider";
+    element.className = "uif-divider";
     if (variant === "subtle") element.classList.add("subtle");
     if (orientation === "vertical") {
       element.setAttribute("aria-orientation", "vertical");
@@ -754,7 +754,7 @@
       element.style.blockSize = "3rem";
     }
 
-    const classes = ["divider"];
+    const classes = ["uif-divider"];
     if (variant === "subtle") classes.push("subtle");
     const attrs = [];
     if (orientation === "vertical") attrs.push('aria-orientation="vertical"');

--- a/site/patterns/divider.md
+++ b/site/patterns/divider.md
@@ -163,6 +163,10 @@ Dividers are non-interactive and not focusable. They are skipped by keyboard nav
 
 Divider adapts across brands and modes through semantic color tokens (`--color-border-default`, `--color-border-subtle`). Use the hero switches above to preview.
 
+<h2 id="v1-naming-migration">v1 naming migration</h2>
+
+Divider emitters now produce the canonical `.uif-divider` class. The legacy `.divider` selector remains supported during the v1 compatibility period. Divider currently has no component-scoped Figma variables; its local runtime input is namespaced as `--uif-divider-color`, and no library-owned legacy `--divider-color` alias is provided. The existing `<ui-divider>` registration and package export remain unchanged by this component-family migration.
+
 <h2 id="design-checklist">Design checklist</h2>
 
 <div class="docs-checklist">

--- a/src/elements/ui-divider.js
+++ b/src/elements/ui-divider.js
@@ -17,7 +17,7 @@ class UIDivider extends UIElement {
     const orientation = this.getAttr("orientation", "horizontal");
     const variant = this.getAttr("variant");
 
-    const classes = ["divider"];
+    const classes = ["uif-divider"];
     if (variant) classes.push(variant);
 
     const attrs = [`class="${classes.join(" ")}"`];

--- a/src/ui/patterns/divider.css
+++ b/src/ui/patterns/divider.css
@@ -1,9 +1,9 @@
 @layer components {
-  .divider {
+  :is(.uif-divider, .divider) {
     border: none;
     margin: 0;
     padding: 0;
-    background: var(--divider-color, var(--color-border-default));
+    background: var(--uif-divider-color, var(--color-border-default));
     block-size: var(--size-border-100);
     inline-size: 100%;
     align-self: stretch;
@@ -11,7 +11,7 @@
 
   /* ── Vertical orientation ── */
 
-  .divider[aria-orientation="vertical"] {
+  :is(.uif-divider, .divider)[aria-orientation="vertical"] {
     block-size: auto;
     inline-size: var(--size-border-100);
     align-self: stretch;
@@ -19,7 +19,7 @@
 
   /* ── Subtle variant ── */
 
-  .divider.subtle {
-    --divider-color: var(--color-border-subtle);
+  :is(.uif-divider, .divider).subtle {
+    --uif-divider-color: var(--color-border-subtle);
   }
 }

--- a/tests/divider-naming-migration.test.mjs
+++ b/tests/divider-naming-migration.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("Divider CSS exposes canonical UIF naming with a v1 class alias", async () => {
+  const css = await read("src/ui/patterns/divider.css");
+
+  assert.match(css, /:is\(\.uif-divider, \.divider\)/);
+  assert.match(css, /--uif-divider-color/);
+  assert.doesNotMatch(css, /--divider-color/);
+  assert.doesNotMatch(css, /\.uif-divider(?:__|--)/);
+});
+
+test("Divider-owned emitters produce the canonical class", async () => {
+  const sources = await Promise.all([
+    read("src/elements/ui-divider.js"),
+    read("site/_includes/macros/ui.njk"),
+    read("site/assets/playground/renderers.js"),
+    read("schemas/web-divider.figma.ts"),
+  ]);
+
+  for (const source of sources) assert.match(source, /uif-divider/);
+  assert.doesNotMatch(sources[0], /class="divider(?:[\s"])/);
+  assert.doesNotMatch(sources[3], /["']divider["']/);
+});
+
+test("Divider runtime input stays code-only rather than becoming a Figma token", async () => {
+  const [validator, tokenExport] = await Promise.all([
+    read("scripts/validate-token-usage.mjs"),
+    read("figma/exports/Patterns (UI).tokens.json"),
+  ]);
+
+  assert.match(validator, /"--uif-divider-color"/);
+  assert.doesNotMatch(validator, /"--divider-color"/);
+  assert.equal(JSON.parse(tokenExport).Divider, undefined);
+  assert.doesNotMatch(tokenExport, /--uif-divider-color/);
+});
+
+test("Divider documentation explains migration while registration stays stable", async () => {
+  const [documentation, element] = await Promise.all([
+    read("site/patterns/divider.md"),
+    read("src/elements/ui-divider.js"),
+  ]);
+
+  assert.match(documentation, /no component-scoped Figma variables/);
+  assert.match(documentation, /no library-owned legacy `--divider-color` alias is provided/);
+  assert.match(element, /define\("ui-divider", UIDivider\)/);
+});


### PR DESCRIPTION
Closes #175

Wave 3 Divider migration under #156.

- verifies directly in Figma that Divider currently has no component-scoped variables
- emits `.uif-divider` from runtime, macro, playground, and Code Connect surfaces
- retains `.divider` as the v1 compatibility selector
- migrates the code-only runtime input to `--uif-divider-color` and explicitly allowlists it without creating a Figma token or legacy alias
- documents the consumer migration boundary while keeping `<ui-divider>` and package exports stable
- adds focused canonical-output and compatibility coverage
- regenerates and inspects package output

Validation:
- `npm run lint`
- `npm run test:unit` (127 tests)
- `npm run ci:check`