### PR TITLE
Migration: Adopt UIF-prefixed naming for Tabs

### DIFF
--- a/figma/exports/Patterns (UI).tokens.json
+++ b/figma/exports/Patterns (UI).tokens.json
@@ -5397,7 +5397,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--tabs-border-color-default)"
+            "WEB": "var(--uif-tabs-border-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:342",
@@ -5419,7 +5419,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--tabs-border-color-active)"
+            "WEB": "var(--uif-tabs-border-color-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:345",
@@ -5441,7 +5441,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--tabs-border-color-hover)"
+            "WEB": "var(--uif-tabs-border-color-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:343",
@@ -5465,7 +5465,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--tabs-text-color-default)"
+            "WEB": "var(--uif-tabs-text-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:326",
@@ -5487,7 +5487,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--tabs-text-color-active)"
+            "WEB": "var(--uif-tabs-text-color-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:340",
@@ -5509,7 +5509,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--tabs-text-color-hover)"
+            "WEB": "var(--uif-tabs-text-color-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:340",
@@ -5531,7 +5531,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--tabs-text-color-disabled)"
+            "WEB": "var(--uif-tabs-text-color-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:328",
@@ -5554,7 +5554,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--tabs-padding-inline)"
+          "WEB": "var(--uif-tabs-padding-inline)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:5",
@@ -5576,7 +5576,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--tabs-padding-block)"
+          "WEB": "var(--uif-tabs-padding-block)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:4",

