### PR TITLE
Migration: Adopt UIF-prefixed naming for Tooltip

### DIFF
--- a/figma/exports/Patterns (UI).tokens.json
+++ b/figma/exports/Patterns (UI).tokens.json
@@ -5601,7 +5601,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--tooltip-text-color-default)"
+            "WEB": "var(--uif-tooltip-text-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:327",
@@ -5625,7 +5625,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--tooltip-container-background-default)"
+            "WEB": "var(--uif-tooltip-container-background-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2039:356",
@@ -5649,7 +5649,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--tooltip-border-radius)"
+            "WEB": "var(--uif-tooltip-border-radius)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3038:2847",
@@ -5672,7 +5672,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--tooltip-padding-inline)"
+          "WEB": "var(--uif-tooltip-padding-inline)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:4",
@@ -5694,7 +5694,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--tooltip-padding-block)"
+          "WEB": "var(--uif-tooltip-padding-block)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:3",

--- a/schemas/web-tooltip.figma.ts
+++ b/schemas/web-tooltip.figma.ts
@@ -14,9 +14,9 @@ figma.connect(
       text: figma.string("Text"),
     },
     example: ({ placement, text }: TooltipProps) =>
-      html`<span class="tooltip-trigger">
-  <button class="button outline" type="button">Trigger</button>
-  <span class="tooltip" role="tooltip" data-placement="${placement}">${text}</span>
+      html`<span class="uif-tooltip-trigger">
+  <button class="uif-button outline" type="button">Trigger</button>
+  <span class="uif-tooltip" role="tooltip" data-placement="${placement}">${text}</span>
 </span>`,
   },
 );

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -223,9 +223,9 @@
 {%- endmacro %}
 
 {% macro tooltip(text='', placement='top', className='') -%}
-{%- set classes = "tooltip-trigger" -%}
+{%- set classes = "uif-tooltip-trigger" -%}
 {%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
-<span class="{{ classes }}">{{ caller() }}<span class="tooltip" role="tooltip" data-placement="{{ placement }}">{{ text }}</span></span>
+<span class="{{ classes }}">{{ caller() }}<span class="uif-tooltip" role="tooltip" data-placement="{{ placement }}">{{ text }}</span></span>
 {%- endmacro %}
 
 {% macro form(borderless=false, className='') -%}

--- a/site/assets/playground/code-generators.js
+++ b/site/assets/playground/code-generators.js
@@ -290,7 +290,7 @@
         var p = state.props;
         var text = p.text || "Tooltip text";
         var placement = p.placement || "top";
-        return '{% call ui.tooltip("' + quoteAttr(text) + '", placement="' + placement + '") %}<button class="button">Hover me</button>{% endcall %}';
+        return '{% call ui.tooltip("' + quoteAttr(text) + '", placement="' + placement + '") %}<button class="uif-button">Hover me</button>{% endcall %}';
       },
     },
     wc: {
@@ -345,7 +345,7 @@
         var p = state.props;
         var text = p.text || "Tooltip text";
         var placement = p.placement || "top";
-        return '<ui-tooltip text="' + quoteAttr(text) + '" placement="' + placement + '">\n  <button class="button">Hover me</button>\n</ui-tooltip>';
+        return '<ui-tooltip text="' + quoteAttr(text) + '" placement="' + placement + '">\n  <button class="uif-button">Hover me</button>\n</ui-tooltip>';
       },
     },
   };

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -952,7 +952,7 @@
     const placement = String(props.placement || "top");
 
     const trigger = document.createElement("span");
-    trigger.className = "tooltip-trigger";
+    trigger.className = "uif-tooltip-trigger";
 
     const btn = document.createElement("button");
     btn.className = "button outline";
@@ -961,15 +961,15 @@
     trigger.append(btn);
 
     const tip = document.createElement("span");
-    tip.className = "tooltip is-visible";
+    tip.className = "uif-tooltip is-visible";
     tip.setAttribute("role", "tooltip");
     tip.setAttribute("data-placement", placement);
     tip.textContent = text;
     trigger.append(tip);
 
-    const code = `<span class="tooltip-trigger">
+    const code = `<span class="uif-tooltip-trigger">
   <button class="button outline" type="button">${quoteAttr(String(children || "Hover me"))}</button>
-  <span class="tooltip" role="tooltip" data-placement="${quoteAttr(placement)}">${quoteAttr(text)}</span>
+  <span class="uif-tooltip" role="tooltip" data-placement="${quoteAttr(placement)}">${quoteAttr(text)}</span>
 </span>`;
 
     return { element: trigger, code };

