### PR TITLE
Consolidate v1 naming migration guidance

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,104 @@
+# UI Foundations v1 migration guide
+
+This repository-only guide collects the consumer changes required for UI
+Foundations v1. Migration history does not belong on individual component pages:
+those pages document the current API, while this file owns the release boundary,
+compatibility policy, and old-to-new mappings.
+
+## Public naming in v1
+
+All UIF-owned public APIs use the canonical `uif` namespace unless a separately
+approved contract governs the surface:
+
+| Surface | Before v1 | v1 | Compatibility |
+|---|---|---|---|
+| CSS classes | `.component`, `.component-part` | `.uif-component`, `.uif-component-part` | Legacy selectors remain CSS-only aliases through v1.x. |
+| Component tokens | `--component-*` | `--uif-component-*` | No library-owned legacy token aliases or fallbacks. |
+| Nunjucks usage | `ui.*` | consumer-selected alias `uif.*` | The macro module path and named exports are unchanged. |
+| Custom Elements | `<ui-*>` | `<uif-*>` | Direct breaking rename; no alias or dual registration. |
+
+The class migration is prefix-only. UIF continues to use flat class chains,
+chained variant classes such as `.outline`, and `.is-*` authored states. It does
+not introduce BEM names.
+
+## Consumer migration sequence
+
+1. Update Figma integrations and token overrides from `--component-*` to
+   `--uif-component-*`.
+2. Update authored and generated markup to `.uif-*` classes. Do not depend on
+   the v1.x selector aliases for new work.
+3. Import the existing Nunjucks macro module as `uif` and invoke `uif.*`.
+4. Replace authored `<ui-*>` tags, DOM creation and queries, tag selectors,
+   automation fixtures, snapshots, and local TypeScript tag maps with
+   `<uif-*>`.
+5. Re-test consumer overrides in every supported brand and appearance mode.
+
+Consumers that temporarily support both v0.9 and v1 should declare old and new
+token names with the same value in consumer-owned CSS. UIF does not provide a
+token alias layer because bidirectional custom-property aliases cannot preserve
+all ancestor- and component-scoped overrides reliably.
+
+## Component-family map
+
+The table lists representative public roots and token families. Structural
+parts follow the same prefix replacement.
+
+| Family | Canonical classes | Canonical token slots or runtime inputs | Canonical Custom Elements |
+|---|---|---|---|
+| Accordion | `.uif-accordion`, `.uif-accordion-item`, `.uif-accordion-item-content` | `--uif-accordion-*` | `<uif-accordion>`, `<uif-accordion-item>` |
+| Avatar | `.uif-avatar`, `.uif-avatar-initials` | `--uif-avatar-*` | `<uif-avatar>` |
+| Badge | `.uif-badge`, `.uif-badge-text` | `--uif-badge-*` | `<uif-badge>` |
+| Button | `.uif-button` with `.solid`, `.outline`, or `.ghost` | `--uif-button-*` | `<uif-button>` |
+| ButtonGroup | `.uif-button-group` | `--uif-button-group-*` | `<uif-button-group>` |
+| Calendar | `.uif-calendar`, `.uif-calendar-*` | `--uif-calendar-*` | No autonomous Calendar element |
+| Checkbox | `.uif-checkbox`, `.uif-checkbox-field`, `.uif-checkbox-field-text` | `--uif-checkbox-*` | `<uif-checkbox>` |
+| Divider | `.uif-divider` | code-only `--uif-divider-color`; no component-scoped Figma variables | `<uif-divider>` |
+| Form | `.uif-form`, `.uif-form-*` | `--uif-form-*` | `<uif-form>`, `<uif-form-group>`, `<uif-form-field>`, `<uif-form-helper>`, `<uif-form-actions>` |
+| Icon | `.uif-icon` | code-only `--uif-icon-src` | `<uif-icon>` |
+| Input | `.uif-input`, `.uif-input-field`, `.uif-input-field-control` | `--uif-input-*` | `<uif-input>` |
+| Label composition | `.uif-label-content`, `.uif-label-content-text`, `.uif-field-label*` | `--uif-field-label-*`; separately governed `--typography-label-*` remains unchanged | `<uif-field-label>` |
+| Link | `.uif-link` | `--uif-link-*` | `<uif-link>` |
+| Radio | `.uif-radio`, `.uif-radio-field`, `.uif-radio-field-text` | `--uif-radio-*` | `<uif-radio>` |
+| Select | `.uif-select` | `--uif-select-*` | `<uif-select>` |
+| Switch | `.uif-switch`, `.uif-switch-field`, `.uif-switch-field-text` | `--uif-switch-*` | `<uif-switch>` |
+| Tabs | `.uif-tabs`, `.uif-tab-list`, `.uif-tab`, `.uif-tab-panels`, `.uif-tab-panel` | `--uif-tabs-*` | `<uif-tab-list>`, `<uif-tab>`, `<uif-tab-panel>` |
+| Textarea | `.uif-textarea` | `--uif-textarea-*` | `<uif-textarea>` |
+| Tooltip | `.uif-tooltip`, `.uif-tooltip-trigger` | `--uif-tooltip-*` | `<uif-tooltip>` |
+
+For every token-bearing family, Figma `codeSyntax.WEB` is the naming source and
+generated `dist/` files must be regenerated rather than edited directly.
+
+## Stable package and JavaScript surfaces
+
+The naming migration does not rename:
+
+- `ui-foundations/macros/ui.njk` or its named macro exports;
+- `ui-foundations/elements` or `ui-foundations/elements/ui-*` package subpaths;
+- `ui-*.js` element module filenames;
+- JavaScript constructors and named exports such as `UIButton`.
+
+## Compatibility removal
+
+Legacy bare class selectors are deprecated in v1.x. Their removal is Wave 4
+work for v2.0 or later and must be tracked separately. The v2 change must remove
+selector aliases, compatibility allowlists, warning fixtures, and related
+release guidance together.
+
+## Governing records
+
+- `docs/migrations/naming-scope-migration-plan.md` — migration strategy,
+  rationale, risks, and implementation waves.
+- `docs/migrations/public-api-namespace-v1.md` — exhaustive Custom Element tag
+  map and macro-alias boundary.
+- `docs/adr/adr-uif-public-api-namespace.md` — approved namespace decision.
+- Issues #145, #156, and #197 — planning, component migration, and final public
+  namespace implementation.
+
+## Validation
+
+```sh
+npm run lint
+npm run test:unit
+npm run ci:check
+npm pack --dry-run
+```

