### PR TITLE
Complete UIF naming migration audit

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -75,10 +75,10 @@ Notes:
 
 - Canonical public pattern tokens follow the consumed Vault Naming Contract:
   `Component.variant.part.property.state` → `--uif-component-variant-part-property-state`
-- Migrated components emit only canonical token names. Button uses
-  `--uif-button-*` and intentionally provides no library-owned `--button-*`
-  aliases. Components that have not yet migrated may still expose unscoped
-  names until their scoped migration is approved.
+- All repository-owned component emitters use canonical `--uif-*` token names.
+  Library-owned unprefixed component token aliases are intentionally not
+  provided. Deprecated bare classes remain CSS-only compatibility selectors
+  through v1.x and are not emitted by owned templates or generators.
 - Brand semantic: role-based and brand-scoped (e.g. `Brand.Color.*`, `Brand.Corner.*`)
 - States: `default`, `hover`, `active`, `focus`, `disabled`
 - CSS variables: kebab-case with `--`

--- a/docs/agentic/assistant-behavior-rules.md
+++ b/docs/agentic/assistant-behavior-rules.md
@@ -32,10 +32,10 @@ type: agent-guide
    - Code Connect file in `schemas/web-<pattern>.figma.ts`
    - Pattern card in `site/patterns/index.md`
    Missing any of these (especially the playground renderer) will cause broken pages.
-9. Every new pattern must have its own pattern-layer tokens. Never reuse tokens from another pattern (e.g. do not use `--input-checkbox-*` for a radio).
+9. Every new pattern must have its own pattern-layer tokens. Never reuse tokens from another pattern (e.g. do not use `--uif-input-checkbox-*` for a radio).
    - Check `dist/tokens/css/patterns-ui.tokens.css` for existing tokens.
    - If the pattern has no tokens in Figma yet, propose new public token slots following the Vault naming pattern `--uif-<pattern>-<part>-<property>-<state>` and add them to the `Patterns (UI)` collection, referencing only Semantics (Brands), Appearance, or Core tokens.
-   - Migrated patterns emit canonical `--uif-*` tokens only. Button has no library-owned `--button-*` alias; components that have not yet migrated may retain unscoped tokens until their scoped migration is approved.
+   - All repository-owned pattern emitters use canonical `--uif-*` tokens only. Library-owned unprefixed component token aliases are not provided.
    - This keeps patterns independently adaptable across brand/mode context and avoids hidden coupling.
 10. Token alias references must point to tokens that actually exist in the system.
     - Before adding a `$ref`, verify the target exists in `dist/tokens/css/` (Core, Appearance, Semantics (Brands)).
@@ -44,7 +44,7 @@ type: agent-guide
     - If a needed Semantic token does not exist, flag it for creation in Figma first.
 11. CSS class naming must follow the consumed Vault Naming Contract from `.uif/packs/governance/contracts/naming-contract.json`; runtime generates its local naming contract from that artifact.
     - Local examples such as `.uif-slider`, `.uif-radio`, and `.uif-checkbox` are examples only, not source rules.
-    - Existing bare pattern classes such as `.button`, `.radio`, and `.checkbox` are deprecated legacy compatibility and should warn during migration.
+    - Existing bare pattern classes such as `.button`, `.radio`, and `.checkbox` are deprecated CSS-only compatibility selectors through v1.x. Repository-owned emitters must produce canonical `.uif-*` classes only.
     - Never use `.ui-` or other non-Vault namespaces.
     - CSS patterns must be wrapped in `@layer components { }`.
 12. Web Components are the canonical convenience layer:

--- a/docs/foundations/foundation-013-class-naming.md
+++ b/docs/foundations/foundation-013-class-naming.md
@@ -69,8 +69,8 @@ namespace prefixes.
 
 ### Migration Note
 
-Some runtime artifacts still use bare classes such as `.select` and `.checkbox`.
-Button emitters now use `.uif-button`; `.button` remains a
-deprecated CSS-only compatibility selector through v1.x. Runtime validation
-should warn with migration guidance rather than fail existing artifacts without
-context.
+All repository-owned emitters use canonical `.uif-*` classes. Bare classes such
+as `.button`, `.select`, and `.checkbox` remain deprecated CSS-only
+compatibility selectors through v1.x; templates, examples, generators, and
+Custom Elements do not emit them. Their removal is Wave 4 work for v2.0 or
+later.

