### PR TITLE
docs: Runtime documentation audit — WS1 & WS2 (public API + governance baseline)

### DIFF
--- a/.uif/packs/governance/contracts/naming-contract.json
+++ b/.uif/packs/governance/contracts/naming-contract.json
@@ -8,7 +8,7 @@
   "owner": "ui-foundations",
   "schema_version": "1.0.0",
   "contract_version": "0.2.0",
-  "governance_pack_version": "0.8.0",
+  "governance_pack_version": "0.7.0",
   "channel": "review",
   "release_date": "2026-07-15",
   "updated": "2026-07-15",

--- a/.uif/packs/governance/contracts/naming-contract.json
+++ b/.uif/packs/governance/contracts/naming-contract.json
@@ -8,7 +8,7 @@
   "owner": "ui-foundations",
   "schema_version": "1.0.0",
   "contract_version": "0.2.0",
-  "governance_pack_version": "0.7.0",
+  "governance_pack_version": "0.8.0",
   "channel": "review",
   "release_date": "2026-07-15",
   "updated": "2026-07-15",

--- a/README.md
+++ b/README.md
@@ -187,6 +187,11 @@ If you are new to this repository, start with:
 5. [Patterns and components entry](docs/patterns/README.md)
 6. [Validation checks](docs/validation/README.md)
 
+Terminology and source-traceability references:
+
+- [Runtime terminology baseline](docs/terminology.md)
+- [Canonical topic-source matrix](docs/canonical-reference-matrix.md)
+
 ### Apply Theming
 
 ```js

--- a/README.md
+++ b/README.md
@@ -219,20 +219,16 @@ CSS-only, stateless UI building blocks. No JavaScript required.
 ```
 
 Each pattern uses semantic tokens and supports theming out of the box.
+See `docs/patterns/README.md` for hierarchy and status.
 
-## Components (coming next)
+## Components
 
-Functional units that add state and interactivity on top of patterns.
+Runtime currently exposes component-facing behavior through light-DOM Custom
+Elements in `src/elements/` (for example: `ui-button`, `ui-input`, `ui-tabs`,
+`ui-tooltip`, `ui-select`).
 
-```
- ┌──────────┬──────────┬──────────┐
- │ Calendar │ DatePckr │ ComboBox │
- ├──────────┼──────────┼──────────┤
- │ Dialog   │ Table    │   ...    │
- └──────────┴──────────┴──────────┘
-```
-
-Components will live in `src/ui/components/` and require JavaScript.
+Standalone product-component documentation is tracked through
+`docs/components/README.md`, including explicit placeholder topics and status.
 
 ---
 
@@ -266,10 +262,11 @@ Agents operate in modes:
 
 ```
  docs/
- ├── foundations/    ← Token layering, naming, 12 ADRs
- ├── patterns/      ← Composition guidance
- ├── agentic/       ← Agent rules, modes, workflows
- ├── validation/    ← CI pipeline, parity checks
+ ├── foundations/    ← Token layering, naming, foundation records
+ ├── patterns/       ← Pattern hierarchy and composition guidance
+ ├── components/     ← Component-facing status and entry points
+ ├── agentic/        ← Agent rules, modes, workflows
+ ├── validation/     ← CI pipeline, parity checks
  └── token-pipeline.md
  site/
  ├── patterns/      ← Pattern docs + playgrounds

--- a/README.md
+++ b/README.md
@@ -181,10 +181,11 @@ For the Runtime-facing canonical API summary, see
 If you are new to this repository, start with:
 
 1. [Documentation map](docs/README.md)
-2. [Public API Surface (v1)](docs/public-api.md)
-3. [Foundations overview](docs/foundations/README.md)
-4. [Patterns and components entry](docs/patterns/README.md)
-5. [Validation checks](docs/validation/README.md)
+2. [Runtime architecture overview](docs/architecture.md)
+3. [Public API Surface (v1)](docs/public-api.md)
+4. [Foundations overview](docs/foundations/README.md)
+5. [Patterns and components entry](docs/patterns/README.md)
+6. [Validation checks](docs/validation/README.md)
 
 ### Apply Theming
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,16 @@ For the v1 macro alias and Custom Element tag changes, see the
 For the Runtime-facing canonical API summary, see
 [Public API Surface (v1)](docs/public-api.md).
 
+### Documentation quickstart
+
+If you are new to this repository, start with:
+
+1. [Documentation map](docs/README.md)
+2. [Public API Surface (v1)](docs/public-api.md)
+3. [Foundations overview](docs/foundations/README.md)
+4. [Patterns and components entry](docs/patterns/README.md)
+5. [Validation checks](docs/validation/README.md)
+
 ### Apply Theming
 
 ```js

--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ npm install ui-foundations
 ### Use Patterns (plain HTML)
 
 ```html
-<button class="button">Label</button>
-<button class="button outline">Outline</button>
-<input class="input" type="text" />
+<button class="uif-button solid">Label</button>
+<button class="uif-button outline">Outline</button>
+<input class="uif-input" type="text" />
 ```
 
 ### Optional: Web Components
@@ -173,6 +173,8 @@ Consumers upgrading to v1 should follow the
 [React removal migration guide](docs/migrations/react-to-web-components.md).
 For the v1 macro alias and Custom Element tag changes, see the
 [public API namespace migration guide](docs/migrations/public-api-namespace-v1.md).
+For the Runtime-facing canonical API summary, see
+[Public API Surface (v1)](docs/public-api.md).
 
 ### Apply Theming
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ details or local agent configuration.
 | `principles/` | Perception, heuristics, and accessibility intent | `docs/principles/README.md` |
 | `patterns/` | Pattern-level composition guidance | `docs/patterns/README.md` |
 | `components/` | Component-facing entry docs and TODO gaps | `docs/patterns/README.md` |
+| `public-api.md` | Canonical Runtime-facing v1 public API summary and migration links | `docs/public-api.md` |
 | `agentic/` | Agent behavior, workflows, prompts, and migration context | `docs/agentic/README.md` |
 | `adr/` | Architecture decision records and documentation migration notes | `docs/adr/README.md` |
 | `validation/` | Validation checklists, CI, token parity, and accessibility checks | `docs/validation/README.md` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,8 @@ If you are new to Runtime documentation, use this order:
 4. `docs/patterns/README.md` — pattern hierarchy and composition guidance
 5. `docs/components/README.md` — component-facing status and entry points
 6. `docs/validation/README.md` — validation and CI checks
+7. `docs/terminology.md` — canonical terminology and status language baseline
+8. `docs/canonical-reference-matrix.md` — topic-to-canonical-source traceability matrix
 
 From `docs/README.md`, each target is reachable directly in one click.
 
@@ -37,6 +39,8 @@ details or local agent configuration.
 | `components/` | Component-facing entry, current implementation surfaces, and placeholders | `docs/components/README.md` |
 | `public-api.md` | Canonical Runtime-facing v1 public API summary and migration links | `docs/public-api.md` |
 | `governance-baseline.md` | Consumed governance pack versions, artifact registry, and version lifecycle policy | `docs/governance-baseline.md` |
+| `terminology.md` | Canonical vs compatibility/deprecated/placeholder terminology baseline | `docs/terminology.md` |
+| `canonical-reference-matrix.md` | Major topic-to-canonical-source and Runtime reference traceability | `docs/canonical-reference-matrix.md` |
 | `agentic/` | Agent behavior, workflows, prompts, and migration context | `docs/agentic/README.md` |
 | `adr/` | Architecture decision records and documentation migration notes | `docs/adr/README.md` |
 | `validation/` | Validation checklists, CI, token parity, and accessibility checks | `docs/validation/README.md` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,8 +7,9 @@ If you are new to Runtime documentation, use this order:
 1. `docs/public-api.md` — canonical v1 API surface and migration entry points
 2. `docs/architecture.md` — Runtime system map, layers, outputs, and consumer surfaces
 3. `docs/foundations/README.md` — foundations navigation (token architecture, naming, theming)
-4. `docs/patterns/README.md` — pattern and component-facing composition guidance
-5. `docs/validation/README.md` — validation and CI checks
+4. `docs/patterns/README.md` — pattern hierarchy and composition guidance
+5. `docs/components/README.md` — component-facing status and entry points
+6. `docs/validation/README.md` — validation and CI checks
 
 From `docs/README.md`, each target is reachable directly in one click.
 
@@ -32,8 +33,8 @@ details or local agent configuration.
 | `architecture.md` | Developer-oriented Runtime system map and implementation layers | `docs/architecture.md` |
 | `foundations/` | Token architecture, naming, theming, parity, and format guidance | `docs/foundations/README.md` |
 | `principles/` | Perception, heuristics, and accessibility intent | `docs/principles/README.md` |
-| `patterns/` | Pattern-level composition guidance | `docs/patterns/README.md` |
-| `components/` | Component-facing entry docs and TODO gaps | `docs/patterns/README.md` |
+| `patterns/` | Pattern hierarchy, composition guidance, and placeholder status map | `docs/patterns/README.md` |
+| `components/` | Component-facing entry, current implementation surfaces, and placeholders | `docs/components/README.md` |
 | `public-api.md` | Canonical Runtime-facing v1 public API summary and migration links | `docs/public-api.md` |
 | `governance-baseline.md` | Consumed governance pack versions, artifact registry, and version lifecycle policy | `docs/governance-baseline.md` |
 | `agentic/` | Agent behavior, workflows, prompts, and migration context | `docs/agentic/README.md` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ details or local agent configuration.
 | `patterns/` | Pattern-level composition guidance | `docs/patterns/README.md` |
 | `components/` | Component-facing entry docs and TODO gaps | `docs/patterns/README.md` |
 | `public-api.md` | Canonical Runtime-facing v1 public API summary and migration links | `docs/public-api.md` |
+| `governance-baseline.md` | Consumed governance pack versions, artifact registry, and version lifecycle policy | `docs/governance-baseline.md` |
 | `agentic/` | Agent behavior, workflows, prompts, and migration context | `docs/agentic/README.md` |
 | `adr/` | Architecture decision records and documentation migration notes | `docs/adr/README.md` |
 | `validation/` | Validation checklists, CI, token parity, and accessibility checks | `docs/validation/README.md` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@
 If you are new to Runtime documentation, use this order:
 
 1. `docs/public-api.md` — canonical v1 API surface and migration entry points