--- a/site/patterns/tooltip.md
+++ b/site/patterns/tooltip.md
@@ -43,36 +43,36 @@ playgroundLabel: Open Tooltip Playground
 <div class="docs-states-grid" style="--docs-states-cols: 4">
   <div class="docs-states-grid-item">
     <div class="docs-states-grid-item-preview" style="padding-block: 2rem;">
-      <span class="tooltip-trigger">
+      <span class="uif-tooltip-trigger">
         <button class="button outline" type="button">Top</button>
-        <span class="tooltip is-visible" role="tooltip" data-placement="top">Tooltip text</span>
+        <span class="uif-tooltip is-visible" role="tooltip" data-placement="top">Tooltip text</span>
       </span>
     </div>
     <span class="docs-states-grid-item-label">Top</span>
   </div>
   <div class="docs-states-grid-item">
     <div class="docs-states-grid-item-preview" style="padding-block: 2rem;">
-      <span class="tooltip-trigger">
+      <span class="uif-tooltip-trigger">
         <button class="button outline" type="button">Bottom</button>
-        <span class="tooltip is-visible" role="tooltip" data-placement="bottom">Tooltip text</span>
+        <span class="uif-tooltip is-visible" role="tooltip" data-placement="bottom">Tooltip text</span>
       </span>
     </div>
     <span class="docs-states-grid-item-label">Bottom</span>
   </div>
   <div class="docs-states-grid-item">
     <div class="docs-states-grid-item-preview" style="padding-inline: 5rem; padding-block: 1rem;">
-      <span class="tooltip-trigger">
+      <span class="uif-tooltip-trigger">
         <button class="button outline" type="button">Left</button>
-        <span class="tooltip is-visible" role="tooltip" data-placement="left">Tip</span>
+        <span class="uif-tooltip is-visible" role="tooltip" data-placement="left">Tip</span>
       </span>
     </div>
     <span class="docs-states-grid-item-label">Left</span>
   </div>
   <div class="docs-states-grid-item">
     <div class="docs-states-grid-item-preview" style="padding-inline: 5rem; padding-block: 1rem;">
-      <span class="tooltip-trigger">
+      <span class="uif-tooltip-trigger">
         <button class="button outline" type="button">Right</button>
-        <span class="tooltip is-visible" role="tooltip" data-placement="right">Tip</span>
+        <span class="uif-tooltip is-visible" role="tooltip" data-placement="right">Tip</span>
       </span>
     </div>
     <span class="docs-states-grid-item-label">Right</span>
@@ -137,6 +137,10 @@ playgroundLabel: Open Tooltip Playground
 - Uses `role="tooltip"` on the tooltip element.
 - Trigger should have `aria-describedby` pointing to the tooltip ID for screen readers.
 - Tooltips are non-interactive — they cannot contain links or buttons.
+
+<h2 id="v1-naming-migration">v1 naming migration</h2>
+
+Tooltip emitters now produce `.uif-tooltip` and `.uif-tooltip-trigger`. The legacy `.tooltip` and `.tooltip-trigger` selectors remain supported during the v1 compatibility period. Component token slots are now `--uif-tooltip-*`; library-owned legacy `--tooltip-*` token aliases are not provided. The existing `<ui-tooltip>` registration and package export remain unchanged by this component-family migration.
 - Shows on both hover and focus to support keyboard users.
 
 <h2 id="design-checklist">Design checklist</h2>