--- a/site/patterns/accordion.md
+++ b/site/patterns/accordion.md
@@ -44,14 +44,6 @@ playgroundLabel: Open Accordion Playground
   </div>
 </div>
 
-### v1 naming migration
-
-Use `.uif-accordion`, `.uif-accordion-item`, and
-`.uif-accordion-item-content` with `--uif-accordion-*` tokens. Unprefixed
-Accordion selectors remain compatible throughout v1.x, but legacy
-`--accordion-*` token aliases are not provided. Wave 4 selector removal remains
-v2.0-or-later work.
-
 <h2 id="anatomy">Anatomy</h2>
 
 <div class="docs-anatomy">

--- a/site/patterns/avatar.md
+++ b/site/patterns/avatar.md
@@ -114,10 +114,6 @@ playgroundLabel: Open Avatar Playground
 - Image avatars include `alt` text on the `<img>` element.
 - Initials are decorative — the `aria-label` on the container provides the accessible name.
 
-<h2 id="v1-naming-migration">v1 naming migration</h2>
-
-Avatar emitters produce the canonical `.uif-avatar` and `.uif-avatar-initials` classes. The legacy `.avatar` and `.avatar-initials` selectors remain supported during the v1 compatibility period. Component token slots use `--uif-avatar-*`; library-owned legacy `--avatar-*` token aliases are not provided. The Custom Element now registers as `<uif-avatar>`; its existing module filename and package export remain unchanged.
-
 <h2 id="design-checklist">Design checklist</h2>
 
 <div class="docs-checklist">

--- a/site/patterns/badge.md
+++ b/site/patterns/badge.md
@@ -157,10 +157,6 @@ Badge adapts across brands and modes through semantic tokens. Use the hero switc
 
 For the full theming architecture see [Foundations: Theming](/foundations/theming/).
 
-<h2 id="v1-naming-migration">v1 naming migration</h2>
-
-Badge emitters produce `.uif-badge` and `.uif-badge-text`. The legacy `.badge` selector remains supported during the v1 compatibility period. Component token slots use `--uif-badge-*`; library-owned legacy `--badge-*` token aliases are not provided. The Custom Element now registers as `<uif-badge>`; its existing module filename and package export remain unchanged.
-
 <h2 id="design-checklist">Design checklist</h2>
 
 <div class="docs-checklist">

--- a/site/patterns/calendar.md
+++ b/site/patterns/calendar.md
@@ -37,14 +37,6 @@ playgroundLabel: Open Calendar Playground
   </div>
 </div>
 
-### v1 naming migration
-
-Use `.uif-calendar` and the `.uif-calendar-*` part classes with
-`--uif-calendar-*` tokens in new and migrated markup. Unprefixed Calendar class
-selectors remain compatible throughout v1.x, but legacy `--calendar-*` token
-aliases are not provided. Consumers must migrate classes and tokens together.
-Legacy selector removal remains Wave 4 work for v2.0 or later.
-
 <h2 id="usage">Usage</h2>
 
 The Calendar component enables date selection in forms, filters, and booking flows. It supports single date selection and date range selection.