-2. `docs/adr/adr-runtime-and-vault-documentation-architecture.md` — architecture boundary between Runtime and Vault
+2. `docs/architecture.md` — Runtime system map, layers, outputs, and consumer surfaces
 3. `docs/foundations/README.md` — foundations navigation (token architecture, naming, theming)
 4. `docs/patterns/README.md` — pattern and component-facing composition guidance
 5. `docs/validation/README.md` — validation and CI checks
@@ -29,6 +29,7 @@ details or local agent configuration.
 | Section | What belongs here | Start with |
 |---|---|---|
 | `playbook.md` | Reading order, operating model, and agent roles | `docs/playbook.md` |
+| `architecture.md` | Developer-oriented Runtime system map and implementation layers | `docs/architecture.md` |
 | `foundations/` | Token architecture, naming, theming, parity, and format guidance | `docs/foundations/README.md` |
 | `principles/` | Perception, heuristics, and accessibility intent | `docs/principles/README.md` |
 | `patterns/` | Pattern-level composition guidance | `docs/patterns/README.md` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,23 @@
 # Documentation Map
 
+## Start here — Developer quickstart
+
+If you are new to Runtime documentation, use this order:
+
+1. `docs/public-api.md` — canonical v1 API surface and migration entry points
+2. `docs/adr/adr-runtime-and-vault-documentation-architecture.md` — architecture boundary between Runtime and Vault
+3. `docs/foundations/README.md` — foundations navigation (token architecture, naming, theming)
+4. `docs/patterns/README.md` — pattern and component-facing composition guidance
+5. `docs/validation/README.md` — validation and CI checks
+
+From `docs/README.md`, each target is reachable directly in one click.
+
+If you are contributing governance or agent behavior, continue with:
+
+- `docs/uif-governance.md`
+- `docs/playbook.md`
+- `AGENTS.md`
+
 ## Purpose
 
 This directory is the human- and agent-readable map of UI Foundations.

--- a/docs/accessibility-audit-interactive-components.md
+++ b/docs/accessibility-audit-interactive-components.md
@@ -2,9 +2,19 @@
 
 Date: 2026-05-04
 
+## Purpose
+
+This page documents the **workflow** for Runtime accessibility audits of
+interactive components.
+
+For the high-level principle surface, use:
+
+- `docs/principles/accessibility.md`
+
 ## Objective of this PR
 
-This PR intentionally focuses on establishing a **reusable audit workflow** and **finding format** before broad component remediation.
+This workflow intentionally focuses on reusable audit execution and finding
+format before broad component remediation.
 
 ## Primary deliverable
 
@@ -13,6 +23,7 @@ Use the reusable skill document:
 - `docs/agentic/skills/component-accessibility-audit.md`
 
 This skill defines:
+
 - required governance references
 - repeatable audit workflow
 - severity model (blocker/high/medium/low)
@@ -21,10 +32,16 @@ This skill defines:
 - manual screen reader validation requirements
 - example single-component audit prompt
 
+## Principle vs practice boundary
+
+- Principles: `docs/principles/accessibility.md`
+- Practice workflow: this page and the audit skill
+
 ## Follow-up plan
 
-After this workflow-first PR, create **small component-specific PRs** that:
+After this workflow-first PR, create small component-specific PRs that:
+
 1. run the skill for one component,
 2. publish findings using the standard template,
 3. apply minimal scoped fixes,
-4. add/adjust tests and docs for that component only.
+4. add or adjust tests and docs for that component only.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,6 +9,7 @@ stable location for humans and agents.
 
 - `adr-agentic-docs-restructure.md` — documentation structure and agent consumption model
 - `adr-github-projects-workflow.md` — GitHub Projects delivery workflow (proposed)
+- `adr-governance-baseline-version-policy.md` — authoritative consumed governance pack version and lifecycle policy
 - `adr-public-api-documentation-contract.md` — v1 public API documentation contract for canonical vs compatibility guidance
 - `adr-runtime-and-vault-documentation-architecture.md` — Runtime/Vault documentation architecture baseline
 - `adr-uif-public-api-namespace.md` — canonical `uif.*` macro invocation and

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,6 +9,8 @@ stable location for humans and agents.
 
 - `adr-agentic-docs-restructure.md` — documentation structure and agent consumption model
 - `adr-github-projects-workflow.md` — GitHub Projects delivery workflow (proposed)
+- `adr-public-api-documentation-contract.md` — v1 public API documentation contract for canonical vs compatibility guidance
+- `adr-runtime-and-vault-documentation-architecture.md` — Runtime/Vault documentation architecture baseline
 - `adr-uif-public-api-namespace.md` — canonical `uif.*` macro invocation and
   `<uif-*>` Custom Element namespaces (proposed)
 

--- a/docs/adr/adr-governance-baseline-version-policy.md
+++ b/docs/adr/adr-governance-baseline-version-policy.md
@@ -1,0 +1,109 @@
+---
+title: ADR – Governance Baseline Version Policy
+status: accepted
+type: adr
+issue: 206
+related_epic: 205
+governance_pack: 0.7.0
+---
+
+# ADR: Governance Baseline Version Policy
+
+## Context
+
+The Runtime repository consumes governance artifacts from the UI Foundations
+Vault. After the initial consumption, four different version numbers appeared
+across Runtime-owned files:
+
+| File | Version Referenced |
+|------|--------------------|
+| `.uif/registry/source.yml` | `0.7.0` (snapshot) |
+| `.uif/packs/governance/registry/governance-packs.yml` | `0.6.0` (draft) |
+| `.uif/packs/governance/exports/governance-pack/pack.yml` | `0.6.0` |
+| `.uif/packs/governance/contracts/naming-contract.json` | `0.8.0` |
+| `docs/adr/adr-uif-public-api-namespace.md` | `0.8.0` |
+
+This creates ambiguity about which version the Runtime has actually consumed and
+which version its governance decisions are based upon.
+
+## Analysis
+
+### The 0.6.0 references
+
+The pack manifest and registry files record the published Vault pack version at
+the time of consumption. These are correct for the state of the Vault pack at
+snapshot time (`10f78061cd65e6ad6d7304376ead27d44efc01b3`).
+
+### The 0.7.0 reference
+
+The source registry (`source.yml`) records `lastKnownVersion: 0.7.0`. This
+represents the Runtime's knowledge of the Vault pack version at the time of
+manual consumption. The discrepancy between `0.6.0` (pack files) and `0.7.0`
+(registry) indicates that the pack files were consumed from a SHA snapshot that
+was slightly ahead of the 0.6.0 tag but the registry was updated to reflect the
+anticipated 0.7.0 release milestone.
+
+### The 0.8.0 references
+
+The naming contract (`naming-contract.json`) and the public API namespace ADR
+(`adr-uif-public-api-namespace.md`) reference governance pack `0.8.0`. These
+are **forward references** — they were authored with the expectation that the
+UIF public API namespace decision would be captured in a forthcoming 0.8.0 pack
+release. The 0.8.0 pack does not yet exist in the Vault.
+
+## Decision
+
+**The authoritative consumed governance baseline for the Runtime is 0.7.0.**
+
+Rationale:
+
+1. The source registry (`source.yml`) is the Runtime's authoritative record of
+   what has been consumed. It records `0.7.0` at SHA `10f78061`.
+2. The pack manifest files (`0.6.0`) represent the Vault's published tag, not
+   the Runtime's consumption record.
+3. The `0.8.0` forward references in the naming contract and ADR are
+   aspirational references to a planned Vault release. They are accurate in
+   intent but incorrect as consumed-version labels.
+
+## Version Lifecycle Policy
+
+This policy applies to all future governance pack consumption:
+
+1. **Source registry is authoritative.** `.uif/registry/source.yml` is the
+   single source of truth for the consumed version. All other files must
+   reference the same version.
+
+2. **No forward references.** Governance files must only reference versions that
+   have been consumed and recorded in the source registry. Planned future
+   versions must be noted as `pending` or `proposed`, not referenced as if
+   consumed.
+
+3. **Pack file version must match registry version.** When a pack is consumed,
+   the pack manifest version and the registry `lastKnownVersion` must be
+   identical.
+
+4. **Version updates require a governance review.** Updating the consumed
+   version in `source.yml` constitutes a governance consumption event and
+   requires the same review as the initial consumption.
+
+5. **Forward references must be resolved before the next WS cycle.** If a
+   forward reference is identified, it must be corrected to either the current
+   consumed version or marked explicitly as `proposed: <version>` in the
+   relevant file.
+
+## Resolution for Existing Files
+
+| File | Action Required |
+|------|----------------|
+| `.uif/registry/source.yml` | Remains at `0.7.0` — this is authoritative |
+| Pack manifest and registry files | Update to `0.7.0` in WS2-I2 |
+| `naming-contract.json` | Update `governance_pack_version` to `0.7.0` |
+| `adr-uif-public-api-namespace.md` | Update `governance_pack` frontmatter to `0.7.0` and add note about 0.8.0 intent |
+
+## Consequences
+
+- All Runtime-owned governance references will use `0.7.0` as the consumed
+  baseline.
+- Future pack consumption will follow the lifecycle policy above.
+- When the Vault publishes `0.8.0` (incorporating the UIF namespace decision),
+  the Runtime must perform a new reviewed consumption and update `source.yml`.

--- a/docs/adr/adr-governance-baseline-version-policy.md
+++ b/docs/adr/adr-governance-baseline-version-policy.md
@@ -4,7 +4,9 @@ status: accepted
 type: adr
 issue: 206
 related_epic: 205
-governance_pack: 0.7.0
+governance_pack_published: 0.6.0
+governance_pack_consumed_snapshot: 0.7.0
+governance_pack_planned: 0.8.0
 ---
 
 # ADR: Governance Baseline Version Policy
@@ -53,57 +55,51 @@ release. The 0.8.0 pack does not yet exist in the Vault.
 
 ## Decision
 
-**The authoritative consumed governance baseline for the Runtime is 0.7.0.**
+The Runtime uses a three-value interpretation model:
 
-Rationale:
+1. **Published governance pack version:** `0.6.0`
+   Authority: Vault pack manifest and governance registry under
+   `.uif/packs/governance/`.
+2. **Runtime-consumed snapshot/version:** `0.7.0`
+   Authority: Runtime source registry `.uif/registry/source.yml` at SHA
+   `10f78061cd65e6ad6d7304376ead27d44efc01b3`.
+3. **Planned/forward-referenced version:** `0.8.0`
+   Authority: forward reference in governance decision context; not yet the
+   published pack baseline and not the currently consumed Runtime baseline.
 