--- a/schemas/web-tab.figma.ts
+++ b/schemas/web-tab.figma.ts
@@ -5,9 +5,7 @@ figma.connect(
   "https://www.figma.com/design/uqMsy8fV1fPbQdAzgwlmBA/UI-Foundations?node-id=2535-286&m=dev",
   {
     props: {
-      className: figma.className([
-        "tab",
-      ]),
+      className: figma.className(["uif-tab"]),
       selected: figma.boolean("Selected", { true: "true", false: "false" }),
       label: figma.string("Label"),
     },

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -196,13 +196,13 @@
 {%- endmacro %}
 
 {% macro tabList(orientation='horizontal', ariaLabel='', className='') -%}
-{%- set classes = "tab-list" -%}
+{%- set classes = "uif-tab-list" -%}
 {%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
 <div class="{{ classes }}" role="tablist" aria-orientation="{{ orientation }}"{% if ariaLabel %} aria-label="{{ ariaLabel }}"{% endif %}>{{ caller() }}</div>
 {%- endmacro %}
 
 {% macro tab(label='', selected=false, disabled=false, controls='', href='') -%}
-{%- set classes = "tab" -%}
+{%- set classes = "uif-tab" -%}
 {%- if selected -%}{%- set classes = classes + " is-active" -%}{%- endif -%}
 {%- if disabled -%}{%- set classes = classes + " is-disabled" -%}{%- endif -%}
 {%- if href -%}
@@ -213,13 +213,13 @@
 {%- endmacro %}
 
 {% macro tabPanels(className='') -%}
-{%- set classes = "tab-panels" -%}
+{%- set classes = "uif-tab-panels" -%}
 {%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
 <div class="{{ classes }}">{{ caller() }}</div>
 {%- endmacro %}
 
 {% macro tabPanel(id='', hidden=false) -%}
-<div class="tab-panel" role="tabpanel"{% if id %} id="{{ id }}"{% endif %}{% if hidden %} hidden{% endif %} tabindex="0">{{ caller() }}</div>
+<div class="uif-tab-panel" role="tabpanel"{% if id %} id="{{ id }}"{% endif %}{% if hidden %} hidden{% endif %} tabindex="0">{{ caller() }}</div>
 {%- endmacro %}
 
 {% macro tooltip(text='', placement='top', className='') -%}

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -699,17 +699,17 @@
     const activeIndex = Number(props.active || 0);
 
     const wrapper = document.createElement("div");
-    wrapper.className = "tabs";
+    wrapper.className = "uif-tabs";
 
     const tablist = document.createElement("div");
-    tablist.className = "tab-list";
+    tablist.className = "uif-tab-list";
     tablist.setAttribute("role", "tablist");
 
-    let codeLines = ['<div class="tabs">', '  <div class="tab-list" role="tablist">'];
+    let codeLines = ['<div class="uif-tabs">', '  <div class="uif-tab-list" role="tablist">'];
 
     for (let i = 0; i < tabCount; i++) {
       const btn = document.createElement("button");
-      btn.className = "tab";
+      btn.className = "uif-tab";
       btn.setAttribute("role", "tab");
       btn.setAttribute("aria-selected", String(i === activeIndex));
       btn.setAttribute("tabindex", i === activeIndex ? "0" : "-1");
@@ -718,20 +718,20 @@
       tablist.append(btn);
 
       const sel = i === activeIndex ? ' aria-selected="true" tabindex="0"' : ' aria-selected="false" tabindex="-1"';
-      codeLines.push(`    <button class="tab" role="tab"${sel} type="button">Tab ${i + 1}</button>`);
+      codeLines.push(`    <button class="uif-tab" role="tab"${sel} type="button">Tab ${i + 1}</button>`);
     }
     codeLines.push("  </div>");
 
     wrapper.append(tablist);
 
     const panel = document.createElement("div");
-    panel.className = "tab-panel";
+    panel.className = "uif-tab-panel";
     panel.setAttribute("role", "tabpanel");
     panel.setAttribute("tabindex", "0");
     panel.innerHTML = `<p>Panel content for Tab ${activeIndex + 1}</p>`;
     wrapper.append(panel);
 
-    codeLines.push(`  <div class="tab-panel" role="tabpanel" tabindex="0">`);
+    codeLines.push(`  <div class="uif-tab-panel" role="tabpanel" tabindex="0">`);
     codeLines.push(`    <p>Panel content</p>`);
     codeLines.push(`  </div>`);
     codeLines.push("</div>");

--- a/site/patterns/tabs.md
+++ b/site/patterns/tabs.md
@@ -134,10 +134,14 @@ playgroundLabel: Open Tabs Playground
 - Only the selected tab has `tabindex="0"`; others have `tabindex="-1"` for roving focus.
 - `aria-orientation` communicates layout direction to assistive technology.
 
+<h2 id="v1-naming-migration">v1 naming migration</h2>
+
+Tabs emitters now produce `.uif-tabs`, `.uif-tab-list`, `.uif-tab`, `.uif-tab-panels`, and `.uif-tab-panel`. Their unprefixed selectors remain supported during the v1 compatibility period. Component token slots are now `--uif-tabs-*`; library-owned legacy `--tabs-*` token aliases are not provided. Existing `<ui-tab-list>`, `<ui-tab>`, and `<ui-tab-panel>` registrations and package exports remain unchanged.
+
 <h2 id="design-checklist">Design checklist</h2>
 
 <div class="docs-checklist">
   <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>All brand/mode contexts</strong><span>Works across light and dark modes.</span></div></div>
   <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Keyboard interactions</strong><span>Full ARIA tablist pattern.</span></div></div>
-  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Design tokens</strong><span>Component-scoped tokens (<code>--tabs-*</code>).</span></div></div>
+  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Design tokens</strong><span>Component-scoped tokens (<code>--uif-tabs-*</code>).</span></div></div>
 </div>

--- a/src/elements/ui-tabs.js
+++ b/src/elements/ui-tabs.js
@@ -20,7 +20,7 @@ class UITabList extends UIElement {
     const children = this.innerHTML;
 
     const attrs = [
-      'class="tab-list"',
+      'class="uif-tab-list"',
       'role="tablist"',
       `aria-orientation="${orientation}"`,
     ];
@@ -54,7 +54,7 @@ class UITab extends UIElement {
     const controls = this.getAttr("controls");
 
     const attrs = [
-      'class="tab"',
+      'class="uif-tab"',
       'role="tab"',
       'type="button"',
       `aria-selected="${selected}"`,
@@ -86,7 +86,7 @@ class UITabPanel extends UIElement {
     const content = this.innerHTML;
     const id = this.id;
 
-    const attrs = ['class="tab-panel"', 'role="tabpanel"', 'tabindex="0"'];
+    const attrs = ['class="uif-tab-panel"', 'role="tabpanel"', 'tabindex="0"'];
     if (id) attrs.push(`id="${id}"`);
     if (hidden) attrs.push("hidden");
 

--- a/src/ui/patterns/tabs.css
+++ b/src/ui/patterns/tabs.css
@@ -1,32 +1,32 @@
 @layer components {
-  .tabs {
+  :is(.uif-tabs, .tabs) {
     display: flex;
     flex-direction: column;
   }
 
-  .tab-list {
+  :is(.uif-tab-list, .tab-list) {
     display: flex;
     gap: 0;
-    border-block-end: var(--size-border-100) solid var(--tabs-border-color-default);
+    border-block-end: var(--size-border-100) solid var(--uif-tabs-border-color-default);
   }
 
-  .tab-list[aria-orientation="vertical"] {
+  :is(.uif-tab-list, .tab-list)[aria-orientation="vertical"] {
     flex-direction: column;
     border-block-end: none;
-    border-inline-end: var(--size-border-100) solid var(--tabs-border-color-default);
+    border-inline-end: var(--size-border-100) solid var(--uif-tabs-border-color-default);
   }
 
-  .tab {
+  :is(.uif-tab, .tab) {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding-inline: var(--tabs-padding-inline);
-    padding-block: var(--tabs-padding-block);
+    padding-inline: var(--uif-tabs-padding-inline);
+    padding-block: var(--uif-tabs-padding-block);
     font-family: var(--font-family-sans);
     font-size: var(--font-size-md);
     font-weight: var(--font-weight-500);
     line-height: var(--line-height-md);
-    color: var(--tabs-text-color-default);
+    color: var(--uif-tabs-text-color-default);
     background: transparent;
     border: none;
     border-block-end: var(--size-border-200) solid transparent;
@@ -36,30 +36,30 @@
     transition: border-color 0.15s ease, color 0.15s ease;
   }
 
-  .tab:hover,
-  .tab.is-hover {
-    color: var(--tabs-text-color-hover);
-    border-block-end-color: var(--tabs-border-color-hover);
+  :is(.uif-tab, .tab):hover,
+  :is(.uif-tab, .tab).is-hover {
+    color: var(--uif-tabs-text-color-hover);
+    border-block-end-color: var(--uif-tabs-border-color-hover);
   }
 
-  .tab[aria-selected="true"],
-  .tab.is-selected,
-  .tab.is-active {
-    color: var(--tabs-text-color-active);
+  :is(.uif-tab, .tab)[aria-selected="true"],
+  :is(.uif-tab, .tab).is-selected,
+  :is(.uif-tab, .tab).is-active {
+    color: var(--uif-tabs-text-color-active);
     font-weight: var(--font-weight-600);
-    border-block-end-color: var(--tabs-border-color-active);
+    border-block-end-color: var(--uif-tabs-border-color-active);
   }
 
-  .tab:focus-visible,
-  .tab.is-focus-visible {
+  :is(.uif-tab, .tab):focus-visible,
+  :is(.uif-tab, .tab).is-focus-visible {
     outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
-  .tab:disabled,
-  .tab[aria-disabled="true"],
-  .tab.is-disabled {
-    color: var(--tabs-text-color-disabled);
+  :is(.uif-tab, .tab):disabled,
+  :is(.uif-tab, .tab)[aria-disabled="true"],
+  :is(.uif-tab, .tab).is-disabled {
+    color: var(--uif-tabs-text-color-disabled);
     cursor: not-allowed;
     border-block-end-color: transparent;
     pointer-events: none;
@@ -67,14 +67,14 @@
 
   /* --- Panel container: CSS-only scroll-snap switching --- */
 
-  .tab-panels {
+  :is(.uif-tab-panels, .tab-panels) {
     display: flex;
     overflow-x: hidden;
     scroll-snap-type: x mandatory;
     scroll-behavior: smooth;
   }
 
-  .tab-panels > .tab-panel {
+  :is(.uif-tab-panels, .tab-panels) > :is(.uif-tab-panel, .tab-panel) {
     flex: 0 0 100%;
     min-inline-size: 100%;
     scroll-snap-align: start;
@@ -82,11 +82,11 @@
   }
 
   /* Legacy: standalone panel with hidden attribute (JS-driven) */
-  .tab-panel {
+  :is(.uif-tab-panel, .tab-panel) {
     padding-block: var(--size-spacing-400);
   }
 
-  .tab-panel[hidden] {
+  :is(.uif-tab-panel, .tab-panel)[hidden] {
     display: none;
   }
 }

--- a/tests/tabs-naming-migration.test.mjs
+++ b/tests/tabs-naming-migration.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("Tabs CSS exposes canonical UIF naming with v1 class aliases", async () => {
+  const css = await read("src/ui/patterns/tabs.css");
+  for (const name of ["tabs", "tab-list", "tab", "tab-panels", "tab-panel"]) {
+    assert.match(css, new RegExp(`:is\\(\\.uif-${name}, \\.${name}\\)`));
+  }
+  assert.match(css, /var\(--uif-tabs-/);
+  assert.doesNotMatch(css, /var\(--tabs-/);
+  assert.doesNotMatch(css, /\.uif-tabs?(?:__|--)/);
+});
+
+test("Tabs Figma export contains canonical tokens without legacy aliases", async () => {
+  const tokenExport = await read("figma/exports/Patterns (UI).tokens.json");
+  assert.equal((tokenExport.match(/var\(--uif-tabs-/g) ?? []).length, 9);
+  assert.doesNotMatch(tokenExport, /var\(--tabs-/);
+});
+
+test("Tabs-owned emitters produce canonical classes", async () => {
+  const sources = await Promise.all([
+    read("src/elements/ui-tabs.js"),
+    read("site/_includes/macros/ui.njk"),
+    read("site/assets/playground/renderers.js"),
+    read("schemas/web-tab.figma.ts"),
+  ]);
+  for (const source of sources) assert.match(source, /uif-tab/);
+  assert.doesNotMatch(sources[0], /class="tab(?:[-\s"])/);
+  assert.doesNotMatch(sources[3], /figma\.className\(\["tab"\]\)/);
+});
+
+test("Tabs documentation explains migration while registrations stay stable", async () => {
+  const [documentation, elements] = await Promise.all([
+    read("site/patterns/tabs.md"),
+    read("src/elements/ui-tabs.js"),
+  ]);
+  assert.match(documentation, /legacy `--tabs-\*` token aliases are not provided/);
+  for (const tag of ["ui-tab-list", "ui-tab", "ui-tab-panel"]) {
+    assert.match(elements, new RegExp(`define\\("${tag}"`));
+  }
+});


### PR DESCRIPTION
Closes #179

Wave 3 Tabs migration under #156.

- updates all nine Tabs Figma WEB mappings/export entries to `--uif-tabs-*`
- canonicalizes Tabs, tab-list, tab, tab-panels, and tab-panel selectors and owned emitters
- retains all unprefixed v1 class compatibility selectors without legacy token aliases
- preserves ARIA semantics, states, element registrations, and package exports
- adds explicit migration docs and focused coverage
- regenerates and inspects package output

Validation:
- `npm run lint`
- `npm run test:unit` (135 tests)
- `npm run ci:check`