### PR TITLE
Migration: Adopt UIF-prefixed naming for Textarea

### DIFF
--- a/figma/exports/Patterns (UI).tokens.json
+++ b/figma/exports/Patterns (UI).tokens.json
@@ -4855,7 +4855,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--textarea-text-color-default)"
+            "WEB": "var(--uif-textarea-text-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:326",
@@ -4877,7 +4877,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--textarea-text-color-disabled)"
+            "WEB": "var(--uif-textarea-text-color-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:328",
@@ -4899,7 +4899,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--textarea-text-color-placeholder)"
+            "WEB": "var(--uif-textarea-text-color-placeholder)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:328",
@@ -4923,7 +4923,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--textarea-border-color-default)"
+            "WEB": "var(--uif-textarea-border-color-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:342",
@@ -4945,7 +4945,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--textarea-border-color-hover)"
+            "WEB": "var(--uif-textarea-border-color-hover)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:344",
@@ -4967,7 +4967,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--textarea-border-color-focus)"
+            "WEB": "var(--uif-textarea-border-color-focus)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:345",
@@ -4989,7 +4989,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--textarea-border-color-disabled)"
+            "WEB": "var(--uif-textarea-border-color-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:346",
@@ -5011,7 +5011,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--textarea-border-size-default)"
+            "WEB": "var(--uif-textarea-border-size-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:3022:7",
@@ -5033,7 +5033,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--textarea-border-radius)"
+            "WEB": "var(--uif-textarea-border-radius)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2028:335",
@@ -5057,7 +5057,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--textarea-container-background-default)"
+            "WEB": "var(--uif-textarea-container-background-default)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:329",
@@ -5079,7 +5079,7 @@
             "ALL_SCOPES"
           ],
           "com.figma.codeSyntax": {
-            "WEB": "var(--textarea-container-background-disabled)"
+            "WEB": "var(--uif-textarea-container-background-disabled)"
           },
           "com.figma.aliasData": {
             "targetVariableId": "VariableID:2007:330",
@@ -5102,7 +5102,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--textarea-font-family)"
+          "WEB": "var(--uif-textarea-font-family)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:2006:213",
@@ -5124,7 +5124,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--textarea-font-size)"
+          "WEB": "var(--uif-textarea-font-size)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3014:13",
@@ -5146,7 +5146,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--textarea-line-height)"
+          "WEB": "var(--uif-textarea-line-height)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3014:14",
@@ -5168,7 +5168,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--textarea-padding-inline)"
+          "WEB": "var(--uif-textarea-padding-inline)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:4",
@@ -5190,7 +5190,7 @@
           "ALL_SCOPES"
         ],
         "com.figma.codeSyntax": {
-          "WEB": "var(--textarea-padding-block)"
+          "WEB": "var(--uif-textarea-padding-block)"
         },
         "com.figma.aliasData": {
           "targetVariableId": "VariableID:3022:4",

--- a/schemas/web-textarea.figma.ts
+++ b/schemas/web-textarea.figma.ts
@@ -6,7 +6,7 @@ figma.connect(
   {
     props: {
       className: figma.className([
-        "textarea",
+        "uif-textarea",
         figma.enum("State", {
           Default: undefined,
           Hover: "is-hover",

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -163,7 +163,7 @@
 {%- endmacro %}
 
 {% macro textarea(placeholder='', value='', disabled=false, readonly=false, rows='', state='default', className='') -%}
-{%- set classes = "textarea" -%}
+{%- set classes = "uif-textarea" -%}
 {%- if state == "hover" -%}{%- set classes = classes + " is-hover" -%}{%- endif -%}
 {%- if state == "focus" -%}{%- set classes = classes + " is-focus-visible" -%}{%- endif -%}
 {%- if state == "disabled" or disabled -%}{%- set classes = classes + " is-disabled" -%}{%- endif -%}

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -615,14 +615,14 @@
     const rows = props.rows || "3";
 
     const element = document.createElement("textarea");
-    element.className = "textarea";
+    element.className = "uif-textarea";
     element.placeholder = placeholder;
     element.value = value;
     element.rows = Number(rows);
     if (disabled) { element.disabled = true; element.classList.add("is-disabled"); }
     if (readonly) element.readOnly = true;
 
-    const attrs = [`class="textarea"`, `placeholder="${quoteAttr(placeholder)}"`, `rows="${rows}"`];
+    const attrs = [`class="uif-textarea"`, `placeholder="${quoteAttr(placeholder)}"`, `rows="${rows}"`];
     if (disabled) attrs.push("disabled");
     if (readonly) attrs.push("readonly");
     const code = `<textarea ${attrs.join(" ")}>${quoteAttr(value)}</textarea>`;

--- a/site/patterns/textarea.md
+++ b/site/patterns/textarea.md
@@ -116,11 +116,15 @@ playgroundLabel: Open TextArea Playground
 - Always pair with a visible `<label>` or `aria-label`.
 - Placeholder text is not a substitute for a label.
 
+<h2 id="v1-naming-migration">v1 naming migration</h2>
+
+Textarea emitters now produce `.uif-textarea`. The legacy `.textarea` selector remains supported during the v1 compatibility period. Component token slots are now `--uif-textarea-*`; library-owned legacy `--textarea-*` token aliases are not provided. The existing `<ui-textarea>` registration and package export remain unchanged.
+
 <h2 id="design-checklist">Design checklist</h2>
 
 <div class="docs-checklist">
   <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>All brand/mode contexts</strong><span>Works across light and dark modes.</span></div></div>
   <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Defined options</strong><span>States and properties documented.</span></div></div>
   <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Keyboard interactions</strong><span>Native textarea behavior.</span></div></div>
-  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Design tokens</strong><span>Component-scoped tokens (<code>--textarea-*</code>).</span></div></div>
+  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Design tokens</strong><span>Component-scoped tokens (<code>--uif-textarea-*</code>).</span></div></div>
 </div>

--- a/src/elements/ui-textarea.js
+++ b/src/elements/ui-textarea.js
@@ -31,7 +31,7 @@ class UITextarea extends UIElement {
       this.warnDev("[ui-foundations] <ui-textarea> should have an id, aria-label, or aria-labelledby.");
     }
 
-    const attrs = ['class="textarea"'];
+    const attrs = ['class="uif-textarea"'];
     if (placeholder) attrs.push(`placeholder="${placeholder}"`);
     if (disabled) attrs.push("disabled");
     if (readonly) attrs.push("readonly");

--- a/src/ui/patterns/textarea.css
+++ b/src/ui/patterns/textarea.css
@@ -1,49 +1,49 @@
 @layer components {
-  .textarea {
+  :is(.uif-textarea, .textarea) {
     display: block;
     inline-size: 100%;
-    min-block-size: calc(var(--textarea-line-height) * 3 + var(--textarea-padding-block) * 2);
-    padding-inline: var(--textarea-padding-inline);
-    padding-block: var(--textarea-padding-block);
-    font-family: var(--textarea-font-family);
-    font-size: var(--textarea-font-size);
-    line-height: var(--textarea-line-height);
-    color: var(--textarea-text-color-default);
-    background: var(--textarea-container-background-default);
-    border: var(--textarea-border-size-default) solid var(--textarea-border-color-default);
-    border-radius: var(--textarea-border-radius);
+    min-block-size: calc(var(--uif-textarea-line-height) * 3 + var(--uif-textarea-padding-block) * 2);
+    padding-inline: var(--uif-textarea-padding-inline);
+    padding-block: var(--uif-textarea-padding-block);
+    font-family: var(--uif-textarea-font-family);
+    font-size: var(--uif-textarea-font-size);
+    line-height: var(--uif-textarea-line-height);
+    color: var(--uif-textarea-text-color-default);
+    background: var(--uif-textarea-container-background-default);
+    border: var(--uif-textarea-border-size-default) solid var(--uif-textarea-border-color-default);
+    border-radius: var(--uif-textarea-border-radius);
     resize: vertical;
     transition: border-color 0.15s ease;
   }
 
-  .textarea::placeholder {
-    color: var(--textarea-text-color-placeholder);
+  :is(.uif-textarea, .textarea)::placeholder {
+    color: var(--uif-textarea-text-color-placeholder);
   }
 
-  .textarea:hover,
-  .textarea.is-hover {
-    border-color: var(--textarea-border-color-hover);
+  :is(.uif-textarea, .textarea):hover,
+  :is(.uif-textarea, .textarea).is-hover {
+    border-color: var(--uif-textarea-border-color-hover);
   }
 
-  .textarea:focus-visible,
-  .textarea.is-focus-visible {
-    border-color: var(--textarea-border-color-focus);
+  :is(.uif-textarea, .textarea):focus-visible,
+  :is(.uif-textarea, .textarea).is-focus-visible {
+    border-color: var(--uif-textarea-border-color-focus);
     outline: 2px solid transparent;
     box-shadow: 0 0 var(--shadow-focus, 0) 0 var(--color-focus, transparent);
   }
 
-  .textarea:disabled,
-  .textarea.is-disabled {
-    color: var(--textarea-text-color-disabled);
-    background: var(--textarea-container-background-disabled);
-    border-color: var(--textarea-border-color-disabled);
+  :is(.uif-textarea, .textarea):disabled,
+  :is(.uif-textarea, .textarea).is-disabled {
+    color: var(--uif-textarea-text-color-disabled);
+    background: var(--uif-textarea-container-background-disabled);
+    border-color: var(--uif-textarea-border-color-disabled);
     cursor: not-allowed;
     resize: none;
   }
 
-  .textarea[readonly] {
-    background: var(--textarea-container-background-default);
-    border-color: var(--textarea-border-color-default);
+  :is(.uif-textarea, .textarea)[readonly] {
+    background: var(--uif-textarea-container-background-default);
+    border-color: var(--uif-textarea-border-color-default);
     cursor: default;
     resize: none;
   }

--- a/tests/textarea-naming-migration.test.mjs
+++ b/tests/textarea-naming-migration.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("Textarea CSS exposes canonical UIF naming with a v1 class alias", async () => {
+  const css = await read("src/ui/patterns/textarea.css");
+  assert.match(css, /:is\(\.uif-textarea, \.textarea\)/);
+  assert.match(css, /var\(--uif-textarea-/);
+  assert.doesNotMatch(css, /var\(--textarea-/);
+  assert.doesNotMatch(css, /\.uif-textarea(?:__|--)/);
+});
+
+test("Textarea Figma export contains canonical tokens without legacy aliases", async () => {
+  const tokenExport = await read("figma/exports/Patterns (UI).tokens.json");
+  assert.equal((tokenExport.match(/var\(--uif-textarea-/g) ?? []).length, 16);
+  assert.doesNotMatch(tokenExport, /var\(--textarea-/);
+});
+
+test("Textarea-owned emitters use the canonical class", async () => {
+  const sources = await Promise.all([
+    read("src/elements/ui-textarea.js"), read("site/_includes/macros/ui.njk"),
+    read("site/assets/playground/renderers.js"), read("schemas/web-textarea.figma.ts"),
+  ]);
+  for (const source of sources) assert.match(source, /uif-textarea/);
+  assert.doesNotMatch(sources[0], /class="textarea(?:[-\s"])/);
+});
+
+test("Textarea docs explain migration while registration stays stable", async () => {
+  const [documentation, element] = await Promise.all([read("site/patterns/textarea.md"), read("src/elements/ui-textarea.js")]);
+  assert.match(documentation, /legacy `--textarea-\*` token aliases are not provided/);
+  assert.match(element, /define\("ui-textarea", UITextarea\)/);
+});


### PR DESCRIPTION
Closes #193

## Summary
- canonicalize all 16 Textarea Figma WEB syntaxes and checked-in export entries to `--uif-textarea-*`
- emit `.uif-textarea` across macros, Web Components, Code Connect, and playground output
- retain `.textarea` as a v1 CSS compatibility selector with no legacy token aliases
- keep `<ui-textarea>` and package exports stable

## Validation
- `npm run lint`
- `npm run test:unit`
- `npm run ci:check`