### PR TITLE
Migration: Adopt UIF-prefixed naming for Select

### DIFF
--- a/figma/exports/Patterns (UI).tokens.json
+++ b/figma/exports/Patterns (UI).tokens.json
@@ -3931,7 +3931,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-text-color-default)"
+            "WEB": "var(--uif-select-text-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:326",
@@ -3953,7 +3953,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-text-color-hover)"
+            "WEB": "var(--uif-select-text-color-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:340",
@@ -3975,7 +3975,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-text-color-active)"
+            "WEB": "var(--uif-select-text-color-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:326",
@@ -3997,7 +3997,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-text-color-disabled)"
+            "WEB": "var(--uif-select-text-color-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:328",
@@ -4019,7 +4019,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-text-color-placeholder)"
+            "WEB": "var(--uif-select-text-color-placeholder)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:341",
@@ -4043,7 +4043,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-border-color-default)"
+            "WEB": "var(--uif-select-border-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:342",
@@ -4065,7 +4065,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-border-color-hover)"
+            "WEB": "var(--uif-select-border-color-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:345",
@@ -4087,7 +4087,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-border-color-active)"
+            "WEB": "var(--uif-select-border-color-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:345",
@@ -4109,7 +4109,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-border-color-focus)"
+            "WEB": "var(--uif-select-border-color-focus)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:345",
@@ -4131,7 +4131,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-border-color-disabled)"
+            "WEB": "var(--uif-select-border-color-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:346",
@@ -4153,7 +4153,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-border-color-invalid)"
+            "WEB": "var(--uif-select-border-color-invalid)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:356",
@@ -4175,7 +4175,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-border-size-default)"
+            "WEB": "var(--uif-select-border-size-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:7",
@@ -4197,7 +4197,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-border-size-hover)"
+            "WEB": "var(--uif-select-border-size-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:7",
@@ -4219,7 +4219,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-border-size-active)"
+            "WEB": "var(--uif-select-border-size-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:8",
@@ -4241,7 +4241,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-border-radius)"
+            "WEB": "var(--uif-select-border-radius)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2028:335",
@@ -4265,7 +4265,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-container-background-default)"
+            "WEB": "var(--uif-select-container-background-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:329",
@@ -4287,7 +4287,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-container-background-hover)"
+            "WEB": "var(--uif-select-container-background-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:329",
@@ -4309,7 +4309,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-container-background-focus)"
+            "WEB": "var(--uif-select-container-background-focus)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:329",
@@ -4331,7 +4331,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-container-background-active)"
+            "WEB": "var(--uif-select-container-background-active)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:329",
@@ -4353,7 +4353,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-container-background-disabled)"
+            "WEB": "var(--uif-select-container-background-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:330",
@@ -4376,7 +4376,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--select-font-family)"
+          "WEB": "var(--uif-select-font-family)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:2006:213",
@@ -4398,7 +4398,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--select-font-weight)"
+          "WEB": "var(--uif-select-font-weight)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3014:12",
@@ -4420,7 +4420,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--select-font-size)"
+          "WEB": "var(--uif-select-font-size)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3014:9",
@@ -4442,7 +4442,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--select-line-height)"
+          "WEB": "var(--uif-select-line-height)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3014:14",
@@ -4464,7 +4464,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--select-padding-inline)"
+          "WEB": "var(--uif-select-padding-inline)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:3",
@@ -4486,7 +4486,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--select-padding-block)"
+          "WEB": "var(--uif-select-padding-block)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:3",
@@ -4508,7 +4508,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--select-overlay-hover)"
+          "WEB": "var(--uif-select-overlay-hover)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:2006:195",
@@ -4530,7 +4530,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--select-overlay-active)"
+          "WEB": "var(--uif-select-overlay-active)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:2006:195",
@@ -4553,7 +4553,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-icon-color-default)"
+            "WEB": "var(--uif-select-icon-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:341",
@@ -4575,7 +4575,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--select-icon-color-disabled)"
+            "WEB": "var(--uif-select-icon-color-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:328",
@@ -4598,7 +4598,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--select-height)"
+          "WEB": "var(--uif-select-height)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3020:2",

