### PR TITLE
Migration: Adopt UIF-prefixed naming for Switch

### DIFF
--- a/figma/exports/Patterns (UI).tokens.json
+++ b/figma/exports/Patterns (UI).tokens.json
@@ -3610,7 +3610,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--switch-track-background-default)"
+              "WEB": "var(--uif-switch-track-background-default)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:329",
@@ -3632,7 +3632,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--switch-track-background-hover)"
+              "WEB": "var(--uif-switch-track-background-hover)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:329",
@@ -3654,7 +3654,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--switch-track-background-active)"
+              "WEB": "var(--uif-switch-track-background-active)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:337",
@@ -3676,7 +3676,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--switch-track-background-disabled)"
+              "WEB": "var(--uif-switch-track-background-disabled)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:330",
@@ -3700,7 +3700,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--switch-track-border-color-default)"
+              "WEB": "var(--uif-switch-track-border-color-default)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:342",
@@ -3722,7 +3722,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--switch-track-border-color-hover)"
+              "WEB": "var(--uif-switch-track-border-color-hover)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:345",
@@ -3744,7 +3744,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--switch-track-border-color-active)"
+              "WEB": "var(--uif-switch-track-border-color-active)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:345",
@@ -3766,7 +3766,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--switch-track-border-color-disabled)"
+              "WEB": "var(--uif-switch-track-border-color-disabled)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:346",
@@ -3792,7 +3792,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--switch-thumb-background-default)"
+              "WEB": "var(--uif-switch-thumb-background-default)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:342",
@@ -3814,7 +3814,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--switch-thumb-background-hover)"
+              "WEB": "var(--uif-switch-thumb-background-hover)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:345",
@@ -3836,7 +3836,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--switch-thumb-background-active)"
+              "WEB": "var(--uif-switch-thumb-background-active)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:329",
@@ -3858,7 +3858,7 @@
               "ALL_SCOPES"
             ],
             "com.figma.codeSyntax": {
-              "WEB": "var(--switch-thumb-background-disabled)"
+              "WEB": "var(--uif-switch-thumb-background-disabled)"
             },
             "com.figma.aliasData": {
               "targetVariableId": "VariableID:2007:329",
@@ -3883,7 +3883,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--switch-text-color-default)"
+            "WEB": "var(--uif-switch-text-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:326",
@@ -3905,7 +3905,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--switch-text-color-disabled)"
+            "WEB": "var(--uif-switch-text-color-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:328",

