### PR TITLE
Migration: Adopt UIF-prefixed naming for Form

### DIFF
--- a/figma/exports/Patterns (UI).tokens.json
+++ b/figma/exports/Patterns (UI).tokens.json
@@ -2035,7 +2035,7 @@
             "GAP"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--form-group-gap)"
+            "WEB": "var(--uif-form-group-gap)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:5",
@@ -2057,7 +2057,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--form-group-title-color)"
+            "WEB": "var(--uif-form-group-title-color)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:326",
@@ -2080,7 +2080,7 @@
           "GAP"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--form-padding-inline)"
+          "WEB": "var(--uif-form-padding-inline)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:5",
@@ -2102,7 +2102,7 @@
           "GAP"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--form-padding-block)"
+          "WEB": "var(--uif-form-padding-block)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:5",
@@ -2125,7 +2125,7 @@
             "CORNER_RADIUS"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--form-border-radius)"
+            "WEB": "var(--uif-form-border-radius)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2028:310",
@@ -2147,7 +2147,7 @@
             "STROKE_FLOAT"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--form-border-size)"
+            "WEB": "var(--uif-form-border-size)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:7",
@@ -2170,7 +2170,7 @@
           "GAP"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--form-gap)"
+          "WEB": "var(--uif-form-gap)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:5",
@@ -2193,7 +2193,7 @@
             "GAP"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--form-field-gap)"
+            "WEB": "var(--uif-form-field-gap)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:3",
@@ -2215,7 +2215,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--form-field-helper-text-color-default)"
+            "WEB": "var(--uif-form-field-helper-text-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:341",
@@ -2237,7 +2237,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--form-field-helper-text-color-invalid)"
+            "WEB": "var(--uif-form-field-helper-text-color-invalid)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:358",
@@ -2261,7 +2261,7 @@
             "ALL_FILLS"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--form-container-background)"
+            "WEB": "var(--uif-form-container-background)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:329",
@@ -2283,7 +2283,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--form-container-border-color)"
+            "WEB": "var(--uif-form-container-border-color)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:343",

--- a/schemas/web-form.figma.ts
+++ b/schemas/web-form.figma.ts
@@ -17,7 +17,7 @@ figma.connect(
       }),
     },
     example: ({ state, helperText }: FormProps) => html`<div
-      class="form-field"
+      class="uif-form-field"
       data-state="${state}"
     >
       <label class="uif-field-label" for="form-field-input" style="line-height: 24px;">
@@ -31,7 +31,7 @@ figma.connect(
         type="text"
         placeholder="Enter value"
       />
-      <p class="form-field-helper">
+      <p class="uif-form-field-helper">
         ${helperText}
       </p>
     </div>`,

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -229,23 +229,23 @@
 {%- endmacro %}
 
 {% macro form(borderless=false, className='') -%}
