### PR TITLE
docs(ws8): establish baseline ownership and review checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/docs-baseline-change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs-baseline-change.md
@@ -1,0 +1,14 @@
+## Baseline documentation change
+
+### Scope
+
+Describe the baseline documentation change and why it is required.
+
+### Review checklist
+
+- [ ] Terminology is consistent with `docs/terminology.md`.
+- [ ] `docs/canonical-reference-matrix.md` is updated when new terms, rules, or canonical sources are introduced.
+- [ ] `@ui-foundations-maintainers` has been notified for review.
+- [ ] Ownership remains team-based; no person-specific or parallel ownership rule is introduced.
+- [ ] Changes preserve the Runtime/Vault authority boundary.
+- [ ] Relevant documentation and CI checks pass.

--- a/.uif/registry/sync-policy.yml
+++ b/.uif/registry/sync-policy.yml
@@ -71,9 +71,9 @@ conflicts:
     - decide-adopt-override-or-promote
 review:
   owners:
-    governance: TODO-governance-owner
-    runtime: TODO-runtime-owner
-    agent: TODO-agent-owner
+    governance: "@ui-foundations-maintainers"
+    runtime: "@ui-foundations-maintainers"
+    agent: "@ui-foundations-maintainers"
   requiredFor:
     - new-imported-pack-version
     - governance-rule-change

--- a/docs/canonical-reference-matrix.md
+++ b/docs/canonical-reference-matrix.md
@@ -1,3 +1,7 @@
+---
+owner: "@ui-foundations-maintainers"
+---
+
 # Canonical Topic-Source Matrix
 
 ## Purpose

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -1,3 +1,7 @@
+---
+owner: "@ui-foundations-maintainers"
+---
+
 # Runtime Terminology Baseline
 
 ## Purpose


### PR DESCRIPTION
## Summary

- assign team-based ownership to the WS7 baseline documents
- align sync-policy ownership with `@ui-foundations-maintainers`
- remove unresolved owner placeholders
- add a pull-request checklist for baseline documentation changes

## Issues

Closes #228
Closes #229

## Boundaries

- no review cadence changes; covered by #231
- no CI drift detection; covered by #230
- no baseline content changes
- no person-based ownership

## Validation

- branch is four commits ahead of `main` and not behind
- both baseline documents declare the same owner
- no `TODO-*-owner` placeholders remain in `sync-policy.yml`
- PR template includes terminology, reference-matrix, owner-notification, authority-boundary, and CI checks