--- a/site/patterns/checkbox.md
+++ b/site/patterns/checkbox.md
@@ -252,10 +252,6 @@ tokens. Use the hero preview switches above to see it in action.
 
 For the full theming architecture see [Foundations: Theming](/foundations/theming/).
 
-<h2 id="v1-naming-migration">v1 naming migration</h2>
-
-Checkbox emitters produce `.uif-checkbox`, `.uif-checkbox-field`, and `.uif-checkbox-field-text`. The legacy `.checkbox` and `.checkbox-field` selectors remain supported during the v1 compatibility period. Component token slots use `--uif-checkbox-*`; library-owned legacy `--checkbox-*` token aliases are not provided. The Custom Element now registers as `<uif-checkbox>`; its existing module filename and package export remain unchanged.
-
 <h2 id="design-checklist">Design checklist</h2>
 
 <div class="docs-checklist">

--- a/site/patterns/divider.md
+++ b/site/patterns/divider.md
@@ -163,10 +163,6 @@ Dividers are non-interactive and not focusable. They are skipped by keyboard nav
 
 Divider adapts across brands and modes through semantic color tokens (`--color-border-default`, `--color-border-subtle`). Use the hero switches above to preview.
 
-<h2 id="v1-naming-migration">v1 naming migration</h2>
-
-Divider emitters produce the canonical `.uif-divider` class. The legacy `.divider` selector remains supported during the v1 compatibility period. Divider currently has no component-scoped Figma variables; its local runtime input is namespaced as `--uif-divider-color`, and no library-owned legacy `--divider-color` alias is provided. The Custom Element now registers as `<uif-divider>`; its existing module filename and package export remain unchanged.
-
 <h2 id="design-checklist">Design checklist</h2>
 
 <div class="docs-checklist">

--- a/site/patterns/form.md
+++ b/site/patterns/form.md
@@ -188,7 +188,3 @@ Form adapts to brands and modes through its component tokens:
 | `--uif-form-field-helper-text-color-default` | Helper text color |
 | `--uif-form-field-helper-text-color-invalid` | Error text color |
 | `--uif-form-group-title-color` | Group legend color |
-
-<h2 id="v1-naming-migration">v1 naming migration</h2>
-
-Form emitters produce canonical `.uif-form*` classes, including groups, fields, helpers, links, field bodies, and actions. The corresponding legacy `.form*` selectors remain supported during the v1 compatibility period. Component token slots use `--uif-form-*`; library-owned legacy `--form-*` token aliases are not provided. The Form Custom Elements now register as `<uif-form*>`; their existing module filename and package exports remain unchanged.

--- a/site/patterns/icon.md
+++ b/site/patterns/icon.md
@@ -99,14 +99,6 @@ needed.
   </tbody>
 </table>
 
-### v1 naming migration
-
-Use `.uif-icon` with `--uif-icon-src` in all new and migrated markup. The
-legacy `.icon` selector remains available throughout v1.x, but the legacy
-`--icon-src` custom property has no library-owned alias or fallback. Consumers
-must rename both public API names together. Removal of the legacy class selector
-is deferred to Wave 4 in v2.0 or later.
-
 <h2 id="behaviors">Behaviors</h2>
 
 <div class="docs-behavior-list">

--- a/site/patterns/input.md
+++ b/site/patterns/input.md
@@ -39,14 +39,6 @@ playgroundLabel: Open Input Playground
   </div>
 </div>
 
-### v1 naming migration
-
-Use `.uif-input`, `.uif-input-field`, and `.uif-input-field-control` with
-`--uif-input-*` tokens in new and migrated markup. The unprefixed Input class
-selectors remain compatible throughout v1.x, but legacy `--input-*` token
-aliases are not provided. Consumers must migrate classes and tokens together.
-Legacy selector removal remains Wave 4 work for v2.0 or later.
-
 <h2 id="anatomy">Anatomy</h2>
 
 <div class="docs-anatomy">

--- a/site/patterns/label.md
+++ b/site/patterns/label.md
@@ -83,16 +83,6 @@ playgroundLabel: Open Label Playground
   </tbody>
 </table>
 
-### v1 naming migration
-
-Use `.uif-label-content`, `.uif-label-content-text`, and the `.uif-field-label*`
-family in new and migrated markup. Their unprefixed class selectors remain
-available throughout v1.x, but the legacy `--field-label-*` custom properties
-have no library-owned aliases or fallbacks. Rename the field-label class and its
-runtime inputs together. Shared `--typography-label-*` tokens keep their
-separately governed typography namespace. Legacy class removal remains Wave 4
-work for v2.0 or later.
-
 <h2 id="behaviors">Behaviors</h2>
 
 <div class="docs-behavior-list">

