### PR TITLE
Migration: Adopt UIF-prefixed naming for Badge

### DIFF
--- a/figma/exports/Patterns (UI).tokens.json
+++ b/figma/exports/Patterns (UI).tokens.json
@@ -3029,7 +3029,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--badge-default-text-color)"
+            "WEB": "var(--uif-badge-default-text-color)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:326",
@@ -3051,7 +3051,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--badge-default-border-color)"
+            "WEB": "var(--uif-badge-default-border-color)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2006:195",
@@ -3074,7 +3074,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--badge-default-container-background)"
+              "WEB": "var(--uif-badge-default-container-background)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:338",
@@ -3099,7 +3099,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--badge-brand-text-color)"
+            "WEB": "var(--uif-badge-brand-text-color)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2616:2",
@@ -3121,7 +3121,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--badge-brand-border-color)"
+            "WEB": "var(--uif-badge-brand-border-color)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2006:195",
@@ -3144,7 +3144,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--badge-brand-container-background)"
+              "WEB": "var(--uif-badge-brand-container-background)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:337",
@@ -3169,7 +3169,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--badge-success-text-color)"
+            "WEB": "var(--uif-badge-success-text-color)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2616:4",
@@ -3191,7 +3191,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--badge-success-border-color)"
+            "WEB": "var(--uif-badge-success-border-color)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2006:195",
@@ -3214,7 +3214,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--badge-success-container-background)"
+              "WEB": "var(--uif-badge-success-container-background)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:376",
@@ -3238,7 +3238,7 @@
           "FONT_FAMILY"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--badge-font-family)"
+          "WEB": "var(--uif-badge-font-family)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:2006:214",
@@ -3260,7 +3260,7 @@
           "FONT_STYLE"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--badge-font-weight)"
+          "WEB": "var(--uif-badge-font-weight)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3014:8",
@@ -3282,7 +3282,7 @@
           "STROKE_FLOAT"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--badge-border-size-default)"
+          "WEB": "var(--uif-badge-border-size-default)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:7",
@@ -3304,7 +3304,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--badge-border-radius)"
+          "WEB": "var(--uif-badge-border-radius)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:1:251",
@@ -3326,7 +3326,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--badge-padding-inline-md)"
+          "WEB": "var(--uif-badge-padding-inline-md)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:4",
@@ -3348,7 +3348,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--badge-padding-inline-icon-only)"
+          "WEB": "var(--uif-badge-padding-inline-icon-only)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:3",
@@ -3370,7 +3370,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--badge-padding-block-md)"
+          "WEB": "var(--uif-badge-padding-block-md)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:2",
@@ -3392,7 +3392,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--badge-gap)"
+          "WEB": "var(--uif-badge-gap)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:2",
@@ -3414,7 +3414,7 @@
           "WIDTH_HEIGHT"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--badge-height-min)"
+          "WEB": "var(--uif-badge-height-min)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3020:2",
@@ -3436,7 +3436,7 @@
           "WIDTH_HEIGHT"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--badge-width-min)"
+          "WEB": "var(--uif-badge-width-min)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3020:2",
@@ -3460,7 +3460,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--badge-danger-container-background)"
+              "WEB": "var(--uif-badge-danger-container-background)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:357",
@@ -3483,7 +3483,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--badge-danger-text-color)"
+            "WEB": "var(--uif-badge-danger-text-color)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2616:3",
@@ -3505,7 +3505,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--badge-danger-border-color)"
+            "WEB": "var(--uif-badge-danger-border-color)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2006:195",
@@ -3526,7 +3526,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--badge-font-size-sm)"
+          "WEB": "var(--uif-badge-font-size-sm)"
         }
       }
     },
@@ -3539,7 +3539,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--badge-font-size-md)"
+          "WEB": "var(--uif-badge-font-size-md)"
         }
       }
     },
@@ -3552,7 +3552,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--badge-line-height-sm)"
+          "WEB": "var(--uif-badge-line-height-sm)"
         }
       }
     },