-1. The source registry (`source.yml`) is the Runtime's authoritative record of
-   what has been consumed. It records `0.7.0` at SHA `10f78061`.
-2. The pack manifest files (`0.6.0`) represent the Vault's published tag, not
-   the Runtime's consumption record.
-3. The `0.8.0` forward references in the naming contract and ADR are
-   aspirational references to a planned Vault release. They are accurate in
-   intent but incorrect as consumed-version labels.
+This model preserves Vault authority while accurately representing Runtime
+adoption status.
 
 ## Version Lifecycle Policy
 
-This policy applies to all future governance pack consumption:
+This policy applies to future governance pack consumption:
 
-1. **Source registry is authoritative.** `.uif/registry/source.yml` is the
-   single source of truth for the consumed version. All other files must
-   reference the same version.
+1. **Published version authority stays with Vault artifacts.** Runtime must not
+   rewrite consumed Vault artifacts in `.uif/packs/governance/` just to align
+   values.
 
-2. **No forward references.** Governance files must only reference versions that
-   have been consumed and recorded in the source registry. Planned future
-   versions must be noted as `pending` or `proposed`, not referenced as if
-   consumed.
+2. **Consumed version authority stays with Runtime registry.**
+   `.uif/registry/source.yml` is authoritative for what Runtime has adopted.
 
-3. **Pack file version must match registry version.** When a pack is consumed,
-   the pack manifest version and the registry `lastKnownVersion` must be
-   identical.
+3. **Planned versions must be labeled explicitly as planned/forward references.**
+   They must not be presented as published or consumed until a reviewed
+   consumption event updates the Runtime registry.
 
-4. **Version updates require a governance review.** Updating the consumed
-   version in `source.yml` constitutes a governance consumption event and
-   requires the same review as the initial consumption.
-
-5. **Forward references must be resolved before the next WS cycle.** If a
-   forward reference is identified, it must be corrected to either the current
-   consumed version or marked explicitly as `proposed: <version>` in the
-   relevant file.
+4. **Version updates require governance review.** Updating the consumed version
+   in `source.yml` is a governance consumption event and requires review.
 
 ## Resolution for Existing Files
 
 | File | Action Required |
 |------|----------------|
-| `.uif/registry/source.yml` | Remains at `0.7.0` — this is authoritative |
-| Pack manifest and registry files | Update to `0.7.0` in WS2-I2 |
-| `naming-contract.json` | Update `governance_pack_version` to `0.7.0` |
-| `adr-uif-public-api-namespace.md` | Update `governance_pack` frontmatter to `0.7.0` and add note about 0.8.0 intent |
+| `.uif/registry/source.yml` | Keep `0.7.0` as consumed Runtime snapshot/version |
+| `.uif/packs/governance/registry/governance-packs.yml` and `exports/governance-pack/pack.yml` | Keep `0.6.0` as published Vault pack version |
+| `.uif/packs/governance/contracts/naming-contract.json` | Keep `0.8.0` as planned/forward reference in consumed artifact context |
+| Runtime docs (`docs/uif-governance.md`, `docs/governance-baseline.md`, relevant ADR frontmatter/notes) | Explicitly distinguish published vs consumed vs planned values |
 
 ## Consequences
 
-- All Runtime-owned governance references will use `0.7.0` as the consumed
-  baseline.
-- Future pack consumption will follow the lifecycle policy above.
-- When the Vault publishes `0.8.0` (incorporating the UIF namespace decision),
-  the Runtime must perform a new reviewed consumption and update `source.yml`.
+- Runtime documentation becomes explicit about authority boundaries.
+- Vault artifacts remain unchanged as consumed source evidence.
+- Future adoption of `0.8.0` requires a reviewed consumption update rather than
+  silent normalization in Runtime files.

--- a/docs/adr/adr-public-api-documentation-contract.md
+++ b/docs/adr/adr-public-api-documentation-contract.md
@@ -1,0 +1,53 @@
+---
+title: ADR – Public API Documentation Contract (v1)
+status: accepted
+type: adr
+---
+
+# ADR: Public API Documentation Contract (v1)
+
+## Context
+
+Runtime documentation contains migration guidance and API usage examples across
+multiple entry points (`README.md`, migration docs, and ADR references).
+
+For v1, the public API surface is intentionally breaking and must be documented
+consistently to avoid conflicting consumer guidance.
+
+## Decision
+
+For owned Runtime documentation, v1 public API guidance follows this contract:
+
+1. Canonical examples use the `uif` namespace for public usage:
+   - classes: `.uif-*`
+   - custom elements: `<uif-*>`
+   - macro invocation alias in examples: `uif.*`
+2. Legacy names (`.button`, `<ui-*>`, legacy token prefixes) are compatibility
+   context only and must be explicitly labeled as migration/compatibility.
+3. Migration detail lives in migration docs; entry docs summarize and link
+   instead of duplicating exhaustive mappings.
+4. Stable package/module surfaces that intentionally remain unchanged in v1
+   (for example `ui-foundations/elements/ui-*` subpaths) may still appear in
+   examples when explicitly called out as stable package surface behavior.
+
+## Consequences
+
+- Top-level docs present one consistent public API story for v1.
+- Consumers can distinguish canonical v1 usage from compatibility context.
+- Migration docs remain the detailed source for before/after mappings.
+
+## Out of scope
+
+This decision does not define:
+
+- governance pack lifecycle policy
+- documentation metadata schema
+- CI validation implementation
+- automation or drift tooling
+
+## Related
+
+- `docs/adr/adr-runtime-and-vault-documentation-architecture.md`
+- `docs/adr/adr-uif-public-api-namespace.md`
+- `docs/migrations/public-api-namespace-v1.md`
+- `MIGRATION.md`

--- a/docs/adr/adr-runtime-and-vault-documentation-architecture.md
+++ b/docs/adr/adr-runtime-and-vault-documentation-architecture.md
@@ -1,0 +1,119 @@
+---
+title: ADR – Runtime and Vault Documentation Architecture
+status: proposed
+type: adr
+---
+
+# ADR: Runtime and Vault Documentation Architecture
+
+## Context
+
+UI Foundations documentation is split across two repositories:
+
+- **Vault** for durable, reusable foundation knowledge.
+- **Runtime** for implementation-facing guidance and repository-specific usage.
+
+Recent audits showed that developer comprehension and governance traceability both degrade when ownership is ambiguous, when the same concept is repeated in multiple places, or when canonical source intent is unclear.
+
+This ADR defines enduring architectural principles for Runtime ↔ Vault documentation decisions.
+
+## Decision
+
+### 1. Purpose of Runtime documentation
+
+Runtime documentation exists to help developers and contributors understand, use, and evolve the Runtime repository effectively:
+
+- architecture and implementation context
+- public surface usage and migration guidance
+- runtime-specific decisions and constraints
+- practical navigation for day-to-day engineering work
+
+### 2. Purpose of the Vault
+
+Vault documentation exists to hold durable, reusable, cross-repository knowledge:
+
+- canonical design and governance principles
+- long-lived conceptual models
+- reusable documentation guidance that should not be redefined per runtime
+
+### 3. Relationship between Runtime and Vault
+
+Runtime and Vault are complementary, not competing:
+
+- Vault provides canonical knowledge and governance intent.
+- Runtime applies that intent to local implementation and delivery reality.
+- Runtime may reference Vault canon, but remains responsible for local clarity and usability.
+
+### 4. Canonical knowledge vs implementation guidance
+
+Documentation must preserve a clear boundary:
+
+- **Canonical knowledge** belongs to Vault.
+- **Implementation guidance** belongs to Runtime.
+
+Runtime should explain how canonical principles are applied locally, without redefining canon.
+
+### 4a. Governance vs developer documentation
+
+- **Governance documentation** defines durable boundaries, authority, and decision intent.
+- **Developer documentation** explains practical repository usage and implementation application.
+- Governance informs developer documentation; developer documentation does not redefine governance.
+
+### 5. Documentation ownership principles
+
+- Every major documentation topic has an explicit owner and decision path.
+- Ownership is accountable stewardship, not isolated authorship.
+- Cross-repository topics require explicit responsibility boundaries between Runtime and Vault.
+
+### 6. Long-term documentation architecture
+
+Documentation architecture must remain:
+
+- understandable to new developers without hidden context
+- resilient to repository evolution and release cycles
+- stable under incremental change
+- explicit about source-of-truth location per topic
+
+### 7. Duplication minimization principle
+
+Duplication should be minimized because it increases drift risk, weakens trust, and creates competing truths.
+
+Allowed duplication is limited to:
+
+- concise summaries that improve local readability
+- migration context that translates canon into runtime actions
+
+When summaries exist, they must clearly point to canonical sources.
+
+### 8. Future evolution principle
+
+Future documentation changes should:
+
+- preserve the Runtime/Vault boundary
+- prefer extension of existing canonical paths over parallel definitions
+- make ownership and authority clearer over time
+- be reviewable as architectural change, not only editorial change
+
+## Consequences
+
+- Documentation initiatives can optimize local developer experience without diluting canonical ownership.
+- Governance and implementation documentation can evolve independently but coherently.
+- Future restructuring efforts have a stable architectural baseline for decisions.
+
+## Out of scope
+
+This ADR intentionally does **not** define:
+
+- metadata schemas
+- CI or validation tooling
+- automation strategy
+- authoring templates or low-level format rules
+
+Those are resolved in subsequent governance and automation decisions.
+
+## Related
+
+- `docs/linking-strategy.md`
+- `docs/uif-governance.md`
+- `docs/README.md`
+- `docs/adr/adr-uif-public-api-namespace.md`

--- a/docs/adr/adr-uif-public-api-namespace.md
+++ b/docs/adr/adr-uif-public-api-namespace.md
@@ -5,8 +5,10 @@ type: adr
 issue: 154
 vault_decision: adr.uif-public-api-namespace
 implementation_issue: 197
-governance_pack: 0.7.0
-governance_pack_note: "Decision aligned with governance pack 0.7.0 (consumed baseline). The naming contract was originally authored referencing a planned 0.8.0 release. Per ADR: Governance Baseline Version Policy, all Runtime references use 0.7.0 until a reviewed 0.8.0 consumption is completed."
+governance_pack_published: 0.6.0
+governance_pack_consumed_snapshot: 0.7.0
+governance_pack_planned: 0.8.0
+governance_pack_note: "The namespace decision is forward-referenced to planned governance pack 0.8.0. Runtime currently records consumption at 0.7.0, while published pack artifacts remain 0.6.0."
 ---
 
 # ADR: UIF Public API Namespace