--- a/packages/mcp-server/src/resources/components.ts
+++ b/packages/mcp-server/src/resources/components.ts
@@ -152,10 +152,10 @@ function generateHtmlPattern(componentName: string, cssContent: string): string 
     return `<input class="${className}" type="text" />`;
   }
   if (componentName === 'checkbox') {
-    return `<input class="checkbox" type="checkbox" />`;
+    return `<input class="${className}" type="checkbox" />`;
   }
   if (componentName === 'radio') {
-    return `<input class="radio" type="radio" />`;
+    return `<input class="${className}" type="radio" />`;
   }
   if (componentName === 'switch') {
     return `<button class="${className}" role="switch" aria-checked="false">Label</button>`;

--- a/site/_includes/macros/playground.njk
+++ b/site/_includes/macros/playground.njk
@@ -83,7 +83,7 @@
           ) }}
           <button
             type="button"
-            class="button ghost playground-color-pick"
+            class="uif-button ghost playground-color-pick"
             data-playground-color-button
             data-target-control="{{ controlId }}"
           >
@@ -168,7 +168,7 @@
       {% endif %}
       {% endfor %}
       <div class="playground-actions">
-        <button type="button" class="button ghost" data-playground-reset>
+        <button type="button" class="uif-button ghost" data-playground-reset>
           Reset
         </button>
       </div>
@@ -177,10 +177,10 @@
 
   <section class="playground-code-panel">
     <div class="code-tabs">
-      <div class="code-tabs-bar button-group" role="group" data-orientation="horizontal" data-attached="true" data-justify="start" aria-label="Code format">
-        <a class="button outline" href="#{{ playgroundId }}-tab-html">HTML</a>
-        <a class="button outline" href="#{{ playgroundId }}-tab-njk">Nunjucks</a>
-        <a class="button outline" href="#{{ playgroundId }}-tab-wc">Web Component</a>
+      <div class="code-tabs-bar uif-button-group" role="group" data-orientation="horizontal" data-attached="true" data-justify="start" aria-label="Code format">
+        <a class="uif-button outline" href="#{{ playgroundId }}-tab-html">HTML</a>
+        <a class="uif-button outline" href="#{{ playgroundId }}-tab-njk">Nunjucks</a>
+        <a class="uif-button outline" href="#{{ playgroundId }}-tab-wc">Web Component</a>
       </div>
       <div class="code-tabs-panels">
         <div class="code-tabs-panel" id="{{ playgroundId }}-tab-html">

--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -1,5 +1,5 @@
 {% macro toggleButton(label, dataName, dataValue, variant='outline') -%}
-{%- set classes = "button" -%}
+{%- set classes = "uif-button" -%}
 {%- if variant -%}{%- set classes = classes + " " + variant -%}{%- endif -%}
 <button class="{{ classes }}" type="button"{% if dataName == "mode" %} data-mode="{{ dataValue }}"{% endif %}{% if dataName == "brand" %} data-brand="{{ dataValue }}"{% endif %}{% if dataName == "lang" %} data-lang="{{ dataValue }}"{% endif %} aria-pressed="false">{{ label }}</button>
 {%- endmacro %}

--- a/site/assets/playground/renderers.js
+++ b/site/assets/playground/renderers.js
@@ -955,7 +955,7 @@
     trigger.className = "uif-tooltip-trigger";
 
     const btn = document.createElement("button");
-    btn.className = "button outline";
+    btn.className = "uif-button outline";
     btn.type = "button";
     btn.textContent = String(children || "Hover me");
     trigger.append(btn);
@@ -968,7 +968,7 @@
     trigger.append(tip);
 
     const code = `<span class="uif-tooltip-trigger">
-  <button class="button outline" type="button">${quoteAttr(String(children || "Hover me"))}</button>
+  <button class="uif-button outline" type="button">${quoteAttr(String(children || "Hover me"))}</button>
   <span class="uif-tooltip" role="tooltip" data-placement="${quoteAttr(placement)}">${quoteAttr(text)}</span>
 </span>`;
 

--- a/site/foundations/class-naming.md
+++ b/site/foundations/class-naming.md
@@ -63,7 +63,8 @@ The examples below illustrate the consumed contract. They are not source rules.
 
 ## Migration
 