--- a/site/patterns/link.md
+++ b/site/patterns/link.md
@@ -41,13 +41,6 @@ breadcrumb:
   </div>
 </div>
 
-### v1 naming migration
-
-Use `.uif-link` and `--uif-link-*` tokens in new and migrated markup. The
-unprefixed `.link` selector remains compatible throughout v1.x, but legacy
-`--link-*` token aliases are not provided. Consumers must migrate classes and
-tokens together. Legacy selector removal remains Wave 4 work for v2.0 or later.
-
 <h2 id="anatomy">Anatomy</h2>
 
 <div class="docs-anatomy">

--- a/site/patterns/radio.md
+++ b/site/patterns/radio.md
@@ -228,10 +228,6 @@ tokens. Use the hero preview switches above to see it in action.
 
 For the full theming architecture see [Foundations: Theming](/foundations/theming/).
 
-<h2 id="v1-naming-migration">v1 naming migration</h2>
-
-Radio emitters produce `.uif-radio`, `.uif-radio-field`, and `.uif-radio-field-text`. The legacy `.radio` and `.radio-field` selectors remain supported during the v1 compatibility period. Component token slots use `--uif-radio-*`; library-owned legacy `--radio-*` token aliases are not provided. The Custom Element now registers as `<uif-radio>`; its existing module filename and package export remain unchanged.
-
 <h2 id="design-checklist">Design checklist</h2>
 
 <div class="docs-checklist">

--- a/site/patterns/select.md
+++ b/site/patterns/select.md
@@ -250,10 +250,6 @@ tokens. Use the hero preview switches above to see it in action.
 
 For the full theming architecture see [Foundations: Theming](/foundations/theming/).
 
-<h2 id="v1-naming-migration">v1 naming migration</h2>
-
-Select emitters produce `.uif-select`. The legacy `.select` selector remains supported during the v1 compatibility period, including when Select is composed into Calendar. Component token slots use `--uif-select-*`; library-owned legacy `--select-*` token aliases are not provided. The Custom Element now registers as `<uif-select>`; its existing module filename and package export remain unchanged.
-
 <h2 id="design-checklist">Design checklist</h2>
 
 <div class="docs-checklist">

--- a/site/patterns/switch.md
+++ b/site/patterns/switch.md
@@ -191,10 +191,6 @@ Switch adapts across brands and modes through tokens. Use the hero switches abov
 
 For the full theming architecture see [Foundations: Theming](/foundations/theming/).
 
-<h2 id="v1-naming-migration">v1 naming migration</h2>
-
-Switch emitters produce `.uif-switch`, `.uif-switch-field`, and `.uif-switch-field-text`. The legacy `.switch` and `.switch-field` selectors remain supported during the v1 compatibility period. Component token slots use `--uif-switch-*`; library-owned legacy `--switch-*` token aliases are not provided. The Custom Element now registers as `<uif-switch>`; its existing module filename and package export remain unchanged.
-
 <h2 id="design-checklist">Design checklist</h2>
 
 <div class="docs-checklist">

--- a/site/patterns/tabs.md
+++ b/site/patterns/tabs.md
@@ -134,10 +134,6 @@ playgroundLabel: Open Tabs Playground
 - Only the selected tab has `tabindex="0"`; others have `tabindex="-1"` for roving focus.
 - `aria-orientation` communicates layout direction to assistive technology.
 
-<h2 id="v1-naming-migration">v1 naming migration</h2>
-
-Tabs emitters produce `.uif-tabs`, `.uif-tab-list`, `.uif-tab`, `.uif-tab-panels`, and `.uif-tab-panel`. Their unprefixed selectors remain supported during the v1 compatibility period. Component token slots use `--uif-tabs-*`; library-owned legacy `--tabs-*` token aliases are not provided. The Custom Elements now register as `<uif-tab-list>`, `<uif-tab>`, and `<uif-tab-panel>`; their existing module filename and package exports remain unchanged.
-
 <h2 id="design-checklist">Design checklist</h2>
 
 <div class="docs-checklist">

--- a/site/patterns/textarea.md
+++ b/site/patterns/textarea.md
@@ -116,10 +116,6 @@ playgroundLabel: Open TextArea Playground
 - Always pair with a visible `<label>` or `aria-label`.
 - Placeholder text is not a substitute for a label.
 
-<h2 id="v1-naming-migration">v1 naming migration</h2>
-
-Textarea emitters produce `.uif-textarea`. The legacy `.textarea` selector remains supported during the v1 compatibility period. Component token slots use `--uif-textarea-*`; library-owned legacy `--textarea-*` token aliases are not provided. The Custom Element now registers as `<uif-textarea>`; its existing module filename and package export remain unchanged.
-
 <h2 id="design-checklist">Design checklist</h2>
 
 <div class="docs-checklist">