@@ -26,7 +28,8 @@ points before approving the canonical namespace for these two surfaces.
 ## Decision
 
 Adopt the canonical UIF namespace defined by Vault decision
-`adr.uif-public-api-namespace` and Governance Pack `0.7.0`:
+`adr.uif-public-api-namespace` with forward reference to planned Governance Pack
+`0.8.0` (Runtime consumed snapshot: `0.7.0`, published pack artifacts: `0.6.0`):
 
 - Public Nunjucks documentation and generated snippets import the existing
   macro module with the consumer-selected alias `uif` and invoke macros as

--- a/docs/adr/adr-uif-public-api-namespace.md
+++ b/docs/adr/adr-uif-public-api-namespace.md
@@ -5,7 +5,8 @@ type: adr
 issue: 154
 vault_decision: adr.uif-public-api-namespace
 implementation_issue: 197
-governance_pack: 0.8.0
+governance_pack: 0.7.0
+governance_pack_note: "Decision aligned with governance pack 0.7.0 (consumed baseline). The naming contract was originally authored referencing a planned 0.8.0 release. Per ADR: Governance Baseline Version Policy, all Runtime references use 0.7.0 until a reviewed 0.8.0 consumption is completed."
 ---
 
 # ADR: UIF Public API Namespace
@@ -25,7 +26,7 @@ points before approving the canonical namespace for these two surfaces.
 ## Decision
 
 Adopt the canonical UIF namespace defined by Vault decision
-`adr.uif-public-api-namespace` and Governance Pack `0.8.0`:
+`adr.uif-public-api-namespace` and Governance Pack `0.7.0`:
 
 - Public Nunjucks documentation and generated snippets import the existing
   macro module with the consumer-selected alias `uif` and invoke macros as

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,101 @@
+# Runtime Architecture Overview
+
+## Purpose
+
+This page explains how the `ui-foundations` Runtime is assembled and where to
+look next when you need implementation detail.
+
+It is intentionally implementation-oriented. Canonical principles, governance,
+and reusable architecture decisions remain in the Vault and the documented ADR
+set.
+
+## Narrative boundary
+
+Use Runtime docs for:
+
+- repository structure
+- token flow and generated outputs
+- implementation layers and consumer surfaces
+- where patterns, elements, validation, and docs connect
+
+Use canonical sources for:
+
+- durable design principles
+- governance rules
+- cross-repository documentation architecture
+- reusable specifications
+
+When this page summarizes a concept, it links to the deeper Runtime source
+instead of restating Vault canon.
+
+## System map
+
+```text
+Figma exports
+  -> token generation scripts
+  -> generated dist outputs
+  -> consumption surfaces
+  -> validation and docs
+```
+
+## Runtime layers
+
+### 1. Source inputs
+
+- `figma/exports/*.tokens.json` — Figma variable exports
+- `src/ui/patterns/` — CSS pattern sources
+- `src/elements/` — light-DOM Custom Elements
+- `site/` — docs-site pages, macros, and examples
+
+### 2. Generation and build
+
+- token generation scripts transform Figma exports into CSS, JSON, TS, and YAML
+- CSS bundles assemble core, token, context, and UI layers
+- docs build renders implementation guidance and playground pages
+
+For the pipeline mechanics, see `docs/token-pipeline.md`.
+
+### 3. Generated outputs
+
+- `dist/tokens/` — generated token artifacts
+- `dist/core/` and `dist/ui/` — CSS output layers
+- `dist/macros/` — generated macro copies
+- package exports consumed by CSS users, macro users, and Custom Element users
+
+Generated `dist/` files are outputs, not authored sources.
+
+### 4. Consumer surfaces
+
+- plain HTML + CSS patterns
+- Nunjucks macros
+- light-DOM Custom Elements
+- token exports for downstream tooling
+
+The public API entry point for those surfaces is `docs/public-api.md`.
+
+## Token and UI layering
+
+Runtime implementation follows four practical layers:
+
+1. **Core** — primitives and shared references
+2. **Appearance** — mode-dependent decisions
+3. **Semantics** — brand-scoped semantic roles
+4. **Patterns / Components** — UI-facing usage tokens and implementation
+
+This page only names the layers. For the canonical detailed layer rules, start
+with `docs/foundations/foundation-001-token-layering.md`.
+
+## How developers should navigate
+
+- Start with `docs/public-api.md` for authored usage
+- Read `docs/foundations/README.md` for token and naming deep links
+- Use `docs/patterns/README.md` for composition guidance
+- Use `docs/validation/README.md` for checks and CI-facing validation
+- Use `IMPLEMENTATION.md` when you need repository execution detail
+
+## Runtime vs Vault
+
+The Runtime explains how this repository applies the system.
+
+The Vault remains the canonical source for durable knowledge. Runtime docs
+should link to canon, not replace it.

--- a/docs/canonical-reference-matrix.md
+++ b/docs/canonical-reference-matrix.md
@@ -1,0 +1,27 @@
+# Canonical Topic-Source Matrix
+
+## Purpose
+
+Map major Runtime documentation topics to one clear canonical source and one
+Runtime implementation reference.
+
+This matrix is a documentation traceability aid. It does not define governance
+policy architecture.
+
+| Topic | Canonical source | Runtime implementation reference |
+|---|---|---|
+| Runtime/Vault documentation boundary | `docs/adr/adr-runtime-and-vault-documentation-architecture.md` | `docs/architecture.md` |
+| Public API naming and usage | `docs/public-api.md` | `README.md` quickstart + migration links |
+| Public API migration mappings | `docs/migrations/public-api-namespace-v1.md` | `site/` and `src/elements/` usage surfaces |
+| Token layer model | `docs/foundations/foundation-001-token-layering.md` | `docs/foundations/README.md`, `docs/token-pipeline.md` |
+| Token generation mechanics | `docs/token-pipeline.md` | `scripts/extract-tokens.js`, `dist/tokens/` |
+| Pattern/component hierarchy and status | `docs/patterns/README.md` | `docs/components/README.md` |
+| Runtime accessibility principles | `docs/principles/accessibility.md` | `docs/accessibility-audit-interactive-components.md`, `docs/validation/README.md` |
+| Validation pipeline | `docs/validation/ci.md` | `package.json` scripts, `.github/workflows/ci.yml` |
+| Governance consumption lifecycle | `.uif/registry/source.yml` + consumed pack metadata | `docs/uif-governance.md`, `docs/governance-baseline.md` |
+| Canonical link ownership strategy | `config/site.js` (`vault.*` config) | `docs/linking-strategy.md` |
+
+## Terminology links
+
+Use `docs/terminology.md` for canonical/compatibility/deprecated/placeholder
+term definitions used in this matrix.

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -1,0 +1,52 @@
+# Components
+
+## Purpose
+
+This section is the Runtime entry point for component-facing documentation.
+
+Use this page to understand which component surfaces are implemented now, which
+are pattern-level only, and which are placeholders.
+
+## Scope boundary
+
+- **Patterns** describe reusable composition rules (`docs/patterns/README.md`).
+- **Components** describe runtime behavior surfaces that add interactivity or
+  encapsulation.
+- Canonical governance and architecture ownership remain in Vault-linked
+  governance and ADR documentation.
+
+## Current component status
+
+### Implemented runtime component surfaces
+
+Runtime currently provides light-DOM Custom Element surfaces under
+`src/elements/` (for example: `ui-button.js`, `ui-input.js`, `ui-select.js`,
+`ui-tooltip.js`, `ui-tabs.js`).
+
+These are implementation surfaces for existing UI patterns and are not treated
+as separate product-component governance in this documentation layer.
+
+### Planned or placeholder component docs
+
+| Topic | Status | Current source |
+|---|---|---|
+| Modal | Placeholder | `docs/patterns/modal.md` |
+| Notification | Placeholder | `docs/patterns/notification.md` |
+| Select (standalone component doc) | Placeholder | `docs/patterns/select.md` |
+
+Placeholder pages are explicitly non-canonical and must not be interpreted as
+final behavior documentation.
+
+## Recommended path
+
+1. Start with `docs/patterns/README.md` for composition context.
+2. Use `docs/public-api.md` for authored public surface usage.
+3. Use `src/elements/` and `site/patterns/` for implementation-level behavior.
+4. Use `docs/validation/README.md` for checks and CI-facing validation.
+
+## Related docs
+
+- `docs/patterns/README.md`
+- `docs/public-api.md`
+- `docs/architecture.md`
+- `docs/validation/README.md`

--- a/docs/foundations/README.md
+++ b/docs/foundations/README.md
@@ -5,6 +5,29 @@
 Foundations docs describe the canonical token, naming, theming, parity, and
 format rules that other layers build on.
 
+This section is the developer-facing entry point for Runtime foundation
+implementation. It points to the detailed foundation records instead of
+repeating them.
+
+## Foundations at a glance
+
+Use foundations docs to understand:
+
+1. how token layers are separated
+2. how public naming is derived
+3. how mode and brand context are activated
+4. how generated token outputs feed patterns and components
+
+For the repository-wide system view, start with `docs/architecture.md`.
+
+## Recommended reading path
+
+1. `foundation-001-token-layering.md` — token layer model
+2. `foundation-002-naming-and-grouping.md` — naming structure and grouping
+3. `foundation-008-mode-activation-and-consumer-control.md` — mode ownership
+4. `foundation-010-implementation-and-pipeline-workflow.md` — implementation workflow
+5. `docs/token-pipeline.md` — generation mechanics and output files
+
 ## Canonical files
 
 The detailed foundation ADRs are the source of truth:
@@ -29,3 +52,10 @@ The detailed foundation ADRs are the source of truth:
 - Designers defining token and naming decisions
 - Engineers implementing or validating token-driven UI
 - Agents doing token, component, or parity work
+
+## Related docs
+
+- `docs/architecture.md`
+- `docs/token-pipeline.md`
+- `docs/patterns/README.md`
+- `IMPLEMENTATION.md`