-Some runtime artifacts still use bare classes such as `.select` and `.checkbox`.
-Button emitters now use `.uif-button`; `.button` remains a
-deprecated CSS-only compatibility selector through v1.x. Runtime validation
-warns with migration guidance while the migration is in progress.
+All repository-owned emitters use canonical `.uif-*` classes. Bare classes such
+as `.button`, `.select`, and `.checkbox` remain deprecated CSS-only
+compatibility selectors through v1.x; templates, examples, generators, and
+Custom Elements do not emit them. Their removal is Wave 4 work for v2.0 or
+later.

--- a/tests/naming-migration-completion.test.mjs
+++ b/tests/naming-migration-completion.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+function filesUnder(relativePath, extensions) {
+  const files = [];
+  const visit = (directory) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) visit(entryPath);
+      else if (extensions.has(path.extname(entryPath))) files.push(entryPath);
+    }
+  };
+  visit(path.join(root, relativePath));
+  return files;
+}
+
+test("the consumed naming contract reports no repository-owned legacy usage", () => {
+  const result = spawnSync(process.execPath, ["scripts/check-vault-naming-contract.mjs"], {
+    cwd: root,
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.doesNotMatch(`${result.stdout}${result.stderr}`, /Naming deprecation warning/);
+  assert.match(result.stdout, /passed \(0 legacy usage warnings\)/);
+});
+
+test("owned templates, previews, schemas, elements, and MCP fixtures do not emit legacy classes", () => {
+  const extensionSet = new Set([".js", ".mjs", ".njk", ".ts"]);
+  const files = [
+    ...filesUnder("src/elements", extensionSet),
+    ...filesUnder("site/_includes", extensionSet),
+    ...filesUnder("site/assets/playground", extensionSet),
+    ...filesUnder("schemas", extensionSet),
+    ...filesUnder("packages/mcp-server/src", extensionSet),
+  ];
+  const legacyNames =
+    "accordion|avatar|badge|button-group|button|calendar|checkbox|divider|form|icon|input|label-content|label|link|radio|select|switch|tab-list|tab-panel|tab|tabs|textarea|tooltip";
+  const literalClass = new RegExp(
+    `(?:class=["']|className\\s*=\\s*["'])(?:${legacyNames})(?:\\s|["'])`,
+  );
+  const legacyClassSeed = new RegExp(
+    `set\\s+[A-Za-z]*[Cc]lasses\\s*=\\s*["'](?:${legacyNames})(?:\\s|["'])`,
+  );
+
+  for (const file of files) {
+    const source = fs.readFileSync(file, "utf8");
+    assert.doesNotMatch(source, literalClass, path.relative(root, file));
+    assert.doesNotMatch(source, legacyClassSeed, path.relative(root, file));
+  }
+});
+
+test("completion guidance defines canonical owned output and v1 CSS-only compatibility", () => {
+  for (const relativePath of [
+    "site/foundations/class-naming.md",
+    "docs/foundations/foundation-013-class-naming.md",
+  ]) {
+    const documentation = read(relativePath);
+    assert.match(documentation, /All repository-owned emitters use canonical `\.uif-\*` classes/);
+    assert.match(documentation, /deprecated CSS-only\s+compatibility selectors through v1\.x/);
+    assert.match(documentation, /Wave 4 work for v2\.0 or\s+later/);
+  }
+});


### PR DESCRIPTION
Closes #195.

## What changed

- corrected the remaining repository-owned emitters that produced legacy Button, ButtonGroup, Checkbox, or Radio classes
- made MCP-generated Checkbox and Radio examples resolve their canonical UIF class
- updated governance and class-naming guidance to reflect completion of Waves 2 and 3
- added a cross-cutting regression test covering zero naming warnings and canonical output across templates, previews, schemas, elements, and MCP fixtures

CSS-only legacy selector compatibility through v1.x remains unchanged. No library-owned legacy token aliases were added, and Wave 4 removal remains reserved for v2.0 or later.

## Validation

- `npm run lint`
- `npm run test:unit` (166 tests)
- `npm run naming:check` (0 warnings)
- `npm run build:all`
- `npm run docs:site`
- `npm run ci:check`
- MCP unit tests (368 tests) and TypeScript build
- `npm pack --dry-run --json` (705 entries; required output present; no React entries)
- regenerated `dist/` inspection (canonical emitters, no legacy component token references)
