### PR TITLE
Migration: Adopt UIF-prefixed naming for Radio

### DIFF
--- a/figma/exports/Patterns (UI).tokens.json
+++ b/figma/exports/Patterns (UI).tokens.json
@@ -2735,7 +2735,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--radio-text-color-default)"
+            "WEB": "var(--uif-radio-text-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:326",
@@ -2757,7 +2757,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--radio-text-color-disabled)"
+            "WEB": "var(--uif-radio-text-color-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:328",
@@ -2781,7 +2781,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--radio-border-color-default)"
+            "WEB": "var(--uif-radio-border-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:343",
@@ -2803,7 +2803,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--radio-border-color-hover)"
+            "WEB": "var(--uif-radio-border-color-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:345",
@@ -2825,7 +2825,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--radio-border-color-active)"
+            "WEB": "var(--uif-radio-border-color-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:345",
@@ -2847,7 +2847,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--radio-border-color-disabled)"
+            "WEB": "var(--uif-radio-border-color-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:346",
@@ -2869,7 +2869,7 @@
             "STROKE_FLOAT"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--radio-border-size-default)"
+            "WEB": "var(--uif-radio-border-size-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:7",
@@ -2891,7 +2891,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--radio-border-size-hover)"
+            "WEB": "var(--uif-radio-border-size-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:8",
@@ -2913,7 +2913,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--radio-border-size-disabled)"
+            "WEB": "var(--uif-radio-border-size-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:6",
@@ -2935,7 +2935,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--radio-border-color-focus)"
+            "WEB": "var(--uif-radio-border-color-focus)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:345",
@@ -2959,7 +2959,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--radio-container-background-default)"
+            "WEB": "var(--uif-radio-container-background-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:329",
@@ -2981,7 +2981,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--radio-container-background-disabled)"
+            "WEB": "var(--uif-radio-container-background-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:330",
@@ -3003,7 +3003,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--radio-container-background-hover)"
+            "WEB": "var(--uif-radio-container-background-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:329",