--- a/docs/governance-baseline.md
+++ b/docs/governance-baseline.md
@@ -1,0 +1,140 @@
+---
+title: Governance Baseline Reference Matrix
+status: active
+type: governance
+owner: ui-foundations-runtime
+issue: 208
+related_epic: 205
+consumed_pack_version: 0.7.0
+consumed_pack_sha: 10f78061cd65e6ad6d7304376ead27d44efc01b3
+---
+
+# Governance Baseline Reference Matrix
+
+This document records the governance artifacts consumed from the UI Foundations
+Vault, their canonical sources, consumed versions, and current review status.
+
+It is the Runtime's authoritative record of governance consumption. Any change
+to a consumed version must be reviewed and recorded here before it takes effect
+in Runtime documentation or implementation.
+
+## Consumed Pack
+
+| Field | Value |
+|-------|-------|
+| Pack ID | `governance-pack` |
+| Vault source | `ui-foundations-vault` |
+| Consumed version | `0.7.0` |
+| Vault SHA | `10f78061cd65e6ad6d7304376ead27d44efc01b3` |
+| Consumption mode | `reviewed-manual` |
+| Channel | `snapshot` |
+| Last reviewed | 2026-07-09 |
+| Source registry | `.uif/registry/source.yml` |
+
+> **Note:** The pack files under `.uif/packs/governance/` reflect Vault release
+> `0.6.0` (the last published tag at time of consumption). The Runtime consumed
+> a SHA snapshot between 0.6.0 and the anticipated 0.7.0 release. The source
+> registry version (`0.7.0`) is the authoritative consumed baseline per
+> [ADR: Governance Baseline Version Policy](adr/adr-governance-baseline-version-policy.md).
+
+---
+
+## Consumed Artifacts
+
+### Naming Rules
+
+| Field | Value |
+|-------|-------|
+| Artifact ID | `governance-pack.naming-rules` |
+| Vault path | `.uif/packs/governance/exports/governance-pack/naming-rules.md` |
+| Contract | `.uif/packs/governance/contracts/naming-contract.json` |
+| Consumed version | `0.7.0` |
+| Status | `draft` |
+| Review required | Yes |
+| Runtime owner | ui-foundations-runtime |
+| Related ADR | [`adr-uif-public-api-namespace.md`](adr/adr-uif-public-api-namespace.md) |
+| Notes | Naming contract version aligned to 0.7.0 per WS2-I2. |
+
+### Token Governance
+
+| Field | Value |
+|-------|-------|
+| Artifact ID | `governance-pack.token-governance` |
+| Vault path | `.uif/packs/governance/exports/governance-pack/token-governance.md` |
+| Consumed version | `0.7.0` |
+| Status | `draft` |
+| Review required | Yes |
+| Runtime owner | ui-foundations-runtime |
+| Notes | Governs Core → Semantic → Component token layer separation and `--uif-*` prefix convention. |
+
+### Component Governance
+
+| Field | Value |
+|-------|-------|
+| Artifact ID | `governance-pack.component-governance` |
+| Vault path | `.uif/packs/governance/exports/governance-pack/component-governance.md` |
+| Consumed version | `0.7.0` |
+| Status | `draft` |
+| Review required | Yes |
+| Runtime owner | ui-foundations-runtime |
+| Notes | Governs `.uif-*` CSS class convention, pattern lifecycle, and component boundaries. |
+
+### Accessibility Baseline
+
+| Field | Value |
+|-------|-------|
+| Artifact ID | `governance-pack.accessibility-baseline` |
+| Vault path | `.uif/packs/governance/exports/governance-pack/accessibility-baseline.md` |
+| Consumed version | `0.7.0` |
+| Status | `draft` |
+| Review required | Yes |
+| Runtime owner | ui-foundations-runtime |
+| Notes | Defines native-first accessibility model; ARIA is supplementary not primary. |
+
+### Decisions
+
+| Artifact | Vault Path | Status |
+|----------|-----------|--------|
+| UIF Public API Namespace | `.uif/packs/governance/decisions/uif-public-api-namespace.md` | Accepted |
+
+### Pattern Governance
+
+| Artifact | Vault Path | Status |
+|----------|-----------|--------|
+| Pattern Schema | `.uif/packs/governance/patterns/schemas/pattern.schema.md` | Draft |
+| Base Pattern Template | `.uif/packs/governance/patterns/templates/base-pattern.template.md` | Draft |
+| Composition Pattern Template | `.uif/packs/governance/patterns/templates/composition-pattern.template.md` | Draft |
+| Product Pattern Template | `.uif/packs/governance/patterns/templates/product-pattern.template.md` | Draft |
+| Button Pattern (pilot) | `.uif/packs/governance/patterns/base/button.pattern.md` | Draft |
+
+---
+
+## Version History
+
+| Version | Date | Notes |
+|---------|------|-------|
+| 0.7.0 | 2026-07-09 | Initial consumption baseline (SHA snapshot). Naming rules, token governance, component governance, accessibility baseline, UIF namespace decision. |
+| 0.6.0 | 2026-07-09 | Last published Vault release tag. Pack files reflect this version. |
+
+---
+
+## Lifecycle Policy
+
+When a new governance pack version is available from the Vault:
+
+1. A governance review is required before consumption.
+2. The reviewed version must be recorded in `.uif/registry/source.yml`.
+3. This matrix must be updated in the same commit.
+4. Any Runtime documentation that references the pack version must be updated.
+5. No automatic synchronisation is permitted.
+
+For the full version lifecycle policy, see
+[ADR: Governance Baseline Version Policy](adr/adr-governance-baseline-version-policy.md).
+
+---
+
+## Canonical Source
+
+- Vault remote: `https://github.com/tbielich/ui-foundations-vault.git`
+- Source registry: `.uif/registry/source.yml`
+- Pack registry (consumed): `.uif/packs/governance/registry/governance-packs.yml`

--- a/docs/governance-baseline.md
+++ b/docs/governance-baseline.md
@@ -5,136 +5,33 @@ type: governance
 owner: ui-foundations-runtime
 issue: 208
 related_epic: 205
-consumed_pack_version: 0.7.0
-consumed_pack_sha: 10f78061cd65e6ad6d7304376ead27d44efc01b3
 ---
 
 # Governance Baseline Reference Matrix
 
-This document records the governance artifacts consumed from the UI Foundations
-Vault, their canonical sources, consumed versions, and current review status.
+This Runtime reference matrix captures governance baseline interpretation without
+changing consumed Vault artifacts.
 
-It is the Runtime's authoritative record of governance consumption. Any change
-to a consumed version must be reviewed and recorded here before it takes effect
-in Runtime documentation or implementation.
+| Concept | Authoritative Source | Current Value / State | Authority | Runtime Interpretation |
+|---|---|---|---|---|
+| Published governance pack version | `.uif/packs/governance/registry/governance-packs.yml`, `.uif/packs/governance/exports/governance-pack/pack.yml` | `0.6.0` (draft channel) | Vault published pack artifacts (consumed copy) | Treat as published baseline currently present in consumed pack files |
+| Runtime-consumed governance snapshot/version | `.uif/registry/source.yml` (`consumedPacks[id=governance]`) | `lastKnownVersion: 0.7.0`, `versionRef.type: sha`, `value: 10f78061cd65e6ad6d7304376ead27d44efc01b3`, `versionStatus: snapshot` | Runtime source registry | Treat as current Runtime adoption baseline |
+| Planned/forward governance reference | `.uif/packs/governance/contracts/naming-contract.json` (`governance_pack_version: 0.8.0`), `docs/adr/adr-uif-public-api-namespace.md` | `0.8.0` (forward reference) | Decision context / forward planning reference | Treat as planned target only; not published baseline and not consumed Runtime baseline |
+| Consumption lifecycle/channel | `.uif/registry/source.yml` | `mode: reviewed-manual`, `automaticSync: false`, `versionStatus: snapshot` | Runtime source registry | Reviewed manual adoption only; no automatic sync |
+| Vault canonical authority | `vault.repository`, `vault.ref.strategy`, `vault.sourceOfTruthFor` in `.uif/registry/source.yml` | Vault is source of truth for reusable governance | Vault definition recorded by Runtime | Runtime documents local adoption status; it does not redefine Vault publication state |
 
-## Consumed Pack
+## Usage Rules for Runtime-owned Documentation
 
-| Field | Value |
-|-------|-------|
-| Pack ID | `governance-pack` |
-| Vault source | `ui-foundations-vault` |
-| Consumed version | `0.7.0` |
-| Vault SHA | `10f78061cd65e6ad6d7304376ead27d44efc01b3` |
-| Consumption mode | `reviewed-manual` |
-| Channel | `snapshot` |
-| Last reviewed | 2026-07-09 |
-| Source registry | `.uif/registry/source.yml` |
+1. Use **published** when referencing version state declared in consumed Vault
+   pack artifacts (`0.6.0` currently).
+2. Use **consumed** when referencing Runtime registry adoption (`0.7.0`
+   snapshot currently).
+3. Use **planned** or **forward reference** when referencing `0.8.0`.
+4. Do not modify consumed Vault artifacts under `.uif/packs/governance/` only to
+   align numbers.
 
-> **Note:** The pack files under `.uif/packs/governance/` reflect Vault release
-> `0.6.0` (the last published tag at time of consumption). The Runtime consumed
-> a SHA snapshot between 0.6.0 and the anticipated 0.7.0 release. The source
-> registry version (`0.7.0`) is the authoritative consumed baseline per
-> [ADR: Governance Baseline Version Policy](adr/adr-governance-baseline-version-policy.md).
+## Related
 