-{%- set classes = "form" -%}
+{%- set classes = "uif-form" -%}
 {%- if borderless -%}{%- set classes = classes + " borderless" -%}{%- endif -%}
 {%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
 <form class="{{ classes }}" novalidate>{{ caller() }}</form>
 {%- endmacro %}
 
 {% macro formGroup(title='', className='') -%}
-{%- set classes = "form-group" -%}
+{%- set classes = "uif-form-group" -%}
 {%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
 <fieldset class="{{ classes }}">
-  {%- if title %}<legend class="form-group-title">{{ title }}</legend>{% endif -%}
+  {%- if title %}<legend class="uif-form-group-title">{{ title }}</legend>{% endif -%}
   {{ caller() }}
 </fieldset>
 {%- endmacro %}
 
 {% macro formField(labelPosition='top', invalid=false, className='') -%}
-{%- set classes = "form-field" -%}
+{%- set classes = "uif-form-field" -%}
 {%- if invalid -%}{%- set classes = classes + " is-invalid" -%}{%- endif -%}
 {%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
 <div class="{{ classes }}"{% if labelPosition == "side" %} data-label-position="side"{% endif %}>{{ caller() }}</div>
@@ -279,11 +279,11 @@
 {%- endmacro %}
 
 {% macro formHelper(text='') -%}
-<p class="form-field-helper">{{ text }}</p>
+<p class="uif-form-field-helper">{{ text }}</p>
 {%- endmacro %}
 
 {% macro formActions(align='end', className='') -%}
-{%- set classes = "form-actions" -%}
+{%- set classes = "uif-form-actions" -%}
 {%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
 <div class="{{ classes }}"{% if align != "end" %} data-align="{{ align }}"{% endif %}>{{ caller() }}</div>
 {%- endmacro %}

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -770,14 +770,14 @@
     const actionsAlign = String(props.actionsAlign || "end");
 
     const form = document.createElement("form");
-    const formClasses = ["form"];
+    const formClasses = ["uif-form"];
     if (borderless) formClasses.push("borderless");
     form.className = formClasses.join(" ");
     form.setAttribute("novalidate", "");
 
     // Field 1
     const field1 = document.createElement("div");
-    const field1Classes = ["form-field"];
+    const field1Classes = ["uif-form-field"];
     if (invalid) field1Classes.push("is-invalid");
     field1.className = field1Classes.join(" ");
     if (labelPosition === "side") field1.dataset.labelPosition = "side";
@@ -793,11 +793,11 @@
 
     if (labelPosition === "side") {
       const body1 = document.createElement("div");
-      body1.className = "form-field-body";
+      body1.className = "uif-form-field-body";
       body1.append(input1);
       if (invalid) {
         const helper = document.createElement("p");
-        helper.className = "form-field-helper";
+        helper.className = "uif-form-field-helper";
         helper.textContent = "Please enter a valid email address.";
         body1.append(helper);
       }
@@ -806,7 +806,7 @@
       field1.append(label1, input1);
       if (invalid) {
         const helper = document.createElement("p");
-        helper.className = "form-field-helper";
+        helper.className = "uif-form-field-helper";
         helper.textContent = "Please enter a valid email address.";
         field1.append(helper);
       }
@@ -814,7 +814,7 @@
 
     // Field 2
     const field2 = document.createElement("div");
-    field2.className = "form-field";
+    field2.className = "uif-form-field";
     if (labelPosition === "side") field2.dataset.labelPosition = "side";
 
     const label2 = document.createElement("label");
@@ -827,7 +827,7 @@
 
     if (labelPosition === "side") {
       const body2 = document.createElement("div");
-      body2.className = "form-field-body";
+      body2.className = "uif-form-field-body";
       body2.append(input2);
       field2.append(label2, body2);
     } else {
@@ -836,11 +836,11 @@
 
     // Actions
     const actions = document.createElement("div");
-    actions.className = "form-actions";
+    actions.className = "uif-form-actions";
     if (actionsAlign !== "end") actions.dataset.align = actionsAlign;
 
     const btn = document.createElement("button");
-    btn.className = "button solid";
+    btn.className = "uif-button solid";
     btn.type = "submit";
     btn.innerHTML = '<span class="uif-label-content"><span class="uif-label-content-text">Sign in</span></span>';
     actions.append(btn);
@@ -850,17 +850,17 @@
     const lp = labelPosition === "side" ? ' data-label-position="side"' : "";
     const inv = invalid ? " is-invalid" : "";
     const alignAttr = actionsAlign !== "end" ? ` data-align="${actionsAlign}"` : "";
-    const helperCode = invalid ? '\n    <p class="form-field-helper">Please enter a valid email address.</p>' : "";
+    const helperCode = invalid ? '\n    <p class="uif-form-field-helper">Please enter a valid email address.</p>' : "";
     const code = `<form class="${formClasses.join(" ")}" novalidate>
-  <div class="form-field${inv}"${lp}>
+  <div class="uif-form-field${inv}"${lp}>
     <label class="uif-field-label"><span class="uif-label-content"><span class="uif-label-content-text">Email</span></span><span class="uif-field-label-required" aria-hidden="true">*</span></label>
     <input class="uif-input" type="email" placeholder="you@example.com" />${helperCode}
   </div>
-  <div class="form-field"${lp}>
+  <div class="uif-form-field"${lp}>
     <label class="uif-field-label"><span class="uif-label-content"><span class="uif-label-content-text">Password</span></span></label>
     <input class="uif-input" type="password" />
   </div>
-  <div class="form-actions"${alignAttr}>
+  <div class="uif-form-actions"${alignAttr}>
     <button class="uif-button solid" type="submit"><span class="uif-label-content"><span class="uif-label-content-text">Sign in</span></span></button>
   </div>
 </form>`;
@@ -1135,7 +1135,7 @@
     const rootClasses = ["uif-input-field", "date"];
     if (isOpen) rootClasses.push("is-open");
 
-    let html = `<div class="form-field date-picker-field">`;
+    let html = `<div class="uif-form-field date-picker-field">`;
     html += `<label class="uif-field-label" id="date-picker-playground-label" for="date-picker-playground-day"><span class="uif-label-content"><span class="uif-label-content-text">Travel date</span></span></label>`;
     html += `<div class="${rootClasses.join(" ")}" role="group" aria-labelledby="date-picker-playground-label">`;
     html += `<div class="date-segments">`;

--- a/site/components/date-picker.md
+++ b/site/components/date-picker.md
@@ -25,7 +25,7 @@ playgroundLabel: Open Date Picker Playground
       </span>
     </div>
     <div class="docs-hero-preview-stage">
-      <div class="form-field date-picker-field">
+      <div class="uif-form-field date-picker-field">
         <label class="uif-field-label" id="date-input-demo-label" for="date-input-demo-day">
           <span class="uif-label-content">
             <span class="uif-label-content-text">Travel date</span>
@@ -62,7 +62,7 @@ Together they form a component that can be opened, navigated, and dismissed — 
 ## Composition
 
 ```
-.form-field.date-picker-field
+.uif-form-field.date-picker-field
 ├── label.uif-field-label [for="date-day"]
 └── .uif-input-field.date [role="group", aria-labelledby]
     ├── .date-segments

--- a/site/examples/login-form.md
+++ b/site/examples/login-form.md
@@ -33,7 +33,7 @@ breadcrumb:
 <div class="example-form-shell">
   {% call ui.form(borderless=true) %}
     {% call ui.formGroup(title="Sign in") %}
-      <p class="form-field-helper">Use your account email and password.</p>
+      <p class="uif-form-field-helper">Use your account email and password.</p>
       {% call ui.formField() %}
         {{ ui.fieldLabel("Email address", htmlFor="login-email", required=true) }}
         {{ ui.input(type="email", id="login-email", name="email", placeholder="name@example.com") }}
@@ -41,7 +41,7 @@ breadcrumb:
       {% call ui.formField() %}
         {{ ui.fieldLabel("Password", htmlFor="login-password", required=true) }}
         {{ ui.input(type="password", id="login-password", name="password", placeholder="Enter password") }}
-        <a class="form-field-link" href="#">Forgot password?</a>
+        <a class="uif-form-field-link" href="#">Forgot password?</a>
       {% endcall %}
     {% endcall %}
     {% call ui.formActions(align="stretch") %}
@@ -61,17 +61,17 @@ breadcrumb:
 <div class="example-form-shell">
   {% call ui.form(borderless=true) %}
     {% call ui.formGroup(title="Sign in") %}
-      <p class="form-field-helper">Use your account email and password.</p>
+      <p class="uif-form-field-helper">Use your account email and password.</p>
       {% call ui.formField(invalid=true) %}
         {{ ui.fieldLabel("Email address", htmlFor="login-email-err", required=true) }}
         {{ ui.input(type="email", id="login-email-err", name="email", placeholder="name@example.com", className="is-invalid") }}
-        <p class="form-field-helper">Please enter a valid email address.</p>
+        <p class="uif-form-field-helper">Please enter a valid email address.</p>
       {% endcall %}
       {% call ui.formField(invalid=true) %}
         {{ ui.fieldLabel("Password", htmlFor="login-password-err", required=true) }}
         {{ ui.input(type="password", id="login-password-err", name="password", placeholder="Enter password", className="is-invalid") }}
-        <p class="form-field-helper">Password is required.</p>
-        <a class="form-field-link" href="#">Forgot password?</a>
+        <p class="uif-form-field-helper">Password is required.</p>
+        <a class="uif-form-field-link" href="#">Forgot password?</a>
       {% endcall %}
     {% endcall %}
     {% call ui.formActions(align="stretch") %}

--- a/site/patterns/form.md
+++ b/site/patterns/form.md
@@ -76,7 +76,7 @@ playgroundLabel: Open Form Playground
 
 <h3>Field grouping</h3>
 
-Use `.form-group` with a `<fieldset>` and `<legend>` to group related fields. The legend provides an accessible name for the group.
+Use `.uif-form-group` with a `<fieldset>` and `<legend>` to group related fields. The legend provides an accessible name for the group.
 
 <div class="docs-example">
 {% call ui.form() %}
@@ -99,7 +99,7 @@ Use `.form-group` with a `<fieldset>` and `<legend>` to group related fields. Th
 
 <h3>Validation and helper text</h3>
 
-Mark a field as invalid with `.is-invalid` on `.form-field`. Helper text switches to danger color automatically.
+Mark a field as invalid with `.is-invalid` on `.uif-form-field`. Helper text switches to danger color automatically.
 
 <div class="docs-example">
 {% call ui.form() %}
@@ -124,7 +124,7 @@ Use `data-label-position="side"` for horizontal label layout. Best suited for wi
 {% call ui.form() %}
   {% call ui.formField(labelPosition="side") %}
     {{ ui.fieldLabel("Username") }}
-    <div class="form-field-body">
+    <div class="uif-form-field-body">
       {{ ui.input(placeholder="janedoe") }}
       {{ ui.formHelper("Visible to other users.") }}
     </div>
@@ -176,15 +176,19 @@ Form adapts to brands and modes through its component tokens:
 
 | Token | Purpose |
 |-------|---------|
-| `--form-gap` | Spacing between fields |
-| `--form-group-gap` | Spacing between fields in a group |
-| `--form-padding-inline` | Horizontal padding |
-| `--form-padding-block` | Vertical padding |
-| `--form-border-radius` | Container corner radius |
-| `--form-container-background` | Background color |
-| `--form-container-border-color` | Border color |
-| `--form-border-size` | Border width |
-| `--form-field-gap` | Gap between label, input, helper |
-| `--form-field-helper-text-color-default` | Helper text color |
-| `--form-field-helper-text-color-invalid` | Error text color |
-| `--form-group-title-color` | Group legend color |
+| `--uif-form-gap` | Spacing between fields |
+| `--uif-form-group-gap` | Spacing between fields in a group |
+| `--uif-form-padding-inline` | Horizontal padding |
+| `--uif-form-padding-block` | Vertical padding |
+| `--uif-form-border-radius` | Container corner radius |
+| `--uif-form-container-background` | Background color |
+| `--uif-form-container-border-color` | Border color |
+| `--uif-form-border-size` | Border width |
+| `--uif-form-field-gap` | Gap between label, input, helper |
+| `--uif-form-field-helper-text-color-default` | Helper text color |
+| `--uif-form-field-helper-text-color-invalid` | Error text color |
+| `--uif-form-group-title-color` | Group legend color |
+
+<h2 id="v1-naming-migration">v1 naming migration</h2>
+
+Form emitters now produce canonical `.uif-form*` classes, including groups, fields, helpers, links, field bodies, and actions. The corresponding legacy `.form*` selectors remain supported during the v1 compatibility period. Component token slots are now `--uif-form-*`; library-owned legacy `--form-*` token aliases are not provided. Existing `<ui-form*>` registrations and package exports remain unchanged.

--- a/src/elements/ui-form.js
+++ b/src/elements/ui-form.js
@@ -15,7 +15,7 @@ class UIForm extends UIElement {
     const borderless = this.getBool("borderless");
     const children = this.innerHTML;
 
-    const classes = ["form"];
+    const classes = ["uif-form"];
     if (borderless) classes.push("borderless");
 
     this.innerHTML = `<form class="${classes.join(" ")}" novalidate>${children}</form>`;
@@ -37,8 +37,8 @@ class UIFormGroup extends UIElement {
     const title = this.getAttr("title");
     const children = this.innerHTML;
 
-    const legend = title ? `<legend class="form-group-title">${title}</legend>` : "";
-    this.innerHTML = `<fieldset class="form-group">${legend}${children}</fieldset>`;
+    const legend = title ? `<legend class="uif-form-group-title">${title}</legend>` : "";
+    this.innerHTML = `<fieldset class="uif-form-group">${legend}${children}</fieldset>`;
   }
 }
 
@@ -58,7 +58,7 @@ class UIFormField extends UIElement {
     const invalid = this.getBool("invalid");
     const children = this.innerHTML;
 
-    const classes = ["form-field"];
+    const classes = ["uif-form-field"];
     if (invalid) classes.push("is-invalid");
 
     const attrs = [`class="${classes.join(" ")}"`];
@@ -77,7 +77,7 @@ export { UIFormField };
 class UIFormHelper extends UIElement {
   render() {
     const text = this.textContent.trim();
-    this.innerHTML = `<p class="form-field-helper">${text}</p>`;
+    this.innerHTML = `<p class="uif-form-field-helper">${text}</p>`;
   }
 }
 
@@ -96,7 +96,7 @@ class UIFormActions extends UIElement {
     const align = this.getAttr("align", "end");
     const children = this.innerHTML;
 
-    const attrs = ['class="form-actions"'];
+    const attrs = ['class="uif-form-actions"'];
     if (align !== "end") attrs.push(`data-align="${align}"`);
 
     this.innerHTML = `<div ${attrs.join(" ")}>${children}</div>`;

--- a/src/ui/patterns/form.css
+++ b/src/ui/patterns/form.css
@@ -3,18 +3,18 @@
    * Form — layout container for form fields
    * ---------------------------------------------------------------- */
 
-  .form {
+  :is(.uif-form, .form) {
     display: flex;
     flex-direction: column;
-    gap: var(--form-gap);
-    padding-inline: var(--form-padding-inline);
-    padding-block: var(--form-padding-block);
-    background: var(--form-container-background);
-    border: var(--form-border-size) solid var(--form-container-border-color);
-    border-radius: var(--form-border-radius);
+    gap: var(--uif-form-gap);
+    padding-inline: var(--uif-form-padding-inline);
+    padding-block: var(--uif-form-padding-block);
+    background: var(--uif-form-container-background);
+    border: var(--uif-form-border-size) solid var(--uif-form-container-border-color);
+    border-radius: var(--uif-form-border-radius);
   }
 
-  .form.borderless {
+  :is(.uif-form, .form).borderless {
     border: none;
     padding: 0;
     background: transparent;
@@ -24,22 +24,22 @@
    * Form Group — groups related fields with an optional title
    * ---------------------------------------------------------------- */
 
-  .form-group {
+  :is(.uif-form-group, .form-group) {
     display: flex;
     flex-direction: column;
-    gap: var(--form-group-gap);
+    gap: var(--uif-form-group-gap);
     margin: 0;
     padding: 0;
     border: 0;
     min-inline-size: 0;
   }
 
-  .form-group-title {
+  :is(.uif-form-group-title, .form-group-title) {
     font-family: var(--typography-heading-font-family);
     font-weight: var(--typography-heading-font-weight);
     font-size: var(--typography-heading-font-size-sm);
     line-height: var(--typography-heading-line-height-sm);
-    color: var(--form-group-title-color);
+    color: var(--uif-form-group-title-color);
     margin: 0;
   }
 
@@ -47,53 +47,53 @@
    * Form Field — single field with label, input, and helper/error
    * ---------------------------------------------------------------- */
 
-  .form-field {
+  :is(.uif-form-field, .form-field) {
     display: flex;
     flex-direction: column;
-    gap: var(--form-field-gap);
+    gap: var(--uif-form-field-gap);
   }
 
-  .form-field[data-label-position="side"] {
+  :is(.uif-form-field, .form-field)[data-label-position="side"] {
     flex-direction: row;
     align-items: flex-start;
   }
 
-  .form-field[data-label-position="side"] > :is(.uif-field-label, .field-label) {
+  :is(.uif-form-field, .form-field)[data-label-position="side"] > :is(.uif-field-label, .field-label) {
     flex-shrink: 0;
     inline-size: 8rem;
     padding-block-start: var(--size-spacing-200);
   }
 
-  .form-field[data-label-position="side"] > .form-field-body {
+  :is(.uif-form-field, .form-field)[data-label-position="side"] > :is(.uif-form-field-body, .form-field-body) {
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: var(--form-field-gap);
+    gap: var(--uif-form-field-gap);
   }
 
   /* ----------------------------------------------------------------
    * Helper and error text
    * ---------------------------------------------------------------- */
 
-  .form-field-helper {
+  :is(.uif-form-field-helper, .form-field-helper) {
     font-family: var(--typography-body-font-family);
     font-size: var(--font-size-sm);
     line-height: var(--line-height-sm);
-    color: var(--form-field-helper-text-color-default);
+    color: var(--uif-form-field-helper-text-color-default);
     margin: 0;
   }
 
-  .form-field.is-invalid .form-field-helper {
-    color: var(--form-field-helper-text-color-invalid);
+  :is(.uif-form-field, .form-field).is-invalid :is(.uif-form-field-helper, .form-field-helper) {
+    color: var(--uif-form-field-helper-text-color-invalid);
   }
 
-  .form-field-link {
+  :is(.uif-form-field-link, .form-field-link) {
     font-size: var(--font-size-sm);
     color: var(--color-text-brand);
     text-decoration: none;
   }
 
-  .form-field-link:hover {
+  :is(.uif-form-field-link, .form-field-link):hover {
     text-decoration: underline;
   }
 
@@ -101,22 +101,22 @@
    * Form Actions — button area at the bottom
    * ---------------------------------------------------------------- */
 
-  .form-actions {
+  :is(.uif-form-actions, .form-actions) {
     display: flex;
     gap: var(--size-spacing-200);
     justify-content: flex-end;
     padding-block-start: var(--size-spacing-200);
   }
 
-  .form-actions[data-align="start"] {
+  :is(.uif-form-actions, .form-actions)[data-align="start"] {
     justify-content: flex-start;
   }
 
-  .form-actions[data-align="stretch"] {
+  :is(.uif-form-actions, .form-actions)[data-align="stretch"] {
     flex-direction: column;
   }
 
-  .form-actions[data-align="stretch"] > * {
+  :is(.uif-form-actions, .form-actions)[data-align="stretch"] > * {
     inline-size: 100%;
   }
 }

--- a/tests/form-naming-migration.test.mjs
+++ b/tests/form-naming-migration.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("Form CSS exposes canonical UIF naming with v1 class aliases", async () => {
+  const css = await read("src/ui/patterns/form.css");
+  for (const name of ["form", "form-group", "form-group-title", "form-field", "form-field-body", "form-field-helper", "form-field-link", "form-actions"]) {
+    assert.match(css, new RegExp(`:is\\(\\.uif-${name}, \\.${name}\\)`));
+  }
+  assert.match(css, /var\(--uif-form-/);
+  assert.doesNotMatch(css, /var\(--form-/);
+  assert.doesNotMatch(css, /\.uif-form(?:__|--)/);
+});
+
+test("Form Figma export contains canonical tokens without legacy aliases", async () => {
+  const tokenExport = await read("figma/exports/Patterns (UI).tokens.json");
+  assert.equal((tokenExport.match(/var\(--uif-form-/g) ?? []).length, 12);
+  assert.doesNotMatch(tokenExport, /var\(--form-/);
+});
+
+test("Form-owned emitters and integrations use canonical classes", async () => {
+  const sources = await Promise.all([
+    read("src/elements/ui-form.js"),
+    read("site/_includes/macros/ui.njk"),
+    read("site/assets/playground/renderers.js"),
+    read("schemas/web-form.figma.ts"),
+    read("site/components/date-picker.md"),
+    read("site/examples/login-form.md"),
+  ]);
+  for (const source of sources) assert.match(source, /uif-form/);
+  assert.match(sources[2], /uif-button solid/);
+  assert.doesNotMatch(sources[0], /class="form(?:[-\s"])/);
+});
+
+test("Form docs explain migration while registrations stay stable", async () => {
+  const [documentation, element] = await Promise.all([
+    read("site/patterns/form.md"),
+    read("src/elements/ui-form.js"),
+  ]);
+  assert.match(documentation, /legacy `--form-\*` token aliases are not provided/);
+  for (const tag of ["ui-form", "ui-form-group", "ui-form-field", "ui-form-helper", "ui-form-actions"]) {
+    assert.match(element, new RegExp(`define\\("${tag}"`));
+  }
+});


### PR DESCRIPTION
Closes #187

## Summary
- canonicalize all 12 Form Figma WEB syntaxes and checked-in export entries to `--uif-form-*`
- emit canonical `.uif-form*` classes across macros, Web Components, Code Connect, playgrounds, examples, and Date Picker integration
- retain corresponding legacy Form selectors during v1 with no legacy token aliases
- keep existing `<ui-form*>` registrations and package exports stable

## Validation
- `npm run lint`
- `npm run test:unit`
- `npm run ci:check`