### PR TITLE
docs(ws8): define baseline review cadence

### DIFF
--- a/.uif/registry/sync-policy.yml
+++ b/.uif/registry/sync-policy.yml
@@ -70,10 +70,18 @@ conflicts:
     - identify-local-owner
     - decide-adopt-override-or-promote
 review:
+  cadence: quarterly
   owners:
     governance: "@ui-foundations-maintainers"
     runtime: "@ui-foundations-maintainers"
     agent: "@ui-foundations-maintainers"
+  baselineDocuments:
+    - path: docs/terminology.md
+      owner: "@ui-foundations-maintainers"
+      reviewCadence: quarterly
+    - path: docs/canonical-reference-matrix.md
+      owner: "@ui-foundations-maintainers"
+      reviewCadence: quarterly
   requiredFor:
     - new-imported-pack-version
     - governance-rule-change


### PR DESCRIPTION
## Summary

- define a quarterly baseline-document review cadence
- add complete sync-policy entries for `docs/terminology.md` and `docs/canonical-reference-matrix.md`
- inherit the team-based ownership established by #228

## Issue

Closes #231

## Boundaries

- no ownership decision or person-based ownership
- no baseline document content changes
- no CI drift detection; covered by #230

## Validation

- both WS7 baseline documents are explicitly represented in `sync-policy.yml`
- review cadence is defined at policy and document-entry level
- ownership remains `@ui-foundations-maintainers`