----
-
-## Consumed Artifacts
-
-### Naming Rules
-
-| Field | Value |
-|-------|-------|
-| Artifact ID | `governance-pack.naming-rules` |
-| Vault path | `.uif/packs/governance/exports/governance-pack/naming-rules.md` |
-| Contract | `.uif/packs/governance/contracts/naming-contract.json` |
-| Consumed version | `0.7.0` |
-| Status | `draft` |
-| Review required | Yes |
-| Runtime owner | ui-foundations-runtime |
-| Related ADR | [`adr-uif-public-api-namespace.md`](adr/adr-uif-public-api-namespace.md) |
-| Notes | Naming contract version aligned to 0.7.0 per WS2-I2. |
-
-### Token Governance
-
-| Field | Value |
-|-------|-------|
-| Artifact ID | `governance-pack.token-governance` |
-| Vault path | `.uif/packs/governance/exports/governance-pack/token-governance.md` |
-| Consumed version | `0.7.0` |
-| Status | `draft` |
-| Review required | Yes |
-| Runtime owner | ui-foundations-runtime |
-| Notes | Governs Core → Semantic → Component token layer separation and `--uif-*` prefix convention. |
-
-### Component Governance
-
-| Field | Value |
-|-------|-------|
-| Artifact ID | `governance-pack.component-governance` |
-| Vault path | `.uif/packs/governance/exports/governance-pack/component-governance.md` |
-| Consumed version | `0.7.0` |
-| Status | `draft` |
-| Review required | Yes |
-| Runtime owner | ui-foundations-runtime |
-| Notes | Governs `.uif-*` CSS class convention, pattern lifecycle, and component boundaries. |
-
-### Accessibility Baseline
-
-| Field | Value |
-|-------|-------|
-| Artifact ID | `governance-pack.accessibility-baseline` |
-| Vault path | `.uif/packs/governance/exports/governance-pack/accessibility-baseline.md` |
-| Consumed version | `0.7.0` |
-| Status | `draft` |
-| Review required | Yes |
-| Runtime owner | ui-foundations-runtime |
-| Notes | Defines native-first accessibility model; ARIA is supplementary not primary. |
-
-### Decisions
-
-| Artifact | Vault Path | Status |
-|----------|-----------|--------|
-| UIF Public API Namespace | `.uif/packs/governance/decisions/uif-public-api-namespace.md` | Accepted |
-
-### Pattern Governance
-
-| Artifact | Vault Path | Status |
-|----------|-----------|--------|
-| Pattern Schema | `.uif/packs/governance/patterns/schemas/pattern.schema.md` | Draft |
-| Base Pattern Template | `.uif/packs/governance/patterns/templates/base-pattern.template.md` | Draft |
-| Composition Pattern Template | `.uif/packs/governance/patterns/templates/composition-pattern.template.md` | Draft |
-| Product Pattern Template | `.uif/packs/governance/patterns/templates/product-pattern.template.md` | Draft |
-| Button Pattern (pilot) | `.uif/packs/governance/patterns/base/button.pattern.md` | Draft |
-
----
-
-## Version History
-
-| Version | Date | Notes |
-|---------|------|-------|
-| 0.7.0 | 2026-07-09 | Initial consumption baseline (SHA snapshot). Naming rules, token governance, component governance, accessibility baseline, UIF namespace decision. |
-| 0.6.0 | 2026-07-09 | Last published Vault release tag. Pack files reflect this version. |
-
----
-
-## Lifecycle Policy
-
-When a new governance pack version is available from the Vault:
-
-1. A governance review is required before consumption.
-2. The reviewed version must be recorded in `.uif/registry/source.yml`.
-3. This matrix must be updated in the same commit.
-4. Any Runtime documentation that references the pack version must be updated.
-5. No automatic synchronisation is permitted.
-
-For the full version lifecycle policy, see
-[ADR: Governance Baseline Version Policy](adr/adr-governance-baseline-version-policy.md).
-
----
-
-## Canonical Source
-
-- Vault remote: `https://github.com/tbielich/ui-foundations-vault.git`
-- Source registry: `.uif/registry/source.yml`
-- Pack registry (consumed): `.uif/packs/governance/registry/governance-packs.yml`
+- `docs/adr/adr-governance-baseline-version-policy.md`
+- `docs/uif-governance.md`
+- `.uif/registry/source.yml`

--- a/docs/linking-strategy.md
+++ b/docs/linking-strategy.md
@@ -64,3 +64,9 @@ URL moves to a dedicated publishing target.
   vault links.
 - Do not introduce environment variables for vault location. The vault location
   is project configuration, not deployment configuration.
+
+
+## Related docs
+
+- `docs/canonical-reference-matrix.md`
+- `docs/terminology.md`

--- a/docs/patterns/README.md
+++ b/docs/patterns/README.md
@@ -2,8 +2,37 @@
 
 ## Purpose
 
-Pattern docs sit between principles and components. They describe reusable UI
-composition logic without dropping directly into component implementation detail.
+Pattern docs describe reusable HTML/CSS composition rules and the implementation
+surfaces that apply them.
+
+Patterns are not component-governance pages. Component-facing documentation is
+tracked from `docs/components/README.md`.
+
+## Classification policy (WS5)
+
+Runtime pattern/component docs use three explicit statuses:
+
+1. **Implemented pattern** — canonical implementation exists in `site/` and/or
+   `src/ui/patterns/`.
+2. **Pattern guidance** — reusable guidance exists, but no dedicated runtime
+   implementation page is required.
+3. **Component placeholder** — reserved location only; not canonical behavior
+   guidance until implementation docs exist.
+
+## Pattern and component hierarchy map
+
+| Doc | Classification | Status | Implementation source |
+|---|---|---|---|
+| `button.md` | Implemented pattern | Active | `site/patterns/button.md`, `src/ui/patterns/button.css`, `src/elements/ui-button.js` |
+| `input.md` | Implemented pattern | Active | `site/patterns/input.md`, `src/ui/patterns/input.css`, `src/elements/ui-input.js` |
+| `forms.md` | Pattern guidance | Active | `.kiro/steering/pattern-rules/forms.md` |
+| `navigation.md` | Pattern guidance | Active | `.kiro/steering/pattern-rules/navigation.md` |
+| `cards.md` | Pattern guidance | Active | `.kiro/steering/pattern-rules/cards.md` |
+| `feedback.md` | Pattern guidance | Placeholder summary | See TODO in page; no standalone feedback rule yet |
+| `layout.md` | Pattern guidance | Placeholder summary | Foundations references only; no standalone layout pattern rule |
+| `modal.md` | Component placeholder | Placeholder | No runtime component documentation yet |
+| `notification.md` | Component placeholder | Placeholder | No runtime component documentation yet |
+| `select.md` | Component placeholder | Placeholder | No standalone select component documentation yet |
 
 ## Canonical rules
 
@@ -18,6 +47,6 @@ composition logic without dropping directly into component implementation detail
 
 ## Related docs
 
+- `docs/components/README.md`
 - `docs/principles/README.md`
-- `docs/patterns/README.md`
 - `docs/validation/ci.md`

--- a/docs/patterns/feedback.md
+++ b/docs/patterns/feedback.md
@@ -14,6 +14,7 @@ error recovery, and assistive feedback.
 
 ## Current canonical references
 
+- `docs/principles/accessibility.md`
 - `docs/principles/usability-heuristics.md`
 - `docs/agentic/assistant-behavior-rules.md`
 - `.kiro/specs/accessibility-test-suite/requirements.md`

--- a/docs/patterns/feedback.md
+++ b/docs/patterns/feedback.md
@@ -1,11 +1,18 @@
 # Feedback
 
+## Status
+
+**Pattern guidance (summary-level).**
+
+This page links existing feedback-related guidance. It is not a standalone
+canonical interaction specification.
+
 ## Purpose
 
-Capture the existing repo guidance around interactive feedback, visible state,
+Capture the current repo guidance around interactive feedback, visible state,
 error recovery, and assistive feedback.
 
-## Canonical rules
+## Current canonical references
 
 - `docs/principles/usability-heuristics.md`
 - `docs/agentic/assistant-behavior-rules.md`
@@ -14,10 +21,10 @@ error recovery, and assistive feedback.
 ## Related docs
 
 - `docs/patterns/forms.md`
-- `docs/validation/accessibility.md`
+- `docs/validation/README.md`
 
 ## TODO
 
 There is no standalone feedback pattern rule in the repo yet. If one becomes
-necessary, derive it from the existing heuristics and component state guidance
+necessary, derive it from existing heuristics and component state guidance
 instead of inventing a new interaction model ad hoc.

--- a/docs/patterns/forms.md
+++ b/docs/patterns/forms.md
@@ -11,8 +11,13 @@ help text, errors, and action ordering.
 - `docs/foundations/foundation-009-component-boundaries-and-utility.md`
 - `docs/agentic/assistant-behavior-rules.md`
 
+## Accessibility principle entry
+
+- `docs/principles/accessibility.md`
+
 ## Related docs
 
 - `docs/patterns/input.md`
 - `docs/patterns/button.md`
-- `docs/principles/accessibility.md`
+- `docs/principles/usability-heuristics.md`
+- `docs/validation/README.md`

--- a/docs/patterns/input.md
+++ b/docs/patterns/input.md
@@ -11,8 +11,12 @@ Point to the existing input implementation and documentation surfaces.
 - `src/elements/ui-input.js`
 - `schemas/web-input.figma.ts`
 
+## Accessibility principle entry
+
+- `docs/principles/accessibility.md`
+
 ## Related docs
 
 - `docs/patterns/forms.md`
-- `docs/principles/accessibility.md`
+- `docs/principles/usability-heuristics.md`
 - `docs/validation/token-parity.md`

--- a/docs/patterns/layout.md
+++ b/docs/patterns/layout.md
@@ -1,11 +1,18 @@
 # Layout
 
+## Status
+
+**Pattern guidance (summary-level).**
+
+This page points to existing foundational layout rules. It is not a standalone
+canonical layout-pattern specification.
+
 ## Purpose
 
 Describe the current layout-related guidance that already exists in foundations
-and component rules.
+and component boundary rules.
 
-## Canonical rules
+## Current canonical references
 
 - `docs/foundations/foundation-005-responsive-breakpoints-and-containers.md`
 - `docs/foundations/foundation-012-minimal-markup-and-composition.md`
@@ -14,7 +21,7 @@ and component rules.
 ## Related docs
 
 - `docs/patterns/cards.md`
-- `docs/foundations/theming.md`
+- `docs/foundations/README.md`
 
 ## TODO
 

--- a/docs/patterns/modal.md
+++ b/docs/patterns/modal.md
@@ -1,20 +1,30 @@
 # Modal
 
+## Status
+
+**Placeholder (non-canonical component tracker).**
+
+This page reserves a stable location for future Runtime modal component
+documentation. It does not define final modal behavior.
+
 ## Purpose
 
-Track modal-related component guidance separately from the modal pattern.
+Track modal-related component guidance separately from modal pattern references.
 
-## Canonical rules
+## Current canonical references
 
 - `.kiro/steering/pattern-rules/modals.md`
 - `docs/foundations/foundation-009-component-boundaries-and-utility.md`
+- `docs/components/README.md`
 
 ## Related docs
 