--- a/schemas/web-select.figma.ts
+++ b/schemas/web-select.figma.ts
@@ -6,7 +6,7 @@ figma.connect(
   {
     props: {
       className: figma.className([
-        "select",
+        "uif-select",
         figma.enum("State", {
           Default: undefined,
           Hover: "is-hover",

--- a/site/_includes/macros/calendar.njk
+++ b/site/_includes/macros/calendar.njk
@@ -5,7 +5,7 @@
 {%- endmacro %}
 
 {% macro calendarSelect(options=[], value='', disabled=false, className='', name='') -%}
-{%- set classes = "select" -%}
+{%- set classes = "uif-select" -%}
 {%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
 <select class="{{ classes }}"{% if name %} name="{{ name }}"{% endif %}{% if disabled %} disabled{% endif %}>
   {%- for opt in options %}

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -252,7 +252,7 @@
 {%- endmacro %}
 
 {% macro select(options=[], placeholder='', value='', state='default', disabled=false, invalid=false, className='', id='', name='') -%}
-{%- set classes = "select" -%}
+{%- set classes = "uif-select" -%}
 {%- if state == "hover" -%}{%- set classes = classes + " is-hover" -%}{%- endif -%}
 {%- if state == "active" -%}{%- set classes = classes + " is-active" -%}{%- endif -%}
 {%- if state == "focus" -%}{%- set classes = classes + " is-focus-visible" -%}{%- endif -%}

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -875,7 +875,7 @@
     const disabled = previewState === "disabled" || asBoolean(props.disabled);
 
     const element = document.createElement("select");
-    const classes = ["select"];
+    const classes = ["uif-select"];
 
     if (previewState === "hover") classes.push("is-hover");
     if (previewState === "active") classes.push("is-active");
@@ -1057,10 +1057,10 @@
     let headerHtml = `<div class="uif-calendar-header">`;
     headerHtml += `<button type="button" class="uif-button ghost" aria-label="Previous month"${disabledAttr}><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/chevron--left.svg');" aria-hidden="true"></span></button>`;
     headerHtml += `<span class="uif-calendar-selectors">`;
-    headerHtml += `<select class="select uif-calendar-header-select" name="month" aria-label="Month"${disabledAttr}>`;
+    headerHtml += `<select class="uif-select uif-calendar-header-select" name="month" aria-label="Month"${disabledAttr}>`;
     months.forEach((m, i) => { headerHtml += `<option value="${i}"${i === selectedMonth ? " selected" : ""}>${m}</option>`; });
     headerHtml += `</select>`;
-    headerHtml += `<select class="select uif-calendar-header-select" name="year" aria-label="Year"${disabledAttr}>`;
+    headerHtml += `<select class="uif-select uif-calendar-header-select" name="year" aria-label="Year"${disabledAttr}>`;
     for (let y = 2020; y <= 2030; y++) { headerHtml += `<option value="${y}"${y === selectedYear ? " selected" : ""}>${y}</option>`; }
     headerHtml += `</select></span>`;
     headerHtml += `<button type="button" class="uif-button ghost" aria-label="Next month"${disabledAttr}><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/chevron.svg');" aria-hidden="true"></span></button>`;
@@ -1151,9 +1151,9 @@
     html += `</button></span>`;
     html += `<div class="uif-calendar" id="date-picker-playground-calendar"><div class="uif-calendar-header">`;
     html += `<button type="button" class="uif-button ghost" aria-label="Previous month"><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/chevron--left.svg');" aria-hidden="true"></span></button>`;
-    html += `<span class="uif-calendar-selectors"><select class="select uif-calendar-header-select" name="month" aria-label="Month">`;
+    html += `<span class="uif-calendar-selectors"><select class="uif-select uif-calendar-header-select" name="month" aria-label="Month">`;
     monthNames.forEach((m, i) => { html += `<option value="${i}"${i === visibleMonth ? " selected" : ""}>${m}</option>`; });
-    html += `</select><select class="select uif-calendar-header-select" name="year" aria-label="Year">`;
+    html += `</select><select class="uif-select uif-calendar-header-select" name="year" aria-label="Year">`;
     for (let y = 2020; y <= 2030; y++) { html += `<option value="${y}"${y === visibleYear ? " selected" : ""}>${y}</option>`; }
     html += `</select></span>`;
     html += `<button type="button" class="uif-button ghost" aria-label="Next month"><span class="uif-icon" style="--uif-icon-src: url('/assets/icons/chevron.svg');" aria-hidden="true"></span></button>`;

--- a/site/patterns/select.md
+++ b/site/patterns/select.md
@@ -250,6 +250,10 @@ tokens. Use the hero preview switches above to see it in action.
 
 For the full theming architecture see [Foundations: Theming](/foundations/theming/).
 
+<h2 id="v1-naming-migration">v1 naming migration</h2>
+
+Select emitters now produce `.uif-select`. The legacy `.select` selector remains supported during the v1 compatibility period, including when Select is composed into Calendar. Component token slots are now `--uif-select-*`; library-owned legacy `--select-*` token aliases are not provided. The existing `<ui-select>` registration and package export remain unchanged.
+
 <h2 id="design-checklist">Design checklist</h2>
 
 <div class="docs-checklist">

--- a/src/elements/ui-select.js
+++ b/src/elements/ui-select.js
@@ -34,7 +34,7 @@ class UISelect extends UIElement {
       this.warnDev("[ui-foundations] <ui-select> should have an id, aria-label, or aria-labelledby.");
     }
 
-    const classes = ["select"];
+    const classes = ["uif-select"];
     if (!value && placeholder) classes.push("is-placeholder");
     if (invalid) classes.push("is-invalid");
 

--- a/src/ui/patterns/calendar.css
+++ b/src/ui/patterns/calendar.css
@@ -46,7 +46,7 @@
   }
 
   /* Header selects: reuse Select pattern with calendar-specific overrides (no border, transparent) */
-  :is(.uif-calendar-header, .calendar-header) .select:is(.uif-calendar-header-select, .calendar-header-select) {
+  :is(.uif-calendar-header, .calendar-header) :is(.uif-select, .select):is(.uif-calendar-header-select, .calendar-header-select) {
     flex: 0 0 auto;
     inline-size: auto;
     border-color: transparent;
@@ -55,15 +55,15 @@
     padding-block: 0;
   }
 
-  :is(.uif-calendar-header, .calendar-header) .select:is(.uif-calendar-header-select, .calendar-header-select)[name="month"] {
+  :is(.uif-calendar-header, .calendar-header) :is(.uif-select, .select):is(.uif-calendar-header-select, .calendar-header-select)[name="month"] {
     min-inline-size: 12ch;
   }
 
-  :is(.uif-calendar-header, .calendar-header) .select:is(.uif-calendar-header-select, .calendar-header-select)[name="year"] {
+  :is(.uif-calendar-header, .calendar-header) :is(.uif-select, .select):is(.uif-calendar-header-select, .calendar-header-select)[name="year"] {
     min-inline-size: 7ch;
   }
 
-  :is(.uif-calendar-header, .calendar-header) .select:is(.uif-calendar-header-select, .calendar-header-select):hover {
+  :is(.uif-calendar-header, .calendar-header) :is(.uif-select, .select):is(.uif-calendar-header-select, .calendar-header-select):hover {
     background: var(--uif-calendar-cell-background-hover);
   }
 

--- a/src/ui/patterns/select.css
+++ b/src/ui/patterns/select.css
@@ -1,41 +1,41 @@
 @layer components {
-  .select {
+  :is(.uif-select, .select) {
     position: relative;
     display: inline-grid;
     grid-template-columns: 1fr auto;
     align-items: center;
     inline-size: 100%;
-    block-size: var(--select-height, 2.5rem);
+    block-size: var(--uif-select-height, 2.5rem);
     appearance: none;
-    font-family: var(--select-font-family);
-    font-weight: var(--select-font-weight);
-    font-size: var(--select-font-size);
-    line-height: var(--select-line-height);
-    color: var(--select-text-color-default);
-    background: var(--select-container-background-default);
+    font-family: var(--uif-select-font-family);
+    font-weight: var(--uif-select-font-weight);
+    font-size: var(--uif-select-font-size);
+    line-height: var(--uif-select-line-height);
+    color: var(--uif-select-text-color-default);
+    background: var(--uif-select-container-background-default);
     border-style: solid;
-    border-width: var(--select-border-size-default);
-    border-color: var(--select-border-color-default);
-    border-radius: var(--select-border-radius);
-    padding-inline-start: var(--select-padding-inline);
-    padding-inline-end: calc(var(--select-padding-inline) + 1.5em);
-    padding-block: var(--select-padding-block);
+    border-width: var(--uif-select-border-size-default);
+    border-color: var(--uif-select-border-color-default);
+    border-radius: var(--uif-select-border-radius);
+    padding-inline-start: var(--uif-select-padding-inline);
+    padding-inline-end: calc(var(--uif-select-padding-inline) + 1.5em);
+    padding-block: var(--uif-select-padding-block);
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m4 6 4 4 4-4'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
-    background-position: right var(--select-padding-inline) center;
+    background-position: right var(--uif-select-padding-inline) center;
     background-size: 1em;
     cursor: pointer;
   }
 
   /* --- Progressive enhancement: base-select --- */
   @supports (appearance: base-select) {
-    .select {
+    :is(.uif-select, .select) {
       appearance: base-select;
       background-image: none;
-      padding-inline-end: var(--select-padding-inline);
+      padding-inline-end: var(--uif-select-padding-inline);
     }
 
-    .select::picker-icon {
+    :is(.uif-select, .select)::picker-icon {
       content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m4 6 4 4 4-4'/%3E%3C/svg%3E");
       display: block;
       inline-size: 1em;
@@ -43,154 +43,154 @@
       transition: rotate 0.2s ease;
     }
 
-    .select:open::picker-icon {
+    :is(.uif-select, .select):open::picker-icon {
       rotate: 180deg;
     }
 
-    .select::picker(select) {
+    :is(.uif-select, .select)::picker(select) {
       appearance: base-select;
-      border: var(--select-border-size-default) solid var(--select-border-color-default);
-      border-radius: var(--select-border-radius);
-      background: var(--select-container-background-default);
+      border: var(--uif-select-border-size-default) solid var(--uif-select-border-color-default);
+      border-radius: var(--uif-select-border-radius);
+      background: var(--uif-select-container-background-default);
       padding: var(--size-spacing-100);
       transition: opacity 0.2s ease, translate 0.2s ease;
       opacity: 0;
       translate: 0 -0.5rem;
     }
 
-    .select::picker(select):popover-open {
+    :is(.uif-select, .select)::picker(select):popover-open {
       opacity: 1;
       translate: 0;
     }
 
     @starting-style {
-      .select::picker(select):popover-open {
+      :is(.uif-select, .select)::picker(select):popover-open {
         opacity: 0;
         translate: 0 -0.5rem;
       }
     }
 
-    .select option {
+    :is(.uif-select, .select) option {
       padding: 0.5rem 0.75rem;
       border-radius: var(--size-radius-200);
       cursor: pointer;
       transition: background-color 0.15s ease, color 0.15s ease;
     }
 
-    .select option:hover {
+    :is(.uif-select, .select) option:hover {
       background-color: color-mix(in srgb, currentColor 8%, transparent);
     }
 
-    .select option:checked {
+    :is(.uif-select, .select) option:checked {
       background-color: color-mix(in srgb, currentColor 12%, transparent);
       font-weight: 500;
     }
   }
 
-  .select:hover,
-  .select.is-hover {
-    background-color: var(--select-container-background-hover);
+  :is(.uif-select, .select):hover,
+  :is(.uif-select, .select).is-hover {
+    background-color: var(--uif-select-container-background-hover);
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m4 6 4 4 4-4'/%3E%3C/svg%3E");
-    border-width: var(--select-border-size-hover);
-    border-color: var(--select-border-color-hover);
-    color: var(--select-text-color-hover);
+    border-width: var(--uif-select-border-size-hover);
+    border-color: var(--uif-select-border-color-hover);
+    color: var(--uif-select-text-color-hover);
     padding-inline-start: calc(
-      var(--select-padding-inline) + var(--select-border-size-default) -
-        var(--select-border-size-hover)
+      var(--uif-select-padding-inline) + var(--uif-select-border-size-default) -
+        var(--uif-select-border-size-hover)
     );
     padding-inline-end: calc(
-      var(--select-padding-inline) + 1.5em + var(--select-border-size-default) -
-        var(--select-border-size-hover)
+      var(--uif-select-padding-inline) + 1.5em + var(--uif-select-border-size-default) -
+        var(--uif-select-border-size-hover)
     );
     padding-block: calc(
-      var(--select-padding-block) + var(--select-border-size-default) -
-        var(--select-border-size-hover)
+      var(--uif-select-padding-block) + var(--uif-select-border-size-default) -
+        var(--uif-select-border-size-hover)
     );
   }
 
   @supports (appearance: base-select) {
-    .select:hover,
-    .select.is-hover {
+    :is(.uif-select, .select):hover,
+    :is(.uif-select, .select).is-hover {
       background-image: none;
       padding-inline-end: calc(
-        var(--select-padding-inline) + var(--select-border-size-default) -
-          var(--select-border-size-hover)
+        var(--uif-select-padding-inline) + var(--uif-select-border-size-default) -
+          var(--uif-select-border-size-hover)
       );
     }
   }
 
-  .select:active,
-  .select.is-active {
-    background-color: var(--select-container-background-active);
+  :is(.uif-select, .select):active,
+  :is(.uif-select, .select).is-active {
+    background-color: var(--uif-select-container-background-active);
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m4 6 4 4 4-4'/%3E%3C/svg%3E");
-    border-width: var(--select-border-size-active);
-    border-color: var(--select-border-color-active);
-    color: var(--select-text-color-active);
+    border-width: var(--uif-select-border-size-active);
+    border-color: var(--uif-select-border-color-active);
+    color: var(--uif-select-text-color-active);
     padding-inline-start: calc(
-      var(--select-padding-inline) + var(--select-border-size-default) -
-        var(--select-border-size-active)
+      var(--uif-select-padding-inline) + var(--uif-select-border-size-default) -
+        var(--uif-select-border-size-active)
     );
     padding-inline-end: calc(
-      var(--select-padding-inline) + 1.5em + var(--select-border-size-default) -
-        var(--select-border-size-active)
+      var(--uif-select-padding-inline) + 1.5em + var(--uif-select-border-size-default) -
+        var(--uif-select-border-size-active)
     );
     padding-block: calc(
-      var(--select-padding-block) + var(--select-border-size-default) -
-        var(--select-border-size-active)
+      var(--uif-select-padding-block) + var(--uif-select-border-size-default) -
+        var(--uif-select-border-size-active)
     );
   }
 
   @supports (appearance: base-select) {
-    .select:active,
-    .select.is-active {
+    :is(.uif-select, .select):active,
+    :is(.uif-select, .select).is-active {
       background-image: none;
       padding-inline-end: calc(
-        var(--select-padding-inline) + var(--select-border-size-default) -
-          var(--select-border-size-active)
+        var(--uif-select-padding-inline) + var(--uif-select-border-size-default) -
+          var(--uif-select-border-size-active)
       );
     }
   }
 
-  .select:focus-visible,
-  .select.is-focus-visible {
-    background: var(--select-container-background-focus);
-    border-color: var(--select-border-color-focus);
+  :is(.uif-select, .select):focus-visible,
+  :is(.uif-select, .select).is-focus-visible {
+    background: var(--uif-select-container-background-focus);
+    border-color: var(--uif-select-border-color-focus);
     outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
-  .select:disabled,
-  .select[disabled],
-  .select.is-disabled {
+  :is(.uif-select, .select):disabled,
+  :is(.uif-select, .select)[disabled],
+  :is(.uif-select, .select).is-disabled {
     cursor: not-allowed;
-    color: var(--select-text-color-disabled);
-    background-color: var(--select-container-background-disabled);
+    color: var(--uif-select-text-color-disabled);
+    background-color: var(--uif-select-container-background-disabled);
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m4 6 4 4 4-4'/%3E%3C/svg%3E");
-    border-color: var(--select-border-color-disabled);
+    border-color: var(--uif-select-border-color-disabled);
   }
 
   @supports (appearance: base-select) {
-    .select:disabled,
-    .select[disabled],
-    .select.is-disabled {
+    :is(.uif-select, .select):disabled,
+    :is(.uif-select, .select)[disabled],
+    :is(.uif-select, .select).is-disabled {
       background-image: none;
     }
   }
 
-  .select.is-placeholder {
-    color: var(--select-text-color-placeholder);
+  :is(.uif-select, .select).is-placeholder {
+    color: var(--uif-select-text-color-placeholder);
   }
 
-  .select.is-invalid,
-  .select[aria-invalid="true"] {
-    border-color: var(--select-border-color-invalid);
+  :is(.uif-select, .select).is-invalid,
+  :is(.uif-select, .select)[aria-invalid="true"] {
+    border-color: var(--uif-select-border-color-invalid);
   }
 
-  .select.is-invalid:focus-visible,
-  .select[aria-invalid="true"]:focus-visible,
-  .select.is-invalid.is-focus-visible,
-  .select[aria-invalid="true"].is-focus-visible {
-    border-color: var(--select-border-color-invalid);
-    box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--select-border-color-invalid);
+  :is(.uif-select, .select).is-invalid:focus-visible,
+  :is(.uif-select, .select)[aria-invalid="true"]:focus-visible,
+  :is(.uif-select, .select).is-invalid.is-focus-visible,
+  :is(.uif-select, .select)[aria-invalid="true"].is-focus-visible {
+    border-color: var(--uif-select-border-color-invalid);
+    box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--uif-select-border-color-invalid);
   }
 }

--- a/tests/select-naming-migration.test.mjs
+++ b/tests/select-naming-migration.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("Select CSS exposes canonical UIF naming with a v1 class alias", async () => {
+  const [css, calendarCss] = await Promise.all([
+    read("src/ui/patterns/select.css"),
+    read("src/ui/patterns/calendar.css"),
+  ]);
+  assert.match(css, /:is\(\.uif-select, \.select\)/);
+  assert.match(calendarCss, /:is\(\.uif-select, \.select\)/);
+  assert.match(css, /var\(--uif-select-/);
+  assert.doesNotMatch(css, /var\(--select-/);
+  assert.doesNotMatch(css, /\.uif-select(?:__|--)/);
+});
+
+test("Select Figma export contains canonical tokens without legacy aliases", async () => {
+  const tokenExport = await read("figma/exports/Patterns (UI).tokens.json");
+  assert.equal((tokenExport.match(/var\(--uif-select-/g) ?? []).length, 31);
+  assert.doesNotMatch(tokenExport, /var\(--select-/);
+});
+
+test("Select-owned emitters and Calendar composition use canonical classes", async () => {
+  const sources = await Promise.all([
+    read("src/elements/ui-select.js"),
+    read("site/_includes/macros/ui.njk"),
+    read("site/_includes/macros/calendar.njk"),
+    read("site/assets/playground/renderers.js"),
+    read("schemas/web-select.figma.ts"),
+  ]);
+  for (const source of sources) assert.match(source, /uif-select/);
+  assert.doesNotMatch(sources[0], /class="select(?:[-\s"])/);
+});
+
+test("Select docs explain migration while registration stays stable", async () => {
+  const [documentation, element] = await Promise.all([
+    read("site/patterns/select.md"),
+    read("src/elements/ui-select.js"),
+  ]);
+  assert.match(documentation, /legacy `--select-\*` token aliases are not provided/);
+  assert.match(element, /define\("ui-select", UISelect\)/);
+});


### PR DESCRIPTION
Closes #189

## Summary
- canonicalize all 31 Select Figma WEB syntaxes and checked-in export entries to `--uif-select-*`
- emit `.uif-select` across Select, Calendar composition, Code Connect, playground, macros, and Web Components
- retain `.select` as a v1 CSS compatibility selector with no legacy token aliases
- keep `<ui-select>` and package exports stable

## Validation
- `npm run lint`
- `npm run test:unit`
- `npm run ci:check`