--- a/schemas/web-switch.figma.ts
+++ b/schemas/web-switch.figma.ts
@@ -6,7 +6,7 @@ figma.connect(
   {
     props: {
       className: figma.className([
-        "switch",
+        "uif-switch",
         figma.enum("Checked", {
           Unchecked: undefined,
           Checked: "is-checked",
@@ -48,11 +48,11 @@ figma.connect(
   {
     props: {
       wrapperClassName: figma.className([
-        "switch-field",
+        "uif-switch-field",
         figma.boolean("Is Disabled", { true: "is-disabled", false: undefined }),
       ]),
       className: figma.className([
-        "switch",
+        "uif-switch",
         figma.boolean("Is Disabled", { true: "is-disabled", false: undefined }),
         "is-checked",
       ]),
@@ -75,7 +75,7 @@ figma.connect(
         checked="${checked}"
         disabled="${disabled}"
       />
-      <span class="switch-field-text">${text}</span>
+      <span class="uif-switch-field-text">${text}</span>
     </label>`,
   },
 );

--- a/site/_includes/layouts/docs.njk
+++ b/site/_includes/layouts/docs.njk
@@ -469,7 +469,7 @@
         }
         document.addEventListener("change", function (e) {
           var t = e.target;
-          if (t.matches && t.matches('.uif-radio, .radio, .uif-checkbox, .checkbox, .switch')) sync(t);
+          if (t.matches && t.matches('.uif-radio, .radio, .uif-checkbox, .checkbox, .uif-switch, .switch')) sync(t);
         });
       })();
     </script>

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -82,8 +82,8 @@
 {%- endmacro %}
 
 {% macro switch(label='Notifications', checked=false, disabled=false, state='default', className='', wrapperClassName='', id='', name='', value='on') -%}
-{%- set switchClasses = "switch" -%}
-{%- set fieldClasses = "switch-field" -%}
+{%- set switchClasses = "uif-switch" -%}
+{%- set fieldClasses = "uif-switch-field" -%}
 {%- if checked -%}{%- set switchClasses = switchClasses + " is-checked" -%}{%- endif -%}
 {%- if state == "hover" -%}{%- set switchClasses = switchClasses + " is-hover" -%}{%- endif -%}
 {%- if state == "active" -%}{%- set switchClasses = switchClasses + " is-active" -%}{%- endif -%}
@@ -96,7 +96,7 @@
 {%- if wrapperClassName -%}{%- set fieldClasses = fieldClasses + " " + wrapperClassName -%}{%- endif -%}
 <label class="{{ fieldClasses }}">
   <input class="{{ switchClasses }}" type="checkbox" role="switch"{% if id %} id="{{ id }}"{% endif %}{% if name %} name="{{ name }}"{% endif %}{% if value %} value="{{ value }}"{% endif %}{% if checked %} checked{% endif %}{% if disabled or state == "disabled" %} disabled{% endif %} />
-  <span class="switch-field-text">{{ label }}</span>
+  <span class="uif-switch-field-text">{{ label }}</span>
 </label>
 {%- endmacro %}
 

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -424,12 +424,12 @@
       asBoolean(props.disabled);
 
     const wrapper = document.createElement("label");
-    const wrapperClasses = ["switch-field"];
+    const wrapperClasses = ["uif-switch-field"];
     if (disabled) wrapperClasses.push("is-disabled");
     wrapper.className = wrapperClasses.join(" ");
 
     const input = document.createElement("input");
-    const inputClasses = ["switch"];
+    const inputClasses = ["uif-switch"];
     if (checked) inputClasses.push("is-checked");
     if (previewState === "hover") inputClasses.push("is-hover");
     if (previewState === "active") inputClasses.push("is-active");
@@ -443,7 +443,7 @@
     input.setAttribute("role", "switch");
 
     const text = document.createElement("span");
-    text.className = "switch-field-text";
+    text.className = "uif-switch-field-text";
     text.textContent = labelText;
 
     wrapper.append(input, text);
@@ -456,7 +456,7 @@
     if (checked) attrs.push("checked");
     if (disabled) attrs.push("disabled");
 
-    const code = `<label class="${quoteAttr(wrapper.className)}"><input ${attrs.join(" ")} /><span class="switch-field-text">${quoteAttr(labelText)}</span></label>`;
+    const code = `<label class="${quoteAttr(wrapper.className)}"><input ${attrs.join(" ")} /><span class="uif-switch-field-text">${quoteAttr(labelText)}</span></label>`;
     return { element: wrapper, code };
   };
 

--- a/site/patterns/switch.md
+++ b/site/patterns/switch.md
@@ -191,6 +191,10 @@ Switch adapts across brands and modes through tokens. Use the hero switches abov
 
 For the full theming architecture see [Foundations: Theming](/foundations/theming/).
 
+<h2 id="v1-naming-migration">v1 naming migration</h2>
+
+Switch emitters now produce `.uif-switch`, `.uif-switch-field`, and `.uif-switch-field-text`. The legacy `.switch` and `.switch-field` selectors remain supported during the v1 compatibility period. Component token slots are now `--uif-switch-*`; library-owned legacy `--switch-*` token aliases are not provided. The existing `<ui-switch>` registration and package export remain unchanged.
+
 <h2 id="design-checklist">Design checklist</h2>
 
 <div class="docs-checklist">

--- a/src/elements/ui-switch.js
+++ b/src/elements/ui-switch.js
@@ -28,7 +28,7 @@ class UISwitch extends UIElement {
       this.warnDev("[ui-foundations] <ui-switch> should have a label or aria-label.");
     }
 
-    const inputAttrs = ['type="checkbox"', 'role="switch"', 'class="switch"'];
+    const inputAttrs = ['type="checkbox"', 'role="switch"', 'class="uif-switch"'];
     if (checked) inputAttrs.push("checked");
     if (disabled) inputAttrs.push("disabled");
     if (name) inputAttrs.push(`name="${name}"`);
@@ -40,12 +40,12 @@ class UISwitch extends UIElement {
       return;
     }
 
-    const wrapperClasses = ["switch-field"];
+    const wrapperClasses = ["uif-switch-field"];
     if (disabled) wrapperClasses.push("is-disabled");
 
     this.innerHTML = `<label class="${wrapperClasses.join(" ")}">
   <input ${inputAttrs.join(" ")} />
-  <span class="switch-field-text">${label}</span>
+  <span class="uif-switch-field-text">${label}</span>
 </label>`;
   }
 }

--- a/src/ui/patterns/switch.css
+++ b/src/ui/patterns/switch.css
@@ -1,5 +1,5 @@
 @layer components {
-  .switch-field {
+  :is(.uif-switch-field, .switch-field) {
     display: inline-flex;
     align-items: center;
     gap: var(--typography-label-gap);
@@ -7,16 +7,16 @@
     font-weight: var(--typography-label-font-weight);
     font-size: var(--typography-label-font-size);
     line-height: var(--typography-label-line-height);
-    color: var(--switch-text-color-default);
+    color: var(--uif-switch-text-color-default);
     cursor: pointer;
   }
 
-  .switch-field.is-disabled {
-    color: var(--switch-text-color-disabled);
+  :is(.uif-switch-field, .switch-field).is-disabled {
+    color: var(--uif-switch-text-color-disabled);
     cursor: not-allowed;
   }
 
-  .switch {
+  :is(.uif-switch, .switch) {
     --_switch-inline-size: var(--size-spacing-1000);
     --_switch-block-size: var(--size-spacing-600);
     --_switch-padding: var(--size-spacing-100);
@@ -32,9 +32,9 @@
     flex: 0 0 auto;
     border-style: solid;
     border-width: var(--size-border-100);
-    border-color: var(--switch-track-border-color-default);
+    border-color: var(--uif-switch-track-border-color-default);
     border-radius: var(--size-radius-full);
-    background: var(--switch-track-background-default);
+    background: var(--uif-switch-track-background-default);
     cursor: pointer;
     transition:
       background-color 160ms ease,
@@ -42,7 +42,7 @@
       opacity 160ms ease;
   }
 
-  .switch::after {
+  :is(.uif-switch, .switch)::after {
     content: "";
     position: absolute;
     inset-block-start: 50%;
@@ -51,105 +51,105 @@
     block-size: var(--_switch-thumb-size);
     box-sizing: border-box;
     border-radius: var(--size-radius-full);
-    background: var(--switch-thumb-background-default);
+    background: var(--uif-switch-thumb-background-default);
     transform: translate(0, -50%);
     transition:
       transform 160ms ease,
       background-color 160ms ease;
   }
 
-  .switch:checked,
-  .switch.is-checked {
-    border-color: var(--switch-track-border-color-active);
-    background: var(--switch-track-background-active);
+  :is(.uif-switch, .switch):checked,
+  :is(.uif-switch, .switch).is-checked {
+    border-color: var(--uif-switch-track-border-color-active);
+    background: var(--uif-switch-track-background-active);
   }
 
-  .switch:checked::after,
-  .switch.is-checked::after {
-    background: var(--switch-thumb-background-active);
+  :is(.uif-switch, .switch):checked::after,
+  :is(.uif-switch, .switch).is-checked::after {
+    background: var(--uif-switch-thumb-background-active);
     transform: translate(
       calc(var(--_switch-inline-size) - var(--_switch-block-size)),
       -50%
     );
   }
 
-  .switch:hover,
-  .switch.is-hover {
+  :is(.uif-switch, .switch):hover,
+  :is(.uif-switch, .switch).is-hover {
     background:
       linear-gradient(0deg, var(--color-overlay-hover), var(--color-overlay-hover)),
-      var(--switch-track-background-hover);
-    border-color: var(--switch-track-border-color-hover);
+      var(--uif-switch-track-background-hover);
+    border-color: var(--uif-switch-track-border-color-hover);
   }
 
-  .switch:hover::after,
-  .switch.is-hover::after {
-    background: var(--switch-thumb-background-hover);
+  :is(.uif-switch, .switch):hover::after,
+  :is(.uif-switch, .switch).is-hover::after {
+    background: var(--uif-switch-thumb-background-hover);
   }
 
-  .switch:checked:hover,
-  .switch.is-checked.is-hover {
+  :is(.uif-switch, .switch):checked:hover,
+  :is(.uif-switch, .switch).is-checked.is-hover {
     background:
       linear-gradient(0deg, var(--color-overlay-hover), var(--color-overlay-hover)),
-      var(--switch-track-background-active);
+      var(--uif-switch-track-background-active);
   }
 
-  .switch:checked:hover::after,
-  .switch.is-checked.is-hover::after {
-    background: var(--switch-thumb-background-active);
+  :is(.uif-switch, .switch):checked:hover::after,
+  :is(.uif-switch, .switch).is-checked.is-hover::after {
+    background: var(--uif-switch-thumb-background-active);
   }
 
-  .switch:active,
-  .switch.is-active {
+  :is(.uif-switch, .switch):active,
+  :is(.uif-switch, .switch).is-active {
     background:
       linear-gradient(0deg, var(--color-overlay-active), var(--color-overlay-active)),
-      var(--switch-track-background-hover);
-    border-color: var(--switch-track-border-color-hover);
+      var(--uif-switch-track-background-hover);
+    border-color: var(--uif-switch-track-border-color-hover);
   }
 
-  .switch:active::after,
-  .switch.is-active::after {
-    background: var(--switch-thumb-background-hover);
+  :is(.uif-switch, .switch):active::after,
+  :is(.uif-switch, .switch).is-active::after {
+    background: var(--uif-switch-thumb-background-hover);
   }
 
-  .switch:checked:active,
-  .switch.is-checked.is-active {
+  :is(.uif-switch, .switch):checked:active,
+  :is(.uif-switch, .switch).is-checked.is-active {
     background:
       linear-gradient(0deg, var(--color-overlay-active), var(--color-overlay-active)),
-      var(--switch-track-background-active);
+      var(--uif-switch-track-background-active);
   }
 
-  .switch:checked:active::after,
-  .switch.is-checked.is-active::after {
-    background: var(--switch-thumb-background-active);
+  :is(.uif-switch, .switch):checked:active::after,
+  :is(.uif-switch, .switch).is-checked.is-active::after {
+    background: var(--uif-switch-thumb-background-active);
   }
 
-  .switch:focus-visible,
-  .switch.is-focus-visible {
-    border-color: var(--switch-track-border-color-active);
+  :is(.uif-switch, .switch):focus-visible,
+  :is(.uif-switch, .switch).is-focus-visible {
+    border-color: var(--uif-switch-track-border-color-active);
     outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
-  .switch:disabled,
-  .switch.is-disabled {
+  :is(.uif-switch, .switch):disabled,
+  :is(.uif-switch, .switch).is-disabled {
     cursor: not-allowed;
     opacity: 0.6;
   }
 
-  .switch:disabled:not(:checked),
-  .switch.is-disabled:not(.is-checked) {
-    border-color: var(--switch-track-border-color-disabled);
-    background: var(--switch-track-background-disabled);
+  :is(.uif-switch, .switch):disabled:not(:checked),
+  :is(.uif-switch, .switch).is-disabled:not(.is-checked) {
+    border-color: var(--uif-switch-track-border-color-disabled);
+    background: var(--uif-switch-track-background-disabled);
   }
 
-  .switch:disabled::after,
-  .switch.is-disabled::after {
-    background: var(--switch-thumb-background-disabled);
+  :is(.uif-switch, .switch):disabled::after,
+  :is(.uif-switch, .switch).is-disabled::after {
+    background: var(--uif-switch-thumb-background-disabled);
   }
 
-  .switch:checked:disabled,
-  .switch.is-checked.is-disabled {
-    border-color: var(--switch-track-border-color-disabled);
-    background: var(--switch-track-background-active);
+  :is(.uif-switch, .switch):checked:disabled,
+  :is(.uif-switch, .switch).is-checked.is-disabled {
+    border-color: var(--uif-switch-track-border-color-disabled);
+    background: var(--uif-switch-track-background-active);
   }
 }

--- a/tests/switch-naming-migration.test.mjs
+++ b/tests/switch-naming-migration.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("Switch CSS exposes canonical UIF naming with v1 class aliases", async () => {
+  const css = await read("src/ui/patterns/switch.css");
+  for (const name of ["switch", "switch-field"]) assert.match(css, new RegExp(`:is\\(\\.uif-${name}, \\.${name}\\)`));
+  assert.match(css, /var\(--uif-switch-/);
+  assert.doesNotMatch(css, /var\(--switch-/);
+  assert.doesNotMatch(css, /\.uif-switch(?:__|--)/);
+});
+
+test("Switch Figma export contains canonical tokens without legacy aliases", async () => {
+  const tokenExport = await read("figma/exports/Patterns (UI).tokens.json");
+  assert.equal((tokenExport.match(/var\(--uif-switch-/g) ?? []).length, 14);
+  assert.doesNotMatch(tokenExport, /var\(--switch-/);
+});
+
+test("Switch-owned emitters and behavior use canonical classes", async () => {
+  const [element, macros, renderer, schema, behavior] = await Promise.all([
+    read("src/elements/ui-switch.js"), read("site/_includes/macros/ui.njk"),
+    read("site/assets/playground/renderers.js"), read("schemas/web-switch.figma.ts"),
+    read("site/_includes/layouts/docs.njk"),
+  ]);
+  for (const source of [element, macros, renderer, schema]) assert.match(source, /uif-switch/);
+  assert.match(behavior, /\.uif-switch, \.switch/);
+  assert.doesNotMatch(element, /class="switch(?:[-\s"])/);
+});
+
+test("Switch docs explain migration while registration stays stable", async () => {
+  const [documentation, element] = await Promise.all([read("site/patterns/switch.md"), read("src/elements/ui-switch.js")]);
+  assert.match(documentation, /legacy `--switch-\*` token aliases are not provided/);
+  assert.match(element, /define\("ui-switch", UISwitch\)/);
+});


### PR DESCRIPTION
Closes #191

## Summary
- canonicalize all 14 Switch Figma WEB syntaxes and checked-in export entries to `--uif-switch-*`
- emit canonical `.uif-switch`, `.uif-switch-field`, and `.uif-switch-field-text` across public surfaces
- retain `.switch` and `.switch-field` as v1 CSS compatibility selectors with no legacy token aliases
- keep `<ui-switch>` and package exports stable

## Validation
- `npm run lint`
- `npm run test:unit`
- `npm run ci:check`