@@ -3565,7 +3565,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--badge-line-height-md)"
+          "WEB": "var(--uif-badge-line-height-md)"
         }
       }
     },
@@ -3578,7 +3578,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--badge-padding-inline-sm)"
+          "WEB": "var(--uif-badge-padding-inline-sm)"
         }
       }
     },
@@ -3591,7 +3591,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--badge-padding-block-sm)"
+          "WEB": "var(--uif-badge-padding-block-sm)"
         }
       }
     }

--- a/schemas/web-badge.figma.ts
+++ b/schemas/web-badge.figma.ts
@@ -6,7 +6,7 @@ figma.connect(
   {
     props: {
       className: figma.className([
-        "badge",
+        "uif-badge",
         figma.enum("Variant", {
           Default: undefined,
           Brand: "brand",
@@ -21,6 +21,6 @@ figma.connect(
       text: figma.string("Text"),
     },
     example: ({ className, text }: BadgeProps) =>
-      html`<span class="${className}"><span class="badge-text">${text}</span></span>`,
+      html`<span class="${className}"><span class="uif-badge-text">${text}</span></span>`,
   },
 );

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -146,12 +146,12 @@
 {%- endmacro %}
 
 {% macro badge(text, variant='', size='', startIcon='') -%}
-{%- set classes = "badge" -%}
+{%- set classes = "uif-badge" -%}
 {%- if variant -%}{%- set classes = classes + " " + variant -%}{%- endif -%}
 {%- if size == "sm" -%}{%- set classes = classes + " sm" -%}{%- endif -%}
 <span class="{{ classes }}">
   {%- if startIcon %}<span class="uif-icon" style="--uif-icon-src: url('/assets/icons/{{ startIcon }}.svg');" aria-hidden="true"></span>{% endif -%}
-  <span class="badge-text">{{ text }}</span>
+  <span class="uif-badge-text">{{ text }}</span>
 </span>
 {%- endmacro %}
 

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -585,7 +585,7 @@
       typeof children === "undefined" ? "Badge" : String(children || "");
 
     const element = document.createElement("span");
-    const classes = ["badge"];
+    const classes = ["uif-badge"];
     if (variant && variant !== "default") classes.push(variant);
     if (size === "sm") classes.push("sm");
     element.className = classes.join(" ");
@@ -596,13 +596,13 @@
     }
 
     const textSpan = document.createElement("span");
-    textSpan.className = "badge-text";
+    textSpan.className = "uif-badge-text";
     textSpan.textContent = rawText;
     element.append(textSpan);
 
     const codeClasses = classes.map((c) => quoteAttr(c)).join(" ");
     const iconMarkup = startIcon ? iconCode({ name: startIcon, decorative: true }) : "";
-    const code = `<span class="${codeClasses}">${iconMarkup}<span class="badge-text">${quoteAttr(rawText)}</span></span>`;
+    const code = `<span class="${codeClasses}">${iconMarkup}<span class="uif-badge-text">${quoteAttr(rawText)}</span></span>`;
 
     return { element, code };
   };

--- a/site/examples/pricing.md
+++ b/site/examples/pricing.md
@@ -47,7 +47,7 @@ breadcrumb:
     position: relative;
   }
 
-  .pricing-card--recommended > .badge {
+  .pricing-card--recommended > .uif-badge {
     position: absolute;
     inset-block-start: 0;
     inset-inline-start: 50%;

--- a/site/patterns/badge.md
+++ b/site/patterns/badge.md
@@ -157,6 +157,10 @@ Badge adapts across brands and modes through semantic tokens. Use the hero switc
 
 For the full theming architecture see [Foundations: Theming](/foundations/theming/).
 
+<h2 id="v1-naming-migration">v1 naming migration</h2>
+
+Badge emitters now produce `.uif-badge` and `.uif-badge-text`. The legacy `.badge` selector remains supported during the v1 compatibility period. Component token slots are now `--uif-badge-*`; library-owned legacy `--badge-*` token aliases are not provided. The existing `<ui-badge>` registration and package export remain unchanged.
+
 <h2 id="design-checklist">Design checklist</h2>
 
 <div class="docs-checklist">

--- a/src/elements/ui-badge.js
+++ b/src/elements/ui-badge.js
@@ -20,7 +20,7 @@ class UIBadge extends UIElement {
     const startIcon = this.getAttr("start-icon");
     const text = this.textContent.trim();
 
-    const classes = ["badge"];
+    const classes = ["uif-badge"];
     if (variant && variant !== "default") classes.push(variant);
     if (size === "sm") classes.push("sm");
 
@@ -29,7 +29,7 @@ class UIBadge extends UIElement {
       inner += `<span class="uif-icon" style="--uif-icon-src: url('/assets/icons/${startIcon}.svg')" aria-hidden="true"></span>`;
     }
     if (text) {
-      inner += `<span class="badge-text">${text}</span>`;
+      inner += `<span class="uif-badge-text">${text}</span>`;
     }
 
     this.innerHTML = `<span class="${classes.join(" ")}">${inner}</span>`;

--- a/src/ui/patterns/badge.css
+++ b/src/ui/patterns/badge.css
@@ -1,68 +1,68 @@
 @layer components {
-  .badge {
+  :is(.uif-badge, .badge) {
     display: inline-flex;
     align-items: center;
-    gap: var(--badge-gap, 0.25rem);
-    border: var(--badge-border-size-default) solid var(--badge-default-border-color);
-    border-radius: var(--badge-border-radius, 625rem);
-    font-family: var(--badge-font-family, inherit);
-    font-weight: var(--badge-font-weight, 700);
+    gap: var(--uif-badge-gap, 0.25rem);
+    border: var(--uif-badge-border-size-default) solid var(--uif-badge-default-border-color);
+    border-radius: var(--uif-badge-border-radius, 625rem);
+    font-family: var(--uif-badge-font-family, inherit);
+    font-weight: var(--uif-badge-font-weight, 700);
     white-space: nowrap;
-    background: var(--badge-default-container-background);
-    color: var(--badge-default-text-color);
-    font-size: var(--badge-font-size-md);
-    line-height: var(--badge-line-height-md);
-    padding-inline: var(--badge-padding-inline-md);
-    padding-block: var(--badge-padding-block-md);
-    min-block-size: var(--badge-height-min);
-    min-inline-size: var(--badge-width-min);
+    background: var(--uif-badge-default-container-background);
+    color: var(--uif-badge-default-text-color);
+    font-size: var(--uif-badge-font-size-md);
+    line-height: var(--uif-badge-line-height-md);
+    padding-inline: var(--uif-badge-padding-inline-md);
+    padding-block: var(--uif-badge-padding-block-md);
+    min-block-size: var(--uif-badge-height-min);
+    min-inline-size: var(--uif-badge-width-min);
   }
 
   /* ── Sizes ── */
 
-  .badge.sm {
-    font-size: var(--badge-font-size-sm);
-    line-height: var(--badge-line-height-sm);
-    padding-inline: var(--badge-padding-inline-sm);
-    padding-block: var(--badge-padding-block-sm);
+  :is(.uif-badge, .badge).sm {
+    font-size: var(--uif-badge-font-size-sm);
+    line-height: var(--uif-badge-line-height-sm);
+    padding-inline: var(--uif-badge-padding-inline-sm);
+    padding-block: var(--uif-badge-padding-block-sm);
   }
 
   /* ── Variants ── */
 
-  .badge.brand {
-    background: var(--badge-brand-container-background);
-    color: var(--badge-brand-text-color);
-    border-color: var(--badge-brand-border-color);
+  :is(.uif-badge, .badge).brand {
+    background: var(--uif-badge-brand-container-background);
+    color: var(--uif-badge-brand-text-color);
+    border-color: var(--uif-badge-brand-border-color);
   }
 
-  .badge.success {
-    background: var(--badge-success-container-background);
-    color: var(--badge-success-text-color);
-    border-color: var(--badge-success-border-color);
+  :is(.uif-badge, .badge).success {
+    background: var(--uif-badge-success-container-background);
+    color: var(--uif-badge-success-text-color);
+    border-color: var(--uif-badge-success-border-color);
   }
 
-  .badge.danger {
-    background: var(--badge-danger-container-background);
-    color: var(--badge-danger-text-color);
-    border-color: var(--badge-danger-border-color);
+  :is(.uif-badge, .badge).danger {
+    background: var(--uif-badge-danger-container-background);
+    color: var(--uif-badge-danger-text-color);
+    border-color: var(--uif-badge-danger-border-color);
   }
 
   /* ── Icon-only ── */
 
-  .badge.icon-only {
-    padding-inline: var(--badge-padding-inline-icon-only);
+  :is(.uif-badge, .badge).icon-only {
+    padding-inline: var(--uif-badge-padding-inline-icon-only);
     justify-content: center;
   }
 
   /* ── Icon slot ── */
 
-  .badge > :is(.uif-icon, .icon) {
+  :is(.uif-badge, .badge) > :is(.uif-icon, .icon) {
     flex: 0 0 auto;
   }
 
   /* ── Ensure children inherit color over base :where(span) rule ── */
 
-  .badge > * {
+  :is(.uif-badge, .badge) > * {
     color: inherit;
   }
 }

--- a/tests/badge-naming-migration.test.mjs
+++ b/tests/badge-naming-migration.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("Badge CSS exposes canonical UIF naming with a v1 class alias", async () => {
+  const css = await read("src/ui/patterns/badge.css");
+  assert.match(css, /:is\(\.uif-badge, \.badge\)/);
+  assert.match(css, /var\(--uif-badge-/);
+  assert.doesNotMatch(css, /var\(--badge-/);
+  assert.doesNotMatch(css, /\.uif-badge(?:__|--)/);
+});
+
+test("Badge Figma export contains canonical tokens without legacy aliases", async () => {
+  const tokenExport = await read("figma/exports/Patterns (UI).tokens.json");
+  assert.equal((tokenExport.match(/var\(--uif-badge-/g) ?? []).length, 28);
+  assert.doesNotMatch(tokenExport, /var\(--badge-/);
+});
+
+test("Badge-owned emitters use canonical classes", async () => {
+  const sources = await Promise.all([
+    read("src/elements/ui-badge.js"),
+    read("site/_includes/macros/ui.njk"),
+    read("site/assets/playground/renderers.js"),
+    read("schemas/web-badge.figma.ts"),
+  ]);
+  for (const source of sources) assert.match(source, /uif-badge/);
+  assert.doesNotMatch(sources[0], /class="badge(?:[-\s"])/);
+});
+
+test("Badge docs explain migration while registration stays stable", async () => {
+  const [documentation, element] = await Promise.all([
+    read("site/patterns/badge.md"),
+    read("src/elements/ui-badge.js"),
+  ]);
+  assert.match(documentation, /legacy `--badge-\*` token aliases are not provided/);
+  assert.match(element, /define\("ui-badge", UIBadge\)/);
+});


### PR DESCRIPTION
Closes #183

## Summary
- update all Badge Figma `codeSyntax.WEB` entries and the checked-in export to canonical `--uif-badge-*` token names
- emit canonical `.uif-badge` and `.uif-badge-text` classes while retaining the legacy `.badge` CSS compatibility selector
- update Code Connect, playground output, examples, documentation, and migration coverage
- keep `<ui-badge>` registration and package exports stable; provide no legacy token aliases

## Validation
- `npm run lint`
- `npm run test:unit`
- `npm run ci:check`