--- a/schemas/web-radio.figma.ts
+++ b/schemas/web-radio.figma.ts
@@ -6,7 +6,7 @@ figma.connect(
   {
     props: {
       className: figma.className([
-        "radio",
+        "uif-radio",
         figma.enum("State", {
           Default: undefined,
           Hover: "is-hover",
@@ -38,11 +38,11 @@ figma.connect(
   {
     props: {
       wrapperClassName: figma.className([
-        "radio-field",
+        "uif-radio-field",
         figma.boolean("Is Disabled", { true: "is-disabled", false: undefined }),
       ]),
       className: figma.className([
-        "radio",
+        "uif-radio",
         figma.boolean("Is Disabled", { true: "is-disabled", false: undefined }),
         "is-checked",
       ]),
@@ -64,7 +64,7 @@ figma.connect(
         checked="${checked}"
         disabled="${disabled}"
       />
-      <span class="radio-field-text">${text}</span>
+      <span class="uif-radio-field-text">${text}</span>
     </label>`,
   },
 );

--- a/site/_includes/layouts/docs.njk
+++ b/site/_includes/layouts/docs.njk
@@ -469,7 +469,7 @@
         }
         document.addEventListener("change", function (e) {
           var t = e.target;
-          if (t.matches && t.matches('.radio, .checkbox, .switch')) sync(t);
+          if (t.matches && t.matches('.uif-radio, .radio, .checkbox, .switch')) sync(t);
         });
       })();
     </script>

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -63,8 +63,8 @@
 {%- endmacro %}
 
 {% macro radio(label='Option', checked=false, disabled=false, state='default', className='', wrapperClassName='', id='', name='', value='') -%}
-{%- set radioClasses = "radio" -%}
-{%- set fieldClasses = "radio-field" -%}
+{%- set radioClasses = "uif-radio" -%}
+{%- set fieldClasses = "uif-radio-field" -%}
 {%- if checked -%}{%- set radioClasses = radioClasses + " is-checked" -%}{%- endif -%}
 {%- if state == "hover" -%}{%- set radioClasses = radioClasses + " is-hover" -%}{%- endif -%}
 {%- if state == "active" -%}{%- set radioClasses = radioClasses + " is-active" -%}{%- endif -%}
@@ -77,7 +77,7 @@
 {%- if wrapperClassName -%}{%- set fieldClasses = fieldClasses + " " + wrapperClassName -%}{%- endif -%}
 <label class="{{ fieldClasses }}">
   <input class="{{ radioClasses }}" type="radio"{% if id %} id="{{ id }}"{% endif %}{% if name %} name="{{ name }}"{% endif %}{% if value %} value="{{ value }}"{% endif %}{% if checked %} checked{% endif %}{% if disabled or state == "disabled" %} disabled{% endif %} />
-  <span class="radio-field-text">{{ label }}</span>
+  <span class="uif-radio-field-text">{{ label }}</span>
 </label>
 {%- endmacro %}
 

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -543,12 +543,12 @@
       asBoolean(props.disabled);
 
     const wrapper = document.createElement("label");
-    const wrapperClasses = ["radio-field"];
+    const wrapperClasses = ["uif-radio-field"];
     if (disabled) wrapperClasses.push("is-disabled");
     wrapper.className = wrapperClasses.join(" ");
 
     const input = document.createElement("input");
-    const inputClasses = ["radio"];
+    const inputClasses = ["uif-radio"];
     if (checked) inputClasses.push("is-checked");
     if (previewState === "hover") inputClasses.push("is-hover");
     if (previewState === "active") inputClasses.push("is-active");
@@ -561,7 +561,7 @@
     input.disabled = disabled;
 
     const text = document.createElement("span");
-    text.className = "radio-field-text";
+    text.className = "uif-radio-field-text";
     text.textContent = labelText;
 
     wrapper.append(input, text);
@@ -573,7 +573,7 @@
     if (checked) attrs.push("checked");
     if (disabled) attrs.push("disabled");
 
-    const code = `<label class="${quoteAttr(wrapper.className)}"><input ${attrs.join(" ")} /><span class="radio-field-text">${quoteAttr(labelText)}</span></label>`;
+    const code = `<label class="${quoteAttr(wrapper.className)}"><input ${attrs.join(" ")} /><span class="uif-radio-field-text">${quoteAttr(labelText)}</span></label>`;
     return { element: wrapper, code };
   };
 

--- a/site/patterns/radio.md
+++ b/site/patterns/radio.md
@@ -228,6 +228,10 @@ tokens. Use the hero preview switches above to see it in action.
 
 For the full theming architecture see [Foundations: Theming](/foundations/theming/).
 
+<h2 id="v1-naming-migration">v1 naming migration</h2>
+
+Radio emitters now produce `.uif-radio`, `.uif-radio-field`, and `.uif-radio-field-text`. The legacy `.radio` and `.radio-field` selectors remain supported during the v1 compatibility period. Component token slots are now `--uif-radio-*`; library-owned legacy `--radio-*` token aliases are not provided. The existing `<ui-radio>` registration and package export remain unchanged.
+
 <h2 id="design-checklist">Design checklist</h2>
 
 <div class="docs-checklist">

--- a/src/elements/ui-radio.js
+++ b/src/elements/ui-radio.js
@@ -28,7 +28,7 @@ class UIRadio extends UIElement {
       this.warnDev("[ui-foundations] <ui-radio> should have a label or aria-label.");
     }
 
-    const inputAttrs = ['type="radio"', 'class="radio"'];
+    const inputAttrs = ['type="radio"', 'class="uif-radio"'];
     if (checked) inputAttrs.push("checked");
     if (disabled) inputAttrs.push("disabled");
     if (name) inputAttrs.push(`name="${name}"`);
@@ -40,12 +40,12 @@ class UIRadio extends UIElement {
       return;
     }
 
-    const wrapperClasses = ["radio-field"];
+    const wrapperClasses = ["uif-radio-field"];
     if (disabled) wrapperClasses.push("is-disabled");
 
     this.innerHTML = `<label class="${wrapperClasses.join(" ")}">
   <input ${inputAttrs.join(" ")} />
-  <span class="radio-field-text">${label}</span>
+  <span class="uif-radio-field-text">${label}</span>
 </label>`;
   }
 }

--- a/src/ui/patterns/radio.css
+++ b/src/ui/patterns/radio.css
@@ -1,5 +1,5 @@
 @layer components {
-  .radio-field {
+  :is(.uif-radio-field, .radio-field) {
     display: inline-flex;
     align-items: center;
     gap: var(--typography-label-gap);
@@ -7,16 +7,16 @@
     font-weight: var(--typography-label-font-weight);
     font-size: var(--typography-label-font-size);
     line-height: var(--typography-label-line-height);
-    color: var(--radio-text-color-default);
+    color: var(--uif-radio-text-color-default);
     cursor: pointer;
   }
 
-  .radio-field.is-disabled {
-    color: var(--radio-text-color-disabled);
+  :is(.uif-radio-field, .radio-field).is-disabled {
+    color: var(--uif-radio-text-color-disabled);
     cursor: not-allowed;
   }
 
-  .radio {
+  :is(.uif-radio, .radio) {
     inline-size: var(--size-spacing-600);
     block-size: var(--size-spacing-600);
     margin: 0;
@@ -24,14 +24,14 @@
     display: inline-grid;
     place-content: center;
     border-style: solid;
-    border-width: var(--radio-border-size-default);
-    border-color: var(--radio-border-color-default);
+    border-width: var(--uif-radio-border-size-default);
+    border-color: var(--uif-radio-border-color-default);
     border-radius: var(--size-radius-full);
-    background: var(--radio-container-background-default);
+    background: var(--uif-radio-container-background-default);
     cursor: pointer;
   }
 
-  .radio::after {
+  :is(.uif-radio, .radio)::after {
     content: "";
     display: block;
     inline-size: 0;
@@ -41,67 +41,67 @@
     transition: all 120ms ease;
   }
 
-  .radio:checked,
-  .radio.is-checked {
-    border-color: var(--radio-border-color-active);
-    background: var(--radio-container-background-default);
+  :is(.uif-radio, .radio):checked,
+  :is(.uif-radio, .radio).is-checked {
+    border-color: var(--uif-radio-border-color-active);
+    background: var(--uif-radio-container-background-default);
   }
 
-  .radio:checked::after,
-  .radio.is-checked::after {
+  :is(.uif-radio, .radio):checked::after,
+  :is(.uif-radio, .radio).is-checked::after {
     inline-size: 0.5rem;
     block-size: 0.5rem;
-    background: var(--radio-border-color-active);
+    background: var(--uif-radio-border-color-active);
   }
 
-  .radio:hover,
-  .radio.is-hover {
+  :is(.uif-radio, .radio):hover,
+  :is(.uif-radio, .radio).is-hover {
     background:
       linear-gradient(0deg, var(--color-overlay-hover), var(--color-overlay-hover)),
-      var(--radio-container-background-hover);
-    border-color: var(--radio-border-color-hover);
-    border-width: var(--radio-border-size-hover);
+      var(--uif-radio-container-background-hover);
+    border-color: var(--uif-radio-border-color-hover);
+    border-width: var(--uif-radio-border-size-hover);
   }
 
-  .radio:checked:hover,
-  .radio.is-checked.is-hover {
+  :is(.uif-radio, .radio):checked:hover,
+  :is(.uif-radio, .radio).is-checked.is-hover {
     background:
       linear-gradient(0deg, var(--color-overlay-hover), var(--color-overlay-hover)),
-      var(--radio-container-background-default);
-    border-color: var(--radio-border-color-hover);
-    border-width: var(--radio-border-size-hover);
+      var(--uif-radio-container-background-default);
+    border-color: var(--uif-radio-border-color-hover);
+    border-width: var(--uif-radio-border-size-hover);
   }
 
-  .radio:active,
-  .radio.is-active {
+  :is(.uif-radio, .radio):active,
+  :is(.uif-radio, .radio).is-active {
     background:
       linear-gradient(0deg, var(--color-overlay-active), var(--color-overlay-active)),
-      var(--radio-container-background-default);
-    border-color: var(--radio-border-color-active);
+      var(--uif-radio-container-background-default);
+    border-color: var(--uif-radio-border-color-active);
     border-width: var(--size-border-200);
   }
 
-  .radio:checked:active,
-  .radio.is-checked.is-active {
+  :is(.uif-radio, .radio):checked:active,
+  :is(.uif-radio, .radio).is-checked.is-active {
     background:
       linear-gradient(0deg, var(--color-overlay-active), var(--color-overlay-active)),
-      var(--radio-container-background-default);
-    border-color: var(--radio-border-color-active);
+      var(--uif-radio-container-background-default);
+    border-color: var(--uif-radio-border-color-active);
   }
 
-  .radio:focus-visible,
-  .radio.is-focus-visible {
-    border-color: var(--radio-border-color-focus);
+  :is(.uif-radio, .radio):focus-visible,
+  :is(.uif-radio, .radio).is-focus-visible {
+    border-color: var(--uif-radio-border-color-focus);
     outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
-  .radio:disabled,
-  .radio.is-disabled {
-    border-width: var(--radio-border-size-disabled);
-    border-color: var(--radio-border-color-disabled);
-    background: var(--radio-container-background-disabled);
-    color: var(--radio-text-color-disabled);
+  :is(.uif-radio, .radio):disabled,
+  :is(.uif-radio, .radio).is-disabled {
+    border-width: var(--uif-radio-border-size-disabled);
+    border-color: var(--uif-radio-border-color-disabled);
+    background: var(--uif-radio-container-background-disabled);
+    color: var(--uif-radio-text-color-disabled);
     cursor: not-allowed;
   }
 }

--- a/tests/radio-naming-migration.test.mjs
+++ b/tests/radio-naming-migration.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("Radio CSS exposes canonical UIF naming with v1 class aliases", async () => {
+  const css = await read("src/ui/patterns/radio.css");
+  for (const name of ["radio", "radio-field"]) assert.match(css, new RegExp(`:is\\(\\.uif-${name}, \\.${name}\\)`));
+  assert.match(css, /var\(--uif-radio-/);
+  assert.doesNotMatch(css, /var\(--radio-/);
+  assert.doesNotMatch(css, /\.uif-radio(?:__|--)/);
+});
+
+test("Radio Figma export contains canonical tokens without legacy aliases", async () => {
+  const tokenExport = await read("figma/exports/Patterns (UI).tokens.json");
+  assert.equal((tokenExport.match(/var\(--uif-radio-/g) ?? []).length, 13);
+  assert.doesNotMatch(tokenExport, /var\(--radio-/);
+});
+
+test("Radio-owned emitters and behavior use canonical classes", async () => {
+  const [element, macros, renderer, schema, behavior] = await Promise.all([
+    read("src/elements/ui-radio.js"), read("site/_includes/macros/ui.njk"),
+    read("site/assets/playground/renderers.js"), read("schemas/web-radio.figma.ts"),
+    read("site/_includes/layouts/docs.njk"),
+  ]);
+  for (const source of [element, macros, renderer, schema]) assert.match(source, /uif-radio/);
+  assert.match(behavior, /\.uif-radio, \.radio/);
+  assert.doesNotMatch(element, /class="radio(?:[-\s"])/);
+});
+
+test("Radio docs explain migration while registration stays stable", async () => {
+  const [documentation, element] = await Promise.all([read("site/patterns/radio.md"), read("src/elements/ui-radio.js")]);
+  assert.match(documentation, /legacy `--radio-\*` token aliases are not provided/);
+  assert.match(element, /define\("ui-radio", UIRadio\)/);
+});


### PR DESCRIPTION
Closes #181

Wave 3 Radio migration under #156.

- migrates all 13 Radio Figma WEB mappings/export entries to `--uif-radio-*`
- canonicalizes Radio, field wrapper, and field-text owned emitters
- retains v1 `.radio`/`.radio-field` selector and behavior compatibility
- preserves native radio semantics, states, element registration, and exports
- documents the migration and adds focused coverage
- regenerates/inspects package output

Validation: lint; 139 unit tests; ci:check.