### PR TITLE
Migration: Adopt UIF-prefixed naming for Checkbox

### DIFF
--- a/figma/exports/Patterns (UI).tokens.json
+++ b/figma/exports/Patterns (UI).tokens.json
@@ -2309,7 +2309,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-text-color-default)"
+            "WEB": "var(--uif-checkbox-text-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:326",
@@ -2331,7 +2331,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-text-color-hover)"
+            "WEB": "var(--uif-checkbox-text-color-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:340",
@@ -2353,7 +2353,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-text-color-active)"
+            "WEB": "var(--uif-checkbox-text-color-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2616:2",
@@ -2375,7 +2375,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-text-color-disabled)"
+            "WEB": "var(--uif-checkbox-text-color-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:328",
@@ -2399,7 +2399,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-border-color-default)"
+            "WEB": "var(--uif-checkbox-border-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:343",
@@ -2421,7 +2421,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-border-color-hover)"
+            "WEB": "var(--uif-checkbox-border-color-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:345",
@@ -2443,7 +2443,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-border-color-active)"
+            "WEB": "var(--uif-checkbox-border-color-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:345",
@@ -2465,7 +2465,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-border-color-focus)"
+            "WEB": "var(--uif-checkbox-border-color-focus)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:345",
@@ -2487,7 +2487,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-border-color-invalid)"
+            "WEB": "var(--uif-checkbox-border-color-invalid)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:356",
@@ -2509,7 +2509,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-border-color-valid)"
+            "WEB": "var(--uif-checkbox-border-color-valid)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:344",
@@ -2531,7 +2531,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-border-color-disabled)"
+            "WEB": "var(--uif-checkbox-border-color-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:346",
@@ -2553,7 +2553,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-border-size-hover)"
+            "WEB": "var(--uif-checkbox-border-size-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:8",
@@ -2575,7 +2575,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-border-size-disabled)"
+            "WEB": "var(--uif-checkbox-border-size-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:6",
@@ -2597,7 +2597,7 @@
             "STROKE_FLOAT"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-border-size-default)"
+            "WEB": "var(--uif-checkbox-border-size-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:7",
@@ -2621,7 +2621,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-container-background-default)"
+            "WEB": "var(--uif-checkbox-container-background-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:329",
@@ -2643,7 +2643,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-container-background-hover)"
+            "WEB": "var(--uif-checkbox-container-background-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:329",
@@ -2665,7 +2665,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-container-background-focus)"
+            "WEB": "var(--uif-checkbox-container-background-focus)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:329",
@@ -2687,7 +2687,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-container-background-active)"
+            "WEB": "var(--uif-checkbox-container-background-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:337",
@@ -2709,7 +2709,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--checkbox-container-background-disabled)"
+            "WEB": "var(--uif-checkbox-container-background-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:330",