@@ -145,5 +149,5 @@ playgroundLabel: Open Tooltip Playground
   <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>All brand/mode contexts</strong><span>Works across light and dark modes.</span></div></div>
   <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Defined options</strong><span>Placement and text documented.</span></div></div>
   <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Usage guidelines</strong><span>Do/don't for content length.</span></div></div>
-  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Design tokens</strong><span>Component-scoped tokens (<code>--tooltip-*</code>).</span></div></div>
+  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Design tokens</strong><span>Component-scoped tokens (<code>--uif-tooltip-*</code>).</span></div></div>
 </div>

--- a/src/core/recipes/layout.css
+++ b/src/core/recipes/layout.css
@@ -20,5 +20,5 @@
   /* Z-index usage (token export example) */
   .modal-overlay { z-index: var(--zindex-modal-overlay); }
   .modal { z-index: var(--zindex-modal); }
-  .tooltip { z-index: var(--zindex-tooltip); }
+  :is(.uif-tooltip, .tooltip) { z-index: var(--zindex-tooltip); }
 }

--- a/src/elements/ui-tooltip.js
+++ b/src/elements/ui-tooltip.js
@@ -19,7 +19,7 @@ class UITooltip extends UIElement {
     const placement = this.getAttr("placement", "top");
     const children = this.innerHTML;
 
-    this.innerHTML = `<span class="tooltip-trigger">${children}<span class="tooltip" role="tooltip" data-placement="${placement}">${text}</span></span>`;
+    this.innerHTML = `<span class="uif-tooltip-trigger">${children}<span class="uif-tooltip" role="tooltip" data-placement="${placement}">${text}</span></span>`;
   }
 }
 