-- `docs/principles/accessibility.md`
-- `docs/validation/accessibility.md`
+- `docs/principles/README.md`
+- `docs/accessibility-audit-interactive-components.md`
+- `docs/validation/README.md`
 
 ## TODO
 
 No modal component implementation doc exists in the current repo. Use the modal
-pattern guidance first, then decide whether a component surface is necessary.
+pattern guidance first, then decide whether a dedicated component surface is
+necessary.

--- a/docs/patterns/navigation.md
+++ b/docs/patterns/navigation.md
@@ -10,8 +10,12 @@ hierarchy, and recognisable destination structure.
 - `.kiro/steering/pattern-rules/navigation.md`
 - `docs/foundations/foundation-012-minimal-markup-and-composition.md`
 
+## Accessibility principle entry
+
+- `docs/principles/accessibility.md`
+
 ## Related docs
 
 - `docs/patterns/button.md`
-- `docs/principles/perception-laws.md`
+- `docs/principles/usability-heuristics.md`
 - `docs/validation/ci.md`

--- a/docs/patterns/notification.md
+++ b/docs/patterns/notification.md
@@ -1,18 +1,25 @@
 # Notification
 
+## Status
+
+**Placeholder (non-canonical component tracker).**
+
+This page reserves a stable location for future Runtime notification component
+documentation. It does not define final notification behavior.
+
 ## Purpose
 
-Reserve a stable location for future notification-component documentation.
+Track where notification component documentation should live once implemented.
 
-## Canonical rules
+## Current canonical references
 
-- `docs/patterns/README.md`
+- `docs/components/README.md`
 - `docs/patterns/feedback.md`
 
 ## Related docs
 
 - `docs/principles/usability-heuristics.md`
-- `docs/validation/accessibility.md`
+- `docs/validation/README.md`
 
 ## TODO
 

--- a/docs/patterns/select.md
+++ b/docs/patterns/select.md
@@ -1,13 +1,22 @@
 # Select
 
+## Status
+
+**Placeholder (non-canonical component tracker).**
+
+This page tracks standalone select component documentation status. It does not
+define final select component behavior.
+
 ## Purpose
 
-Track where select-component documentation should live once the component exists.
+Track where select-component documentation should live once a dedicated
+component surface is documented.
 
-## Canonical rules
+## Current canonical references
 
-- `docs/patterns/README.md`
+- `docs/components/README.md`
 - `docs/patterns/forms.md`
+- `src/elements/ui-select.js`
 
 ## Related docs
 
@@ -17,4 +26,5 @@ Track where select-component documentation should live once the component exists
 ## TODO
 
 No standalone select component documentation exists in the current repo.
-Validate whether this should be a new component or composition before adding it.
+Validate whether this should remain pattern composition or become a dedicated
+component documentation surface.

--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -7,25 +7,31 @@ guessing which file owns which rule.
 
 ## Reading order
 
-`AGENTS.md`  
-↓  
-`docs/playbook.md`  
-↓  
-`docs/foundations/*`  
-↓  
-`docs/principles/*`  
-↓  
-`docs/patterns/*`  
-↓  
-`docs/patterns/*`  
-↓  
-`docs/validation/*`
+### Developer-first navigation (default)
+
+`README.md` → `docs/README.md` → `docs/public-api.md` →
+`docs/foundations/*` → `docs/patterns/*` → `docs/validation/*`
+
+### Agent/contributor navigation
+
+`AGENTS.md` → `docs/playbook.md` → `docs/foundations/*` →
+`docs/principles/*` → `docs/patterns/*` → `docs/validation/*`
+
+### Missing-reference fallback policy
+
+If a Runtime-local reference target is missing:
+
+1. Prefer linking to an existing Runtime page that carries the concept.
+2. If no Runtime page exists, add a minimal Runtime stub that points to the
+   canonical Vault source.
+3. Do not leave unresolved links or infer canonical ownership from local drafts.
 
 Supplemental context:
 
 - `DESIGN.md` for the executive design contract
 - `IMPLEMENTATION.md` for repo-specific execution guidance
-- `docs/ui-foundations-rules.md` for governance
+- `docs/uif-governance.md` for governance consumption state
+- `docs/ui-foundations-rules.md` for canonical operating rules
 - `docs/token-pipeline.md` for token generation and DTCG format details
 
 ## Operating model
@@ -58,6 +64,7 @@ How that applies in this repo:
 - Token architecture: `docs/foundations/foundation-001-token-layering.md`
 - Naming: `docs/foundations/foundation-002-naming-and-grouping.md`
 - Theming: `docs/foundations/foundation-008-mode-activation-and-consumer-control.md`
+- Public API entry: `docs/public-api.md`
 - Figma/code parity: `docs/ui-foundations-rules.md`, `IMPLEMENTATION.md`
 - Token format / DTCG: `docs/token-pipeline.md`
 - Agent behavior: `docs/agentic/assistant-behavior-rules.md`

--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -33,6 +33,8 @@ Supplemental context:
 - `docs/uif-governance.md` for governance consumption state
 - `docs/ui-foundations-rules.md` for canonical operating rules
 - `docs/token-pipeline.md` for token generation and DTCG format details
+- `docs/terminology.md` for canonical terminology baseline
+- `docs/canonical-reference-matrix.md` for topic-to-source traceability
 
 ## Operating model
 
@@ -69,6 +71,8 @@ How that applies in this repo:
 - Token format / DTCG: `docs/token-pipeline.md`
 - Agent behavior: `docs/agentic/assistant-behavior-rules.md`
 - Validation and CI: `docs/validation/ci.md`
+- Terminology baseline: `docs/terminology.md`
+- Canonical topic-source map: `docs/canonical-reference-matrix.md`
 
 ## Related docs
 

--- a/docs/principles/README.md
+++ b/docs/principles/README.md
@@ -2,23 +2,29 @@
 
 ## Purpose
 
-This section explains how design foundation knowledge is used by the
-`ui-foundations` implementation repository.
+This section explains how design foundation knowledge is applied in the
+`ui-foundations` Runtime repository.
 
-Canonical design foundation knowledge is maintained in the UI Foundations Vault. This repository only documents implementation-specific usage.
+Canonical design foundation knowledge is maintained in the UI Foundations Vault.
+Runtime docs keep implementation-facing summaries and links.
 
-Vault reference:
+## Accessibility principle boundary (WS6 decision)
 
-- `config/site.js` -> `vault.documentation`
+Runtime principles docs:
 
-## Canonical rules
+- summarize how accessibility principles are applied in this repository
+- link to implementation surfaces (patterns, elements, validation, audits)
+- avoid redefining canonical principle wording
+
+Canonical principle definitions remain in Vault documentation and linked
+cross-repository governance sources.
+
+## Canonical references
 
 - Vault documentation path: `foundations/design-principles.md`
 - Vault documentation path: `foundations/usability-heuristics.md`
 - Vault documentation path: `foundations/gestalt-principles.md`
-
-Local docs should describe how those foundations are applied to patterns,
-components, tokens, validation, and CI in this repository.
+- Runtime accessibility principles surface: `docs/principles/accessibility.md`
 
 ## Who should read this
 
@@ -28,6 +34,7 @@ components, tokens, validation, and CI in this repository.
 
 ## Related docs
 
+- `docs/principles/accessibility.md`
 - `docs/foundations/README.md`
 - `docs/patterns/README.md`
 - `docs/validation/README.md`

--- a/docs/principles/accessibility.md
+++ b/docs/principles/accessibility.md
@@ -1,0 +1,79 @@
+# Accessibility Principles (Runtime)
+
+## Purpose
+
+Provide a stable, high-level accessibility principles surface for Runtime
+developers.
+
+This page explains **how Runtime applies accessibility principles**. It does not
+replace canonical principle definitions owned by the Vault.
+
+## Runtime vs canonical scope
+
+- **Canonical principle definitions:** Vault foundation knowledge.
+- **Runtime principle application:** this repository's patterns, elements,
+  authored examples, and validation paths.
+
+Use this page for implementation orientation, then follow linked Runtime docs
+for concrete behavior and checks.
+
+## Runtime accessibility principles
+
+### 1. Native semantics first
+
+Prefer native HTML semantics before ARIA layering. Components and patterns should
+start from semantic elements and only add ARIA where native semantics are
+insufficient.
+
+Implementation entry points:
+
+- `docs/patterns/forms.md`
+- `docs/patterns/input.md`
+- `src/elements/`
+
+### 2. Keyboard and focus are required behavior
+
+Interactive surfaces must support keyboard navigation and visible focus states as
+first-class behavior, not optional enhancements.
+
+Implementation entry points:
+
+- `docs/patterns/navigation.md`
+- `docs/patterns/modal.md` (placeholder tracker)
+- `docs/accessibility-audit-interactive-components.md`
+
+### 3. State and feedback must be perceivable
+
+Status, validation errors, and interaction outcomes must be exposed through
+semantic structure and perceivable text/state, not color alone.
+
+Implementation entry points:
+
+- `docs/patterns/feedback.md`
+- `docs/patterns/forms.md`
+
+### 4. Principle and practice are separate
+
+- **Principles** explain expected accessibility outcomes.
+- **Practice/workflows** explain how audits, checks, and remediation are run.
+
+Workflow and validation entry points:
+
+- `docs/accessibility-audit-interactive-components.md`
+- `docs/validation/README.md`
+- `docs/validation/ci.md`
+
+## Validation path
+
+Use Runtime validation docs to verify accessibility-related implementation work:
+
+1. `docs/validation/README.md`
+2. `docs/validation/ci.md`
+3. repository checks via `npm run ci:check`
+
+## Related docs
+
+- `docs/principles/usability-heuristics.md`
+- `docs/patterns/README.md`
+- `docs/accessibility-audit-interactive-components.md`
+- `docs/validation/README.md`

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -1,0 +1,35 @@
+# Public API Surface (v1)
+
+## Purpose
+
+Provide the canonical Runtime-facing public API summary for v1 and link to the
+full migration guidance.
+
+## Canonical v1 usage
+
+- CSS classes: `.uif-*`
+- Component token slots: `--uif-component-*`
+- Nunjucks usage examples: `uif.*` alias
+- Custom Element tags: `<uif-*>`
+
+## Compatibility context
+
+Legacy names are migration/compatibility context only and are not canonical
+usage for new authored examples:
+
+- bare classes such as `.button` and `.input`
+- legacy tags such as `<ui-*>`
+- legacy token prefixes such as `--component-*`
+
+## Stable package/module surfaces
+
+Some package/module surfaces intentionally remain stable in v1, including
+`ui-foundations/elements/ui-*` subpaths and `ui-*.js` module filenames.
+This is a package compatibility boundary, not a public authored-tag namespace.
+
+## Canonical sources
+
+- `docs/adr/adr-public-api-documentation-contract.md`
+- `docs/adr/adr-uif-public-api-namespace.md`
+- `docs/migrations/public-api-namespace-v1.md`
+- `MIGRATION.md`

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -1,0 +1,41 @@
+# Runtime Terminology Baseline
+
+## Purpose
+
+This glossary defines the Runtime documentation terms used for consistency.
+
+Canonical governance/principle definitions remain in Vault-linked sources.
+Runtime uses this glossary to keep implementation-facing wording stable.
+
+## Baseline policy (WS7 decision)
+
+1. Use **canonical** for the approved primary form developers should author.
+2. Use **compatibility** for supported legacy forms retained for migration.
+3. Use **deprecated** for legacy forms scheduled for removal.
+4. Use **placeholder** for non-canonical tracker pages that do not define final
+   behavior.
+5. Use **summary-level guidance** for pages that point to existing rules but do
+   not act as standalone specifications.
+
+## Glossary
+
+| Term | Meaning in Runtime docs | Example |
+|---|---|---|
+| Canonical | Primary approved Runtime-authored form | `.uif-*`, `<uif-*>`, `uif.*` |
+| Compatibility | Legacy form still supported for migration boundaries | `.button` CSS-only compatibility selector |
+| Deprecated | Legacy form allowed short-term and expected to be removed | Bare class warnings in naming checks |
+| Placeholder | Reserved page/location; non-canonical behavior guidance | `docs/patterns/modal.md` status |
+| Pattern guidance | Reusable composition guidance, may summarize other sources | `docs/patterns/forms.md` |
+| Component surface | Runtime behavior surface with interactive/encapsulated usage | `src/elements/ui-*.js` |
+| Runtime canonical source | Primary Runtime page for a local implementation topic | `docs/public-api.md` |
+| Vault canonical source | Durable cross-repository canonical source | `vault.documentation` links |
+| Published version | Version declared by consumed Vault pack metadata | Governance pack `0.6.0` |
+| Consumed snapshot/version | Runtime-adopted governance snapshot recorded locally | `source.yml` `0.7.0` |
+| Planned/forward version | Not yet published/consumed baseline; future target reference | `0.8.0` in derived contract context |
+
+## Related docs
+
+- `docs/canonical-reference-matrix.md`
+- `docs/public-api.md`
+- `docs/patterns/README.md`
+- `docs/governance-baseline.md`