--- a/schemas/web-checkbox.figma.ts
+++ b/schemas/web-checkbox.figma.ts
@@ -6,7 +6,7 @@ figma.connect(
   {
     props: {
       className: figma.className([
-        "checkbox",
+        "uif-checkbox",
         figma.enum("Checked", {
           Unchecked: undefined,
           Checked: "is-checked",
@@ -56,11 +56,11 @@ figma.connect(
   {
     props: {
       wrapperClassName: figma.className([
-        "checkbox-field",
+        "uif-checkbox-field",
         figma.boolean("Is Disabled", { true: "is-disabled", false: undefined }),
       ]),
       className: figma.className([
-        "checkbox",
+        "uif-checkbox",
         figma.enum("State", {
           Default: undefined,
           Hover: "is-hover",
@@ -86,7 +86,7 @@ figma.connect(
         checked="${checked}"
         disabled="${disabled}"
       />
-      <span class="checkbox-field-text">${text}</span>
+      <span class="uif-checkbox-field-text">${text}</span>
     </label>`,
   },
 );

--- a/site/_includes/layouts/docs.njk
+++ b/site/_includes/layouts/docs.njk
@@ -469,7 +469,7 @@
         }
         document.addEventListener("change", function (e) {
           var t = e.target;
-          if (t.matches && t.matches('.uif-radio, .radio, .checkbox, .switch')) sync(t);
+          if (t.matches && t.matches('.uif-radio, .radio, .uif-checkbox, .checkbox, .switch')) sync(t);
         });
       })();
     </script>

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -43,8 +43,8 @@
 {%- endmacro %}
 
 {% macro checkbox(label='Checkbox', checked=false, disabled=false, state='default', indeterminate=false, className='', wrapperClassName='', id='', name='', value='on') -%}
-{%- set checkboxClasses = "checkbox" -%}
-{%- set fieldClasses = "checkbox-field" -%}
+{%- set checkboxClasses = "uif-checkbox" -%}
+{%- set fieldClasses = "uif-checkbox-field" -%}
 {%- if checked -%}{%- set checkboxClasses = checkboxClasses + " is-checked" -%}{%- endif -%}
 {%- if indeterminate or state == "indeterminate" -%}{%- set checkboxClasses = checkboxClasses + " is-indeterminate" -%}{%- endif -%}
 {%- if state == "hover" -%}{%- set checkboxClasses = checkboxClasses + " is-hover" -%}{%- endif -%}
@@ -58,7 +58,7 @@
 {%- if wrapperClassName -%}{%- set fieldClasses = fieldClasses + " " + wrapperClassName -%}{%- endif -%}
 <label class="{{ fieldClasses }}">
   <input class="{{ checkboxClasses }}" type="checkbox"{% if id %} id="{{ id }}"{% endif %}{% if name %} name="{{ name }}"{% endif %}{% if value %} value="{{ value }}"{% endif %}{% if checked %} checked{% endif %}{% if indeterminate or state == "indeterminate" %} aria-checked="mixed"{% endif %}{% if disabled or state == "disabled" %} disabled{% endif %} />
-  <span class="checkbox-field-text">{{ label }}</span>
+  <span class="uif-checkbox-field-text">{{ label }}</span>
 </label>
 {%- endmacro %}
 

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -377,12 +377,12 @@
       asBoolean(props.disabled);
 
     const wrapper = document.createElement("label");
-    const wrapperClasses = ["checkbox-field"];
+    const wrapperClasses = ["uif-checkbox-field"];
     if (disabled) wrapperClasses.push("is-disabled");
     wrapper.className = wrapperClasses.join(" ");
 
     const input = document.createElement("input");
-    const inputClasses = ["checkbox"];
+    const inputClasses = ["uif-checkbox"];
     if (checked) inputClasses.push("is-checked");
     if (indeterminate) inputClasses.push("is-indeterminate");
     if (previewState === "hover") inputClasses.push("is-hover");
@@ -398,7 +398,7 @@
     if (indeterminate) input.setAttribute("aria-checked", "mixed");
 
     const text = document.createElement("span");
-    text.className = "checkbox-field-text";
+    text.className = "uif-checkbox-field-text";
     text.textContent = labelText;
 
     wrapper.append(input, text);
@@ -411,7 +411,7 @@
     if (indeterminate) attrs.push('aria-checked="mixed"');
     if (disabled) attrs.push("disabled");
 
-    const code = `<label class="${quoteAttr(wrapper.className)}"><input ${attrs.join(" ")} /><span class="checkbox-field-text">${quoteAttr(labelText)}</span></label>`;
+    const code = `<label class="${quoteAttr(wrapper.className)}"><input ${attrs.join(" ")} /><span class="uif-checkbox-field-text">${quoteAttr(labelText)}</span></label>`;
     return { element: wrapper, code };
   };
 

--- a/site/examples/vanilla-starter.md
+++ b/site/examples/vanilla-starter.md
@@ -40,7 +40,7 @@ import "ui-foundations/tokens/components.css";
 
 ## 3. Render an example page
 
-Use package classes like `.uif-button`, `.uif-input`, `.uif-field-label`, and `.checkbox`.
+Use package classes like `.uif-button`, `.uif-input`, `.uif-field-label`, and `.uif-checkbox`.
 
 ```js
 document.querySelector("#app").innerHTML = `

--- a/site/patterns/checkbox.md
+++ b/site/patterns/checkbox.md
@@ -252,6 +252,10 @@ tokens. Use the hero preview switches above to see it in action.
 
 For the full theming architecture see [Foundations: Theming](/foundations/theming/).
 
+<h2 id="v1-naming-migration">v1 naming migration</h2>
+
+Checkbox emitters now produce `.uif-checkbox`, `.uif-checkbox-field`, and `.uif-checkbox-field-text`. The legacy `.checkbox` and `.checkbox-field` selectors remain supported during the v1 compatibility period. Component token slots are now `--uif-checkbox-*`; library-owned legacy `--checkbox-*` token aliases are not provided. The existing `<ui-checkbox>` registration and package export remain unchanged.
+
 <h2 id="design-checklist">Design checklist</h2>
 
 <div class="docs-checklist">

--- a/src/elements/ui-checkbox.js
+++ b/src/elements/ui-checkbox.js
@@ -29,7 +29,7 @@ class UICheckbox extends UIElement {
       this.warnDev("[ui-foundations] <ui-checkbox> should have a label or aria-label.");
     }
 
-    const inputAttrs = ['type="checkbox"', 'class="checkbox"'];
+    const inputAttrs = ['type="checkbox"', 'class="uif-checkbox"'];
     if (checked) inputAttrs.push("checked");
     if (disabled) inputAttrs.push("disabled");
     if (name) inputAttrs.push(`name="${name}"`);
@@ -41,12 +41,12 @@ class UICheckbox extends UIElement {
       return;
     }
 
-    const wrapperClasses = ["checkbox-field"];
+    const wrapperClasses = ["uif-checkbox-field"];
     if (disabled) wrapperClasses.push("is-disabled");
 
     this.innerHTML = `<label class="${wrapperClasses.join(" ")}">
   <input ${inputAttrs.join(" ")} />
-  <span class="checkbox-field-text">${label}</span>
+  <span class="uif-checkbox-field-text">${label}</span>
 </label>`;
   }
 }

--- a/src/ui/patterns/checkbox.css
+++ b/src/ui/patterns/checkbox.css
@@ -1,5 +1,5 @@
 @layer components {
-  .checkbox-field {
+  :is(.uif-checkbox-field, .checkbox-field) {
     display: inline-flex;
     align-items: center;
     gap: var(--typography-label-gap);
@@ -7,16 +7,16 @@
     font-weight: var(--typography-label-font-weight);
     font-size: var(--typography-label-font-size);
     line-height: var(--typography-label-line-height);
-    color: var(--checkbox-text-color-default);
+    color: var(--uif-checkbox-text-color-default);
     cursor: pointer;
   }
 
-  .checkbox-field.is-disabled {
-    color: var(--checkbox-text-color-disabled);
+  :is(.uif-checkbox-field, .checkbox-field).is-disabled {
+    color: var(--uif-checkbox-text-color-disabled);
     cursor: not-allowed;
   }
 
-  .checkbox {
+  :is(.uif-checkbox, .checkbox) {
     inline-size: var(--size-spacing-600);
     block-size: var(--size-spacing-600);
     margin: 0;
@@ -24,27 +24,27 @@
     display: inline-grid;
     place-content: center;
     border-style: solid;
-    border-width: var(--checkbox-border-size-default);
-    border-color: var(--checkbox-border-color-default);
+    border-width: var(--uif-checkbox-border-size-default);
+    border-color: var(--uif-checkbox-border-color-default);
     border-radius: var(--brand-corner-input);
-    background: var(--checkbox-container-background-default);
-    color: var(--checkbox-text-color-active);
+    background: var(--uif-checkbox-container-background-default);
+    color: var(--uif-checkbox-text-color-active);
     cursor: pointer;
   }
 
-  .checkbox::after {
+  :is(.uif-checkbox, .checkbox)::after {
     content: "";
     display: block;
   }
 
-  .checkbox:checked,
-  .checkbox.is-checked {
-    border-color: var(--checkbox-border-color-active);
-    background: var(--checkbox-container-background-active);
+  :is(.uif-checkbox, .checkbox):checked,
+  :is(.uif-checkbox, .checkbox).is-checked {
+    border-color: var(--uif-checkbox-border-color-active);
+    background: var(--uif-checkbox-container-background-active);
   }
 
-  .checkbox:checked::after,
-  .checkbox.is-checked::after {
+  :is(.uif-checkbox, .checkbox):checked::after,
+  :is(.uif-checkbox, .checkbox).is-checked::after {
     content: "";
     inline-size: 0.75em;
     block-size: 0.75em;
@@ -59,88 +59,88 @@
     mask-position: center;
   }
 
-  .checkbox:indeterminate,
-  .checkbox.is-indeterminate {
-    border-color: var(--checkbox-border-color-active);
-    background: var(--checkbox-container-background-active);
+  :is(.uif-checkbox, .checkbox):indeterminate,
+  :is(.uif-checkbox, .checkbox).is-indeterminate {
+    border-color: var(--uif-checkbox-border-color-active);
+    background: var(--uif-checkbox-container-background-active);
   }
 
-  .checkbox:indeterminate::after,
-  .checkbox.is-indeterminate::after {
+  :is(.uif-checkbox, .checkbox):indeterminate::after,
+  :is(.uif-checkbox, .checkbox).is-indeterminate::after {
     inline-size: 0.75rem;
     block-size: var(--size-border-200);
     border-radius: var(--size-radius-full);
     background: currentColor;
   }
 
-  .checkbox:hover,
-  .checkbox.is-hover {
+  :is(.uif-checkbox, .checkbox):hover,
+  :is(.uif-checkbox, .checkbox).is-hover {
     background:
       linear-gradient(0deg, var(--color-overlay-hover), var(--color-overlay-hover)),
-      var(--checkbox-container-background-hover);
-    color: var(--checkbox-text-color-hover);
-    border-color: var(--checkbox-border-color-hover);
-    border-width: var(--checkbox-border-size-hover);
+      var(--uif-checkbox-container-background-hover);
+    color: var(--uif-checkbox-text-color-hover);
+    border-color: var(--uif-checkbox-border-color-hover);
+    border-width: var(--uif-checkbox-border-size-hover);
   }
 
-  .checkbox:checked:hover,
-  .checkbox.is-checked.is-hover {
+  :is(.uif-checkbox, .checkbox):checked:hover,
+  :is(.uif-checkbox, .checkbox).is-checked.is-hover {
     background:
       linear-gradient(0deg, var(--color-overlay-hover), var(--color-overlay-hover)),
-      var(--checkbox-container-background-active);
-    color: var(--checkbox-text-color-hover);
-    border-color: var(--checkbox-border-color-hover);
-    border-width: var(--checkbox-border-size-hover);
+      var(--uif-checkbox-container-background-active);
+    color: var(--uif-checkbox-text-color-hover);
+    border-color: var(--uif-checkbox-border-color-hover);
+    border-width: var(--uif-checkbox-border-size-hover);
   }
 
-  .checkbox:indeterminate:hover,
-  .checkbox.is-indeterminate.is-hover {
+  :is(.uif-checkbox, .checkbox):indeterminate:hover,
+  :is(.uif-checkbox, .checkbox).is-indeterminate.is-hover {
     background:
       linear-gradient(0deg, var(--color-overlay-hover), var(--color-overlay-hover)),
-      var(--checkbox-container-background-active);
-    color: var(--checkbox-text-color-hover);
-    border-color: var(--checkbox-border-color-hover);
-    border-width: var(--checkbox-border-size-hover);
+      var(--uif-checkbox-container-background-active);
+    color: var(--uif-checkbox-text-color-hover);
+    border-color: var(--uif-checkbox-border-color-hover);
+    border-width: var(--uif-checkbox-border-size-hover);
   }
 
-  .checkbox:active,
-  .checkbox.is-active {
+  :is(.uif-checkbox, .checkbox):active,
+  :is(.uif-checkbox, .checkbox).is-active {
     background:
       linear-gradient(0deg, var(--color-overlay-active), var(--color-overlay-active)),
-      var(--checkbox-container-background-default);
-    border-color: var(--checkbox-border-color-active);
+      var(--uif-checkbox-container-background-default);
+    border-color: var(--uif-checkbox-border-color-active);
     border-width: var(--size-border-200);
   }
 
-  .checkbox:checked:active,
-  .checkbox.is-checked.is-active {
+  :is(.uif-checkbox, .checkbox):checked:active,
+  :is(.uif-checkbox, .checkbox).is-checked.is-active {
     background:
       linear-gradient(0deg, var(--color-overlay-active), var(--color-overlay-active)),
-      var(--checkbox-container-background-active);
-    border-color: var(--checkbox-border-color-active);
+      var(--uif-checkbox-container-background-active);
+    border-color: var(--uif-checkbox-border-color-active);
   }
 
-  .checkbox:indeterminate:active,
-  .checkbox.is-indeterminate.is-active {
+  :is(.uif-checkbox, .checkbox):indeterminate:active,
+  :is(.uif-checkbox, .checkbox).is-indeterminate.is-active {
     background:
       linear-gradient(0deg, var(--color-overlay-active), var(--color-overlay-active)),
-      var(--checkbox-container-background-active);
-    border-color: var(--checkbox-border-color-active);
+      var(--uif-checkbox-container-background-active);
+    border-color: var(--uif-checkbox-border-color-active);
   }
 
-  .checkbox:focus-visible,
-  .checkbox.is-focus-visible {
-    border-color: var(--checkbox-border-color-focus);
+  :is(.uif-checkbox, .checkbox):focus-visible,
+  :is(.uif-checkbox, .checkbox).is-focus-visible {
+    border-color: var(--uif-checkbox-border-color-focus);
     outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
-  .checkbox:disabled,
-  .checkbox.is-disabled {
-    border-width: var(--checkbox-border-size-disabled);
-    border-color: var(--checkbox-border-color-disabled);
-    background: var(--checkbox-container-background-disabled);
-    color: var(--checkbox-text-color-disabled);
+  :is(.uif-checkbox, .checkbox):disabled,
+  :is(.uif-checkbox, .checkbox).is-disabled {
+    border-width: var(--uif-checkbox-border-size-disabled);
+    border-color: var(--uif-checkbox-border-color-disabled);
+    background: var(--uif-checkbox-container-background-disabled);
+    color: var(--uif-checkbox-text-color-disabled);
     cursor: not-allowed;
   }
 }

--- a/tests/checkbox-naming-migration.test.mjs
+++ b/tests/checkbox-naming-migration.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("Checkbox CSS exposes canonical UIF naming with v1 class aliases", async () => {
+  const css = await read("src/ui/patterns/checkbox.css");
+  for (const name of ["checkbox", "checkbox-field"]) {
+    assert.match(css, new RegExp(`:is\\(\\.uif-${name}, \\.${name}\\)`));
+  }
+  assert.match(css, /var\(--uif-checkbox-/);
+  assert.doesNotMatch(css, /var\(--checkbox-/);
+  assert.doesNotMatch(css, /\.uif-checkbox(?:__|--)/);
+});
+
+test("Checkbox Figma export contains canonical tokens without legacy aliases", async () => {
+  const tokenExport = await read("figma/exports/Patterns (UI).tokens.json");
+  assert.equal((tokenExport.match(/var\(--uif-checkbox-/g) ?? []).length, 19);
+  assert.doesNotMatch(tokenExport, /var\(--checkbox-/);
+});
+
+test("Checkbox-owned emitters and behavior use canonical classes", async () => {
+  const [element, macros, renderer, schema, behavior] = await Promise.all([
+    read("src/elements/ui-checkbox.js"),
+    read("site/_includes/macros/ui.njk"),
+    read("site/assets/playground/renderers.js"),
+    read("schemas/web-checkbox.figma.ts"),
+    read("site/_includes/layouts/docs.njk"),
+  ]);
+  for (const source of [element, macros, renderer, schema]) assert.match(source, /uif-checkbox/);
+  assert.match(behavior, /\.uif-checkbox, \.checkbox/);
+  assert.doesNotMatch(element, /class="checkbox(?:[-\s"])/);
+});
+
+test("Checkbox docs explain migration while registration stays stable", async () => {
+  const [documentation, element] = await Promise.all([
+    read("site/patterns/checkbox.md"),
+    read("src/elements/ui-checkbox.js"),
+  ]);
+  assert.match(documentation, /legacy `--checkbox-\*` token aliases are not provided/);
+  assert.match(element, /define\("ui-checkbox", UICheckbox\)/);
+});


### PR DESCRIPTION
Closes #185

## Summary
- canonicalize all 19 Checkbox Figma WEB syntaxes and checked-in token export entries to `--uif-checkbox-*`
- emit `.uif-checkbox`, `.uif-checkbox-field`, and `.uif-checkbox-field-text`
- retain v1 CSS compatibility for `.checkbox` and `.checkbox-field`, with no legacy token aliases
- update behavior hooks, Code Connect, playground, docs, examples, and migration tests while keeping `<ui-checkbox>` and package exports stable

## Validation
- `npm run lint`
- `npm run test:unit`
- `npm run ci:check`