--- a/src/ui/patterns/tooltip.css
+++ b/src/ui/patterns/tooltip.css
@@ -1,49 +1,49 @@
 @layer components {
-  .tooltip {
+  :is(.uif-tooltip, .tooltip) {
     position: absolute;
     z-index: var(--zindex-tooltip);
     max-inline-size: 15rem;
-    padding-inline: var(--tooltip-padding-inline);
-    padding-block: var(--tooltip-padding-block);
+    padding-inline: var(--uif-tooltip-padding-inline);
+    padding-block: var(--uif-tooltip-padding-block);
     font-family: var(--font-family-sans);
     font-size: var(--font-size-sm);
     line-height: var(--line-height-sm);
-    color: var(--tooltip-text-color-default);
-    background: var(--tooltip-container-background-default);
-    border-radius: var(--tooltip-border-radius);
+    color: var(--uif-tooltip-text-color-default);
+    background: var(--uif-tooltip-container-background-default);
+    border-radius: var(--uif-tooltip-border-radius);
     pointer-events: none;
     opacity: 0;
     transition: opacity 0.15s ease;
   }
 
-  .tooltip.is-visible {
+  :is(.uif-tooltip, .tooltip).is-visible {
     opacity: 1;
   }
 
   /* ── Placement ── */
 
-  .tooltip[data-placement="top"] {
+  :is(.uif-tooltip, .tooltip)[data-placement="top"] {
     inset-block-end: 100%;
     inset-inline-start: 50%;
     transform: translateX(-50%);
     margin-block-end: var(--size-spacing-200);
   }
 
-  .tooltip[data-placement="bottom"] {
+  :is(.uif-tooltip, .tooltip)[data-placement="bottom"] {
     inset-block-start: 100%;
     inset-inline-start: 50%;
     transform: translateX(-50%);
     margin-block-start: var(--size-spacing-200);
   }
 
-  .tooltip[data-placement="left"] {
+  :is(.uif-tooltip, .tooltip)[data-placement="left"] {
     inset-inline-end: 100%;
     inset-block-start: 50%;
     transform: translateY(-50%);
     margin-inline-end: var(--size-spacing-200);
   }
 
-  .tooltip[data-placement="right"] {
+  :is(.uif-tooltip, .tooltip)[data-placement="right"] {
     inset-inline-start: 100%;
     inset-block-start: 50%;
     transform: translateY(-50%);
@@ -52,13 +52,13 @@
 
   /* ── Trigger wrapper ── */
 
-  .tooltip-trigger {
+  :is(.uif-tooltip-trigger, .tooltip-trigger) {
     position: relative;
     display: inline-flex;
   }
 
-  .tooltip-trigger:hover > .tooltip,
-  .tooltip-trigger:focus-within > .tooltip {
+  :is(.uif-tooltip-trigger, .tooltip-trigger):hover > :is(.uif-tooltip, .tooltip),
+  :is(.uif-tooltip-trigger, .tooltip-trigger):focus-within > :is(.uif-tooltip, .tooltip) {
     opacity: 1;
   }
 }

--- a/tests/tooltip-naming-migration.test.mjs
+++ b/tests/tooltip-naming-migration.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("Tooltip CSS exposes canonical UIF naming with v1 class aliases", async () => {
+  const [css, layout] = await Promise.all([
+    read("src/ui/patterns/tooltip.css"),
+    read("src/core/recipes/layout.css"),
+  ]);
+
+  for (const className of ["tooltip", "tooltip-trigger"]) {
+    assert.match(css, new RegExp(`:is\\(\\.uif-${className}, \\.${className}\\)`));
+  }
+  assert.match(layout, /:is\(\.uif-tooltip, \.tooltip\)/);
+  assert.match(css, /var\(--uif-tooltip-/);
+  assert.doesNotMatch(css, /var\(--tooltip-/);
+  assert.doesNotMatch(css, /\.uif-tooltip(?:__|--)/);
+});
+
+test("Tooltip Figma export contains canonical tokens without legacy aliases", async () => {
+  const tokenExport = await read("figma/exports/Patterns (UI).tokens.json");
+  const canonical = tokenExport.match(/var\(--uif-tooltip-/g) ?? [];
+
+  assert.equal(canonical.length, 5);
+  assert.doesNotMatch(tokenExport, /var\(--tooltip-/);
+});
+
+test("Tooltip-owned emitters produce canonical classes", async () => {
+  const sources = await Promise.all([
+    read("src/elements/ui-tooltip.js"),
+    read("site/_includes/macros/ui.njk"),
+    read("site/assets/playground/renderers.js"),
+    read("schemas/web-tooltip.figma.ts"),
+  ]);
+
+  for (const source of sources) assert.match(source, /uif-tooltip/);
+  assert.doesNotMatch(sources[0], /class="tooltip(?:[\s"])/);
+  assert.doesNotMatch(sources[3], /class="tooltip(?:[\s"])/);
+});
+
+test("Tooltip documentation explains migration while registration stays stable", async () => {
+  const [documentation, element] = await Promise.all([
+    read("site/patterns/tooltip.md"),
+    read("src/elements/ui-tooltip.js"),
+  ]);
+
+  assert.match(documentation, /legacy `--tooltip-\*` token aliases are not provided/);
+  assert.match(element, /define\("ui-tooltip", UITooltip\)/);
+});


### PR DESCRIPTION
Closes #177

Wave 3 Tooltip migration under #156.

- updates all five Tooltip Figma WEB token mappings and the checked-in export to `--uif-tooltip-*`
- emits `.uif-tooltip` and `.uif-tooltip-trigger` from UIF-owned runtime, macro, playground, docs, and Code Connect surfaces
- retains `.tooltip` and `.tooltip-trigger` as v1 compatibility selectors, including the shared layout recipe
- keeps stable `<ui-tooltip>` registration/package exports while its rendered light DOM is canonical
- provides explicit migration documentation and focused compatibility coverage
- regenerates and inspects package output with no legacy Tooltip token references

Validation:
- `npm run lint`
- `npm run test:unit` (131 tests)
- `npm run ci:check`