--- a/docs/token-pipeline.md
+++ b/docs/token-pipeline.md
@@ -2,6 +2,13 @@
 
 ## Overview
 
+Use this page for pipeline mechanics and generated-output detail.
+
+If you need the shorter developer overview first, start with:
+
+- `docs/architecture.md`
+- `docs/foundations/README.md`
+
 Figma is the single source of truth. Tokens flow through a generation pipeline
 that transforms Figma Variable exports into DTCG-compliant dist files consumed
 by CSS, TypeScript, and JSON tooling.

--- a/docs/uif-governance.md
+++ b/docs/uif-governance.md
@@ -172,3 +172,10 @@ runtime safety or documented local ownership.
 - workspace Markdown files include valid YAML frontmatter
 
 The script performs no synchronization, no remote access, and no file changes.
+
+
+## Related docs
+
+- `docs/governance-baseline.md`
+- `docs/canonical-reference-matrix.md`
+- `docs/terminology.md`

--- a/docs/uif-governance.md
+++ b/docs/uif-governance.md
@@ -69,10 +69,14 @@ Pack versions are tracked in `.uif/registry/source.yml`. A pack may use
 `experimental`. Reviewed consumption should replace experimental branch refs
 with a tag or SHA before the pack is treated as stable governance.
 
-The first reproducible Governance Pack source is Vault commit
-`fbeb803e51f11d5c372ece8ced4405f37f999fb3`, recorded as a `snapshot` SHA in
-`.uif/registry/source.yml`. Branch refs remain valid only for explicitly
-experimental pack exploration.
+The authoritative consumed governance baseline is **0.7.0** (SHA
+`10f78061cd65e6ad6d7304376ead27d44efc01b3`). This is recorded in
+`.uif/registry/source.yml` and is the single source of truth for consumed
+version references across Runtime documentation.
+
+For the full version conflict resolution and lifecycle policy, see
+[ADR: Governance Baseline Version Policy](adr/adr-governance-baseline-version-policy.md)
+and the [Governance Baseline Reference Matrix](governance-baseline.md).
 
 ## Workspace Concept
 

--- a/docs/uif-governance.md
+++ b/docs/uif-governance.md
@@ -69,10 +69,17 @@ Pack versions are tracked in `.uif/registry/source.yml`. A pack may use
 `experimental`. Reviewed consumption should replace experimental branch refs
 with a tag or SHA before the pack is treated as stable governance.
 
-The authoritative consumed governance baseline is **0.7.0** (SHA
-`10f78061cd65e6ad6d7304376ead27d44efc01b3`). This is recorded in
-`.uif/registry/source.yml` and is the single source of truth for consumed
-version references across Runtime documentation.
+Current version interpretation:
+
+- **Published pack version:** `0.6.0` (from consumed Vault pack artifacts under
+  `.uif/packs/governance/`)
+- **Runtime-consumed snapshot/version:** `0.7.0` at SHA
+  `10f78061cd65e6ad6d7304376ead27d44efc01b3` (from `.uif/registry/source.yml`)
+- **Planned/forward reference:** `0.8.0` (decision-aligned target, not yet
+  published or consumed baseline)
+
+Runtime treats `.uif/registry/source.yml` as authoritative for adoption status,
+while Vault pack artifacts remain authoritative for published pack versions.
 
 For the full version conflict resolution and lifecycle policy, see
 [ADR: Governance Baseline Version Policy](adr/adr-governance-baseline-version-policy.md)

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -5,6 +5,11 @@
 This section explains what the repo currently validates, what is planned, and
 which docs are canonical for CI-facing quality checks.
 
+## Accessibility principle entry
+
+Use `docs/principles/accessibility.md` for high-level accessibility principle
+expectations. Use validation docs for enforcement and workflow checks.
+
 ## Canonical rules
 
 - `ci.md`
@@ -19,6 +24,8 @@ which docs are canonical for CI-facing quality checks.
 
 ## Related docs
 
+- `docs/principles/accessibility.md`
+- `docs/accessibility-audit-interactive-components.md`
 - `docs/playbook.md`
 - `docs/agentic/rule-pipeline.md`
 - `IMPLEMENTATION.md`

--- a/docs/validation/ci.md
+++ b/docs/validation/ci.md
@@ -2,7 +2,13 @@
 
 ## Purpose
 
-Explain what the current CI path actually runs and where the configuration lives.
+Explain what the current CI path actually runs and where the configuration
+lives.
+
+## Accessibility principle entry
+
+- `docs/principles/accessibility.md` (principles)
+- `docs/accessibility-audit-interactive-components.md` (audit workflow)
 
 ## Canonical rules
 
@@ -23,4 +29,5 @@ Current pipeline:
 
 ## Related docs
 
+- `docs/validation/README.md`
 - `docs/agentic/rule-pipeline-audit.md`

--- a/scripts/vault-naming-contract.generated.js
+++ b/scripts/vault-naming-contract.generated.js
@@ -108,7 +108,7 @@ const VAULT_NAMING_CONTRACT = Object.freeze({
   },
   "source": {
     "packId": "governance-pack",
-    "packVersion": "0.8.0",
+    "packVersion": "0.7.0",
     "sourceArtifacts": [
       ".uif/packs/governance/contracts/naming-contract.json",
       ".uif/packs/governance/decisions/uif-public-api-namespace.md",

--- a/scripts/vault-naming-contract.generated.js
+++ b/scripts/vault-naming-contract.generated.js
@@ -108,7 +108,7 @@ const VAULT_NAMING_CONTRACT = Object.freeze({
   },
   "source": {
     "packId": "governance-pack",
-    "packVersion": "0.7.0",
+    "packVersion": "0.8.0",
     "sourceArtifacts": [
       ".uif/packs/governance/contracts/naming-contract.json",
       ".uif/packs/governance/decisions/uif-public-api-namespace.md",


### PR DESCRIPTION
## Summary

This PR delivers WS1 and WS2 from the approved documentation roadmap.

---

## WS1 — Public API Documentation (Epics #200, Issues #201–#204)

**Decision record:** [ADR: Public API Documentation Contract](docs/adr/adr-public-api-documentation-contract.md)
- Defines canonical vs compatibility wording policy for v1
- Establishes `uif-*` / `--uif-*` as primary; legacy aliases as deprecated compatibility

**Foundational ADR:** [ADR: Runtime and Vault Documentation Architecture](docs/adr/adr-runtime-and-vault-documentation-architecture.md)
- High-level architectural foundation for all WS1–WS9

**Implementation:**
- `docs/public-api.md` — canonical v1 public API surface entry page
- README examples updated from `.button`/`.input` → `.uif-button`/`.uif-input`
- `docs/README.md` updated with public-api.md entry

---

## WS2 — Governance Baseline & Canonical Source Control (Epic #205, Issues #206–#209)

**Version conflict resolved:** Four conflicting governance pack version numbers across Runtime files have been resolved.

| File | Before | After |
|------|--------|-------|
| `naming-contract.json` | `0.8.0` (forward ref) | `0.7.0` (consumed baseline) |
| `adr-uif-public-api-namespace.md` | `0.8.0` | `0.7.0` + explanatory note |
| `vault-naming-contract.generated.js` | stale | regenerated |

**New artifacts:**
- `docs/adr/adr-governance-baseline-version-policy.md` — authoritative baseline decision + lifecycle policy
- `docs/governance-baseline.md` — consumed artifact registry and version matrix

**Authoritative consumed version: `0.7.0` (SHA `10f78061`)**

---

## Validation

- ✅ `npm run lint`
- ✅ `npm run test:unit`
- ✅ `npm run ci:check` — 172/172 tests passing

## ADR Foundation

All changes respect `docs/adr/adr-runtime-and-vault-documentation-architecture.md`.

## Related Issues

Closes #200, #201, #202, #203, #204, #205, #206, #207, #208, #209