--- a/site/patterns/tooltip.md
+++ b/site/patterns/tooltip.md
@@ -138,9 +138,6 @@ playgroundLabel: Open Tooltip Playground
 - Trigger should have `aria-describedby` pointing to the tooltip ID for screen readers.
 - Tooltips are non-interactive — they cannot contain links or buttons.
 
-<h2 id="v1-naming-migration">v1 naming migration</h2>
-
-Tooltip emitters produce `.uif-tooltip` and `.uif-tooltip-trigger`. The legacy `.tooltip` and `.tooltip-trigger` selectors remain supported during the v1 compatibility period. Component token slots use `--uif-tooltip-*`; library-owned legacy `--tooltip-*` token aliases are not provided. The Custom Element now registers as `<uif-tooltip>`; its existing module filename and package export remain unchanged.
 - Shows on both hover and focus to support keyboard users.
 
 <h2 id="design-checklist">Design checklist</h2>

--- a/tests/accordion-naming-migration.test.mjs
+++ b/tests/accordion-naming-migration.test.mjs
@@ -38,13 +38,13 @@ test("Accordion-owned emitters produce canonical classes", async () => {
   assert.doesNotMatch(sources[3], /class="accordion(?:[\s"])/);
 });
 
-test("Accordion documentation explains migration and uses canonical registrations", async () => {
+test("Accordion migration guide and registrations use the canonical namespace", async () => {
   const [documentation, element] = await Promise.all([
-    read("site/patterns/accordion.md"),
+    read("MIGRATION.md"),
     read("src/elements/ui-accordion.js"),
   ]);
 
-  assert.match(documentation, /legacy\s+`--accordion-\*` token aliases are not provided/);
+  assert.match(documentation, /\| Accordion \|.*`--uif-accordion-\*`/);
   assert.match(element, /define\("uif-accordion", UIAccordion\)/);
   assert.match(element, /define\("uif-accordion-item", UIAccordionItem\)/);
 });

--- a/tests/avatar-naming-migration.test.mjs
+++ b/tests/avatar-naming-migration.test.mjs
@@ -36,12 +36,12 @@ test("Avatar-owned emitters produce canonical classes", async () => {
   assert.doesNotMatch(sources[3], /["']avatar["']/);
 });
 
-test("Avatar documentation and registration use the canonical public namespace", async () => {
+test("Avatar migration guide and registration use the canonical public namespace", async () => {
   const [documentation, element] = await Promise.all([
-    read("site/patterns/avatar.md"),
+    read("MIGRATION.md"),
     read("src/elements/ui-avatar.js"),
   ]);
 
-  assert.match(documentation, /legacy `--avatar-\*` token aliases are not provided/);
+  assert.match(documentation, /\| Avatar \|.*`--uif-avatar-\*`/);
   assert.match(element, /define\("uif-avatar", UIAvatar\)/);
 });

--- a/tests/badge-naming-migration.test.mjs
+++ b/tests/badge-naming-migration.test.mjs
@@ -29,11 +29,11 @@ test("Badge-owned emitters use canonical classes", async () => {
   assert.doesNotMatch(sources[0], /class="badge(?:[-\s"])/);
 });
 
-test("Badge docs explain migration and use the canonical registration", async () => {
+test("Badge migration guide and registration use the canonical namespace", async () => {
   const [documentation, element] = await Promise.all([
-    read("site/patterns/badge.md"),
+    read("MIGRATION.md"),
     read("src/elements/ui-badge.js"),
   ]);
-  assert.match(documentation, /legacy `--badge-\*` token aliases are not provided/);
+  assert.match(documentation, /\| Badge \|.*`--uif-badge-\*`/);
   assert.match(element, /define\("uif-badge", UIBadge\)/);
 });

--- a/tests/calendar-naming-migration.test.mjs
+++ b/tests/calendar-naming-migration.test.mjs
@@ -69,10 +69,10 @@ test("Calendar behavior accepts legacy markup but renders canonical cells", asyn
 test("Calendar no longer relies on pending-export token exceptions", async () => {
   const [validator, documentation] = await Promise.all([
     read("scripts/validate-token-usage.mjs"),
-    read("site/patterns/calendar.md"),
+    read("MIGRATION.md"),
   ]);
 
   assert.doesNotMatch(validator, /calendar-cell-background-selected/);
   assert.doesNotMatch(validator, /calendar-cell-text-color-selected/);
-  assert.match(documentation, /legacy `--calendar-\*` token\s+aliases are not provided/);
+  assert.match(documentation, /\| Calendar \|.*`--uif-calendar-\*`/);
 });

--- a/tests/checkbox-naming-migration.test.mjs
+++ b/tests/checkbox-naming-migration.test.mjs
@@ -33,11 +33,11 @@ test("Checkbox-owned emitters and behavior use canonical classes", async () => {
   assert.doesNotMatch(element, /class="checkbox(?:[-\s"])/);
 });
 
-test("Checkbox docs explain migration and use the canonical registration", async () => {
+test("Checkbox migration guide and registration use the canonical namespace", async () => {
   const [documentation, element] = await Promise.all([
-    read("site/patterns/checkbox.md"),
+    read("MIGRATION.md"),
     read("src/elements/ui-checkbox.js"),
   ]);
-  assert.match(documentation, /legacy `--checkbox-\*` token aliases are not provided/);
+  assert.match(documentation, /\| Checkbox \|.*`--uif-checkbox-\*`/);
   assert.match(element, /define\("uif-checkbox", UICheckbox\)/);
 });

--- a/tests/divider-naming-migration.test.mjs
+++ b/tests/divider-naming-migration.test.mjs
@@ -38,13 +38,13 @@ test("Divider runtime input stays code-only rather than becoming a Figma token",
   assert.doesNotMatch(tokenExport, /--uif-divider-color/);
 });
 
-test("Divider documentation explains migration and uses the canonical registration", async () => {
+test("Divider migration guide explains its boundary and canonical registration", async () => {
   const [documentation, element] = await Promise.all([
-    read("site/patterns/divider.md"),
+    read("MIGRATION.md"),
     read("src/elements/ui-divider.js"),
   ]);
 
-  assert.match(documentation, /no component-scoped Figma variables/);
-  assert.match(documentation, /no library-owned legacy `--divider-color` alias is provided/);
+  assert.match(documentation, /code-only `--uif-divider-color`; no component-scoped Figma variables/);
+  assert.match(documentation, /No library-owned legacy token aliases or fallbacks/);
   assert.match(element, /define\("uif-divider", UIDivider\)/);
 });

--- a/tests/form-naming-migration.test.mjs
+++ b/tests/form-naming-migration.test.mjs
@@ -34,12 +34,12 @@ test("Form-owned emitters and integrations use canonical classes", async () => {
   assert.doesNotMatch(sources[0], /class="form(?:[-\s"])/);
 });
 
-test("Form docs and registrations use the canonical public namespace", async () => {
+test("Form migration guide and registrations use the canonical public namespace", async () => {
   const [documentation, element] = await Promise.all([
-    read("site/patterns/form.md"),
+    read("MIGRATION.md"),
     read("src/elements/ui-form.js"),
   ]);
-  assert.match(documentation, /legacy `--form-\*` token aliases are not provided/);
+  assert.match(documentation, /\| Form \|.*`--uif-form-\*`/);
   for (const tag of ["uif-form", "uif-form-group", "uif-form-field", "uif-form-helper", "uif-form-actions"]) {
     assert.match(element, new RegExp(`define\\("${tag}"`));
   }

--- a/tests/icon-naming-migration.test.mjs
+++ b/tests/icon-naming-migration.test.mjs
@@ -55,11 +55,12 @@ test("the namespaced runtime input remains code-only rather than a Figma token",
   const [validator, tokenExport, documentation] = await Promise.all([
     read("scripts/validate-token-usage.mjs"),
     read("figma/exports/Patterns (UI).tokens.json"),
-    read("site/patterns/icon.md"),
+    read("MIGRATION.md"),
   ]);
 
   assert.match(validator, /"--uif-icon-src"/);
   assert.doesNotMatch(validator, /"--icon-src"/);
   assert.doesNotMatch(tokenExport, /--uif-icon-src/);
-  assert.match(documentation, /legacy\s+`--icon-src` custom property has no library-owned alias/);
+  assert.match(documentation, /\| Icon \|.*code-only `--uif-icon-src`/);
+  assert.match(documentation, /No library-owned legacy token aliases or fallbacks/);
 });

--- a/tests/input-naming-migration.test.mjs
+++ b/tests/input-naming-migration.test.mjs
@@ -58,13 +58,13 @@ test("Input behavior and Date Input accept canonical and legacy Input markup", a
   assert.match(dateCss, /:is\(\.uif-input-field, \.input-field\)\.date/);
 });
 
-test("Input documentation explains the v1 boundary and uses the canonical registration", async () => {
+test("Input migration guide explains the v1 boundary and canonical registration", async () => {
   const [documentation, element] = await Promise.all([
-    read("site/patterns/input.md"),
+    read("MIGRATION.md"),
     read("src/elements/ui-input.js"),
   ]);
 
-  assert.match(documentation, /legacy `--input-\*` token\s+aliases are not provided/);
+  assert.match(documentation, /\| Input \|.*`--uif-input-\*`/);
   assert.match(documentation, /\.uif-input-field-control/);
   assert.match(element, /define\("uif-input", UIInput\)/);
 });

--- a/tests/label-naming-migration.test.mjs
+++ b/tests/label-naming-migration.test.mjs
@@ -63,14 +63,14 @@ test("Typography Label tokens keep their separately governed namespace", async (
   assert.doesNotMatch(tokenExport, /--uif-field-label-/);
 });
 
-test("Label migration guidance uses the canonical Custom Element tag", async () => {
+test("Label migration guide uses the canonical Custom Element tag", async () => {
   const [documentation, element, declarations] = await Promise.all([
-    read("site/patterns/label.md"),
+    read("MIGRATION.md"),
     read("src/elements/ui-label.js"),
     read("src/elements/index.d.ts"),
   ]);
 
-  assert.match(documentation, /legacy `--field-label-\*` custom properties/);
+  assert.match(documentation, /\| Label composition \|.*`--uif-field-label-\*`/);
   assert.match(element, /define\("uif-field-label", UIFieldLabel\)/);
   assert.match(declarations, /"uif-field-label": UIFieldLabel/);
   assert.doesNotMatch(element, /ui-uif-field-label/);

--- a/tests/link-naming-migration.test.mjs
+++ b/tests/link-naming-migration.test.mjs
@@ -45,14 +45,13 @@ test("Link retains Icon and legacy class compatibility without token aliases", a
   assert.doesNotMatch(css, /--link-[\w-]+\s*:/);
 });
 
-test("Link documentation explains the v1 boundary and uses the canonical registration", async () => {
+test("Link migration guide explains the v1 boundary and canonical registration", async () => {
   const [documentation, element] = await Promise.all([
-    read("site/patterns/link.md"),
+    read("MIGRATION.md"),
     read("src/elements/ui-link.js"),
   ]);
 
-  assert.match(documentation, /legacy\s+`--link-\*` token aliases are not provided/);
-  assert.match(documentation, /class="uif-link/);
-  assert.doesNotMatch(documentation, /class="link(?:[\s"])/);
+  assert.match(documentation, /\| Link \|.*`--uif-link-\*`/);
+  assert.match(documentation, /\.uif-link/);
   assert.match(element, /define\("uif-link", UILink\)/);
 });

--- a/tests/naming-migration-completion.test.mjs
+++ b/tests/naming-migration-completion.test.mjs
@@ -71,3 +71,16 @@ test("completion guidance defines canonical owned output and v1 CSS-only compati
     assert.match(documentation, /Wave 4 work for v2\.0 or\s+later/);
   }
 });
+
+test("migration history lives in the repository guide, not public pattern pages", () => {
+  const migration = read("MIGRATION.md");
+  assert.match(migration, /Legacy selectors remain CSS-only aliases through v1\.x/);
+  assert.match(migration, /No library-owned legacy token aliases or fallbacks/);
+  assert.match(migration, /no alias or dual registration/);
+  assert.match(migration, /Wave 4\s+work for v2\.0 or later/);
+
+  for (const file of filesUnder("site/patterns", new Set([".md"]))) {
+    const documentation = fs.readFileSync(file, "utf8");
+    assert.doesNotMatch(documentation, /v1 naming migration|v1-naming-migration/i, path.relative(root, file));
+  }
+});

--- a/tests/radio-naming-migration.test.mjs
+++ b/tests/radio-naming-migration.test.mjs
@@ -29,8 +29,8 @@ test("Radio-owned emitters and behavior use canonical classes", async () => {
   assert.doesNotMatch(element, /class="radio(?:[-\s"])/);
 });
 
-test("Radio docs explain migration and use the canonical registration", async () => {
-  const [documentation, element] = await Promise.all([read("site/patterns/radio.md"), read("src/elements/ui-radio.js")]);
-  assert.match(documentation, /legacy `--radio-\*` token aliases are not provided/);
+test("Radio migration guide and registration use the canonical namespace", async () => {
+  const [documentation, element] = await Promise.all([read("MIGRATION.md"), read("src/elements/ui-radio.js")]);
+  assert.match(documentation, /\| Radio \|.*`--uif-radio-\*`/);
   assert.match(element, /define\("uif-radio", UIRadio\)/);
 });

--- a/tests/select-naming-migration.test.mjs
+++ b/tests/select-naming-migration.test.mjs
@@ -34,11 +34,11 @@ test("Select-owned emitters and Calendar composition use canonical classes", asy
   assert.doesNotMatch(sources[0], /class="select(?:[-\s"])/);
 });
 
-test("Select docs explain migration and use the canonical registration", async () => {
+test("Select migration guide and registration use the canonical namespace", async () => {
   const [documentation, element] = await Promise.all([
-    read("site/patterns/select.md"),
+    read("MIGRATION.md"),
     read("src/elements/ui-select.js"),
   ]);
-  assert.match(documentation, /legacy `--select-\*` token aliases are not provided/);
+  assert.match(documentation, /\| Select \|.*`--uif-select-\*`/);
   assert.match(element, /define\("uif-select", UISelect\)/);
 });

--- a/tests/switch-naming-migration.test.mjs
+++ b/tests/switch-naming-migration.test.mjs
@@ -29,8 +29,8 @@ test("Switch-owned emitters and behavior use canonical classes", async () => {
   assert.doesNotMatch(element, /class="switch(?:[-\s"])/);
 });
 
-test("Switch docs explain migration and use the canonical registration", async () => {
-  const [documentation, element] = await Promise.all([read("site/patterns/switch.md"), read("src/elements/ui-switch.js")]);
-  assert.match(documentation, /legacy `--switch-\*` token aliases are not provided/);
+test("Switch migration guide and registration use the canonical namespace", async () => {
+  const [documentation, element] = await Promise.all([read("MIGRATION.md"), read("src/elements/ui-switch.js")]);
+  assert.match(documentation, /\| Switch \|.*`--uif-switch-\*`/);
   assert.match(element, /define\("uif-switch", UISwitch\)/);
 });

--- a/tests/tabs-naming-migration.test.mjs
+++ b/tests/tabs-naming-migration.test.mjs
@@ -32,12 +32,12 @@ test("Tabs-owned emitters produce canonical classes", async () => {
   assert.doesNotMatch(sources[3], /figma\.className\(\["tab"\]\)/);
 });
 
-test("Tabs documentation and registrations use the canonical public namespace", async () => {
+test("Tabs migration guide and registrations use the canonical public namespace", async () => {
   const [documentation, elements] = await Promise.all([
-    read("site/patterns/tabs.md"),
+    read("MIGRATION.md"),
     read("src/elements/ui-tabs.js"),
   ]);
-  assert.match(documentation, /legacy `--tabs-\*` token aliases are not provided/);
+  assert.match(documentation, /\| Tabs \|.*`--uif-tabs-\*`/);
   for (const tag of ["uif-tab-list", "uif-tab", "uif-tab-panel"]) {
     assert.match(elements, new RegExp(`define\\("${tag}"`));
   }

--- a/tests/textarea-naming-migration.test.mjs
+++ b/tests/textarea-naming-migration.test.mjs
@@ -27,8 +27,8 @@ test("Textarea-owned emitters use the canonical class", async () => {
   assert.doesNotMatch(sources[0], /class="textarea(?:[-\s"])/);
 });
 
-test("Textarea docs explain migration and use the canonical registration", async () => {
-  const [documentation, element] = await Promise.all([read("site/patterns/textarea.md"), read("src/elements/ui-textarea.js")]);
-  assert.match(documentation, /legacy `--textarea-\*` token aliases are not provided/);
+test("Textarea migration guide and registration use the canonical namespace", async () => {
+  const [documentation, element] = await Promise.all([read("MIGRATION.md"), read("src/elements/ui-textarea.js")]);
+  assert.match(documentation, /\| Textarea \|.*`--uif-textarea-\*`/);
   assert.match(element, /define\("uif-textarea", UITextarea\)/);
 });

--- a/tests/tooltip-naming-migration.test.mjs
+++ b/tests/tooltip-naming-migration.test.mjs
@@ -40,12 +40,12 @@ test("Tooltip-owned emitters produce canonical classes", async () => {
   assert.doesNotMatch(sources[3], /class="tooltip(?:[\s"])/);
 });
 
-test("Tooltip documentation explains migration and uses the canonical registration", async () => {
+test("Tooltip migration guide and registration use the canonical namespace", async () => {
   const [documentation, element] = await Promise.all([
-    read("site/patterns/tooltip.md"),
+    read("MIGRATION.md"),
     read("src/elements/ui-tooltip.js"),
   ]);
 
-  assert.match(documentation, /legacy `--tooltip-\*` token aliases are not provided/);
+  assert.match(documentation, /\| Tooltip \|.*`--uif-tooltip-\*`/);
   assert.match(element, /define\("uif-tooltip", UITooltip\)/);
 });


### PR DESCRIPTION
## Summary

- add a repository-only `MIGRATION.md` as the single consumer guide for v1 classes, tokens, Nunjucks macros, Custom Elements, stable package surfaces, and v2 alias removal
- remove the repeated `v1 naming migration` sections from 17 public pattern pages
- update component migration tests to validate the consolidated guide
- add regression coverage preventing migration-history sections from returning to public pattern pages

## Why

Component pages should document the current public API. Release history, compatibility policy, and old-to-new mappings are easier to understand and maintain in one dedicated migration guide outside the generated public website.

## Validation

- `npm run lint`
- `npm run test:unit` (172 tests)
- `npm run ci:check`
- public Eleventy site build
- focused naming migration tests (84 tests)