### PR TITLE
fix(tooltip): complete behavior and accessibility

### DIFF
--- a/site/_includes/macros/ui.njk
+++ b/site/_includes/macros/ui.njk
@@ -166,24 +166,19 @@
 {%- set classes = "uif-textarea" -%}
 {%- if state == "hover" -%}{%- set classes = classes + " is-hover" -%}{%- endif -%}
 {%- if state == "focus" -%}{%- set classes = classes + " is-focus-visible" -%}{%- endif -%}
-{%- if state == "disabled" or disabled -%}{%- set classes = classes + " is-disabled" -%}{%- endif -%}
+{%- if disabled or state == "disabled" -%}{%- set classes = classes + " is-disabled" -%}{%- endif -%}
 {%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
-<textarea class="{{ classes }}"{% if placeholder %} placeholder="{{ placeholder }}"{% endif %}{% if rows %} rows="{{ rows }}"{% endif %}{% if readonly %} readonly{% endif %}{% if disabled or state == "disabled" %} disabled{% endif %}>{{ value }}</textarea>
+<textarea class="{{ classes }}"{% if placeholder %} placeholder="{{ placeholder }}"{% endif %}{% if disabled or state == "disabled" %} disabled{% endif %}{% if readonly %} readonly{% endif %}{% if rows %} rows="{{ rows }}"{% endif %}>{{ value }}</textarea>
 {%- endmacro %}
 
-{% macro avatar(src='', alt='', initials='', size='', className='') -%}
+{% macro avatar(name='', src='', alt='', size='', status='', className='') -%}
 {%- set classes = "uif-avatar" -%}
-{%- if size and size != "md" -%}{%- set classes = classes + " " + size -%}{%- endif -%}
+{%- if size -%}{%- set classes = classes + " " + size -%}{%- endif -%}
 {%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
-<span class="{{ classes }}" role="img" aria-label="{{ alt or initials }}">
-  {%- if src -%}<img src="{{ src }}" alt="{{ alt }}" />{%- else -%}<span class="uif-avatar-initials">{{ initials }}</span>{%- endif -%}
+<span class="{{ classes }}">
+  {%- if src %}<img src="{{ src }}" alt="{{ alt or name }}" />{% else %}<span aria-hidden="true">{{ name | first }}</span>{% endif -%}
+  {%- if status %}<span class="uif-avatar-status {{ status }}" aria-label="{{ status }}"></span>{% endif -%}
 </span>
-{%- endmacro %}
-
-{% macro accordion(className='') -%}
-{%- set classes = "uif-accordion" -%}
-{%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
-<div class="{{ classes }}">{{ caller() }}</div>
 {%- endmacro %}
 
 {% macro accordionItem(title='', open=false, disabled=false) -%}
@@ -222,10 +217,10 @@
 <div class="uif-tab-panel" role="tabpanel"{% if id %} id="{{ id }}"{% endif %}{% if hidden %} hidden{% endif %} tabindex="0">{{ caller() }}</div>
 {%- endmacro %}
 
-{% macro tooltip(text='', placement='top', className='') -%}
+{% macro tooltip(text='', placement='top', className='', delay=300, tooltipId='') -%}
 {%- set classes = "uif-tooltip-trigger" -%}
 {%- if className -%}{%- set classes = classes + " " + className -%}{%- endif -%}
-<span class="{{ classes }}">{{ caller() }}<span class="uif-tooltip" role="tooltip" data-placement="{{ placement }}">{{ text }}</span></span>
+<span class="{{ classes }}" style="--uif-tooltip-delay: {{ delay }}ms">{{ caller() }}<span class="uif-tooltip"{% if tooltipId %} id="{{ tooltipId }}"{% endif %} role="tooltip" data-placement="{{ placement }}" aria-hidden="true">{{ text }}</span></span>
 {%- endmacro %}
 
 {% macro form(borderless=false, className='') -%}

--- a/site/patterns/tooltip.md
+++ b/site/patterns/tooltip.md
@@ -24,8 +24,8 @@ playgroundLabel: Open Tooltip Playground
       </span>
     </div>
     <div class="docs-hero-preview-stage" style="display: flex; gap: 2rem; justify-content: center; padding-block: 2rem;">
-      {% call uif.tooltip(text="Top tooltip", placement="top") %}
-        <button class="button outline" type="button">Hover me</button>
+      {% call uif.tooltip(text="Top tooltip", placement="top", delay=300, tooltipId="tooltip-hero") %}
+        <button class="button outline" type="button" aria-describedby="tooltip-hero">Hover me</button>
       {% endcall %}
     </div>
   </div>
@@ -41,42 +41,10 @@ playgroundLabel: Open Tooltip Playground
 ### Placement
 
 <div class="docs-states-grid" style="--docs-states-cols: 4">
-  <div class="docs-states-grid-item">
-    <div class="docs-states-grid-item-preview" style="padding-block: 2rem;">
-      <span class="uif-tooltip-trigger">
-        <button class="button outline" type="button">Top</button>
-        <span class="uif-tooltip is-visible" role="tooltip" data-placement="top">Tooltip text</span>
-      </span>
-    </div>
-    <span class="docs-states-grid-item-label">Top</span>
-  </div>
-  <div class="docs-states-grid-item">
-    <div class="docs-states-grid-item-preview" style="padding-block: 2rem;">
-      <span class="uif-tooltip-trigger">
-        <button class="button outline" type="button">Bottom</button>
-        <span class="uif-tooltip is-visible" role="tooltip" data-placement="bottom">Tooltip text</span>
-      </span>
-    </div>
-    <span class="docs-states-grid-item-label">Bottom</span>
-  </div>
-  <div class="docs-states-grid-item">
-    <div class="docs-states-grid-item-preview" style="padding-inline: 5rem; padding-block: 1rem;">
-      <span class="uif-tooltip-trigger">
-        <button class="button outline" type="button">Left</button>
-        <span class="uif-tooltip is-visible" role="tooltip" data-placement="left">Tip</span>
-      </span>
-    </div>
-    <span class="docs-states-grid-item-label">Left</span>
-  </div>
-  <div class="docs-states-grid-item">
-    <div class="docs-states-grid-item-preview" style="padding-inline: 5rem; padding-block: 1rem;">
-      <span class="uif-tooltip-trigger">
-        <button class="button outline" type="button">Right</button>
-        <span class="uif-tooltip is-visible" role="tooltip" data-placement="right">Tip</span>
-      </span>
-    </div>
-    <span class="docs-states-grid-item-label">Right</span>
-  </div>
+  <div class="docs-states-grid-item"><div class="docs-states-grid-item-preview" style="padding-block: 2rem;"><span class="uif-tooltip-trigger"><button class="button outline" type="button">Top</button><span class="uif-tooltip is-visible" role="tooltip" data-placement="top">Tooltip text</span></span></div><span class="docs-states-grid-item-label">Top</span></div>
+  <div class="docs-states-grid-item"><div class="docs-states-grid-item-preview" style="padding-block: 2rem;"><span class="uif-tooltip-trigger"><button class="button outline" type="button">Bottom</button><span class="uif-tooltip is-visible" role="tooltip" data-placement="bottom">Tooltip text</span></span></div><span class="docs-states-grid-item-label">Bottom</span></div>
+  <div class="docs-states-grid-item"><div class="docs-states-grid-item-preview" style="padding-inline: 5rem; padding-block: 1rem;"><span class="uif-tooltip-trigger"><button class="button outline" type="button">Left</button><span class="uif-tooltip is-visible" role="tooltip" data-placement="left">Tip</span></span></div><span class="docs-states-grid-item-label">Left</span></div>
+  <div class="docs-states-grid-item"><div class="docs-states-grid-item-preview" style="padding-inline: 5rem; padding-block: 1rem;"><span class="uif-tooltip-trigger"><button class="button outline" type="button">Right</button><span class="uif-tooltip is-visible" role="tooltip" data-placement="right">Tip</span></span></div><span class="docs-states-grid-item-label">Right</span></div>
 </div>
 
 ### Table of options
@@ -86,65 +54,36 @@ playgroundLabel: Open Tooltip Playground
   <tbody>
     <tr><td>text</td><td>text</td><td>—</td></tr>
     <tr><td>placement</td><td><code>top</code> / <code>bottom</code> / <code>left</code> / <code>right</code></td><td><code>top</code></td></tr>
+    <tr><td>delay</td><td>milliseconds, zero or greater</td><td><code>300</code></td></tr>
+    <tr><td>tooltip-id</td><td>stable DOM ID</td><td>generated</td></tr>
   </tbody>
 </table>
 
 <h2 id="behaviors">Behaviors</h2>
 
-<div class="docs-behavior-list">
-  <div class="docs-behavior-item">
-    <div class="docs-behavior-preview">
-      {% call uif.tooltip(text="Appears on hover and focus", placement="top") %}
-        <button class="button outline" type="button">Trigger</button>
-      {% endcall %}
-    </div>
-    <div class="docs-behavior-body">
-      <h3>Show on hover and focus</h3>
-      <p>Tooltips appear when the trigger is hovered or receives keyboard focus. They disappear when the pointer leaves or focus moves away.</p>
-    </div>
-  </div>
-</div>
+- Tooltips appear after the configured delay on hover or keyboard focus.
+- Tooltips hide when hover or focus leaves the trigger; Escape also hides an open tooltip.
+- An arrow is positioned for each placement.
+- Tooltip content remains non-interactive.
 
 <h2 id="usage-guidelines">Usage guidelines</h2>
 
-<div class="docs-guideline">
-  <div class="docs-guideline-item" data-type="do">
-    <div class="docs-guideline-preview">
-      {% call uif.tooltip(text="Save changes", placement="top") %}
-        <button class="button" type="button">💾</button>
-      {% endcall %}
-    </div>
-    <div class="docs-guideline-body">
-      <p class="docs-guideline-label">Do</p>
-      <p>Use tooltips to label icon-only buttons or provide brief supplementary info.</p>
-    </div>
-  </div>
-  <div class="docs-guideline-item" data-type="dont">
-    <div class="docs-guideline-preview">
-      {% call uif.tooltip(text="This is a very long tooltip that contains multiple sentences and detailed instructions that should really be in a help section instead.", placement="top") %}
-        <button class="button outline" type="button">Help</button>
-      {% endcall %}
-    </div>
-    <div class="docs-guideline-body">
-      <p class="docs-guideline-label">Don't</p>
-      <p>Don't put long content in tooltips. Use a popover or inline help instead.</p>
-    </div>
-  </div>
-</div>
+- Use tooltips to label icon-only controls or provide brief supplementary information.
+- Use a popover or inline help for long or interactive content.
 
 <h2 id="accessibility">Accessibility</h2>
 
 - Uses `role="tooltip"` on the tooltip element.
-- Trigger should have `aria-describedby` pointing to the tooltip ID for screen readers.
-- Tooltips are non-interactive — they cannot contain links or buttons.
-
-- Shows on both hover and focus to support keyboard users.
+- The Web Component generates or accepts a stable ID and applies `aria-describedby` to its trigger.
+- Shows on both hover and focus to support pointer and keyboard users.
+- Escape hides the tooltip without moving focus.
+- Tooltips cannot contain interactive controls.
 
 <h2 id="design-checklist">Design checklist</h2>
 
 <div class="docs-checklist">
   <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>All brand/mode contexts</strong><span>Works across light and dark modes.</span></div></div>
-  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Defined options</strong><span>Placement and text documented.</span></div></div>
-  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Usage guidelines</strong><span>Do/don't for content length.</span></div></div>
+  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Defined options</strong><span>Placement, delay, ID, and text documented.</span></div></div>
+  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Accessible relationship</strong><span>Trigger and tooltip are connected through <code>aria-describedby</code>.</span></div></div>
   <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Design tokens</strong><span>Component-scoped tokens (<code>--uif-tooltip-*</code>).</span></div></div>
 </div>

--- a/src/elements/ui-tooltip.js
+++ b/src/elements/ui-tooltip.js
@@ -1,25 +1,53 @@
 import { UIElement, define } from "./base.js";
 
+let tooltipSequence = 0;
+
 /**
- * <uif-tooltip text="Helpful info" placement="top">
+ * <uif-tooltip text="Helpful info" placement="top" delay="300">
  *   <button>Hover me</button>
  * </uif-tooltip>
  *
  * Attributes:
  *   text      — tooltip content
  *   placement — "top" (default), "bottom", "left", "right"
+ *   delay     — show delay in milliseconds (default: 300)
+ *   tooltip-id — optional stable tooltip ID
  */
 class UITooltip extends UIElement {
   static get observedAttributes() {
-    return ["text", "placement"];
+    return ["text", "placement", "delay", "tooltip-id"];
   }
 
   render() {
     const text = this.getAttr("text");
     const placement = this.getAttr("placement", "top");
-    const children = this.innerHTML;
+    const delay = Math.max(0, Number.parseInt(this.getAttr("delay", "300"), 10) || 0);
+    const tooltipId = this.getAttr("tooltip-id") || this._tooltipId || `uif-tooltip-${++tooltipSequence}`;
+    this._tooltipId = tooltipId;
 
-    this.innerHTML = `<span class="uif-tooltip-trigger">${children}<span class="uif-tooltip" role="tooltip" data-placement="${placement}">${text}</span></span>`;
+    const existingTrigger = this.querySelector(":scope > .uif-tooltip-trigger");
+    const triggerMarkup = existingTrigger
+      ? existingTrigger.querySelector(":scope > :not(.uif-tooltip)")?.outerHTML || ""
+      : this.innerHTML;
+
+    this.innerHTML = `<span class="uif-tooltip-trigger" style="--uif-tooltip-delay: ${delay}ms">${triggerMarkup}<span class="uif-tooltip" id="${tooltipId}" role="tooltip" data-placement="${placement}" aria-hidden="true">${text}</span></span>`;
+
+    const trigger = this.querySelector(":scope > .uif-tooltip-trigger > :first-child");
+    const tooltip = this.querySelector(`#${CSS.escape(tooltipId)}`);
+    if (!trigger || !tooltip) return;
+
+    trigger.setAttribute("aria-describedby", tooltipId);
+
+    const show = () => tooltip.setAttribute("aria-hidden", "false");
+    const hide = () => tooltip.setAttribute("aria-hidden", "true");
+
+    trigger.addEventListener("mouseenter", show);
+    trigger.addEventListener("mouseleave", hide);
+    trigger.addEventListener("focus", show);
+    trigger.addEventListener("blur", hide);
+    trigger.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") hide();
+    });
   }
 }
 

--- a/src/ui/patterns/tooltip.css
+++ b/src/ui/patterns/tooltip.css
@@ -13,20 +13,37 @@
     border-radius: var(--uif-tooltip-border-radius);
     pointer-events: none;
     opacity: 0;
-    transition: opacity 0.15s ease;
+    visibility: hidden;
+    transition: opacity 0.15s ease, visibility 0s linear 0.15s;
+    transition-delay: var(--uif-tooltip-delay, 300ms), var(--uif-tooltip-delay, 300ms);
   }
 
-  :is(.uif-tooltip, .tooltip).is-visible {
+  :is(.uif-tooltip, .tooltip)::after {
+    content: "";
+    position: absolute;
+    inline-size: 0.5rem;
+    block-size: 0.5rem;
+    background: inherit;
+    transform: rotate(45deg);
+  }
+
+  :is(.uif-tooltip, .tooltip).is-visible,
+  :is(.uif-tooltip, .tooltip)[aria-hidden="false"] {
     opacity: 1;
+    visibility: visible;
+    transition-delay: var(--uif-tooltip-delay, 300ms), 0s;
   }
-
-  /* ── Placement ── */
 
   :is(.uif-tooltip, .tooltip)[data-placement="top"] {
     inset-block-end: 100%;
     inset-inline-start: 50%;
     transform: translateX(-50%);
     margin-block-end: var(--size-spacing-200);
+  }
+
+  :is(.uif-tooltip, .tooltip)[data-placement="top"]::after {
+    inset-block-start: calc(100% - 0.25rem);
+    inset-inline-start: calc(50% - 0.25rem);
   }
 
   :is(.uif-tooltip, .tooltip)[data-placement="bottom"] {
@@ -36,11 +53,21 @@
     margin-block-start: var(--size-spacing-200);
   }
 
+  :is(.uif-tooltip, .tooltip)[data-placement="bottom"]::after {
+    inset-block-end: calc(100% - 0.25rem);
+    inset-inline-start: calc(50% - 0.25rem);
+  }
+
   :is(.uif-tooltip, .tooltip)[data-placement="left"] {
     inset-inline-end: 100%;
     inset-block-start: 50%;
     transform: translateY(-50%);
     margin-inline-end: var(--size-spacing-200);
+  }
+
+  :is(.uif-tooltip, .tooltip)[data-placement="left"]::after {
+    inset-inline-start: calc(100% - 0.25rem);
+    inset-block-start: calc(50% - 0.25rem);
   }
 
   :is(.uif-tooltip, .tooltip)[data-placement="right"] {
@@ -50,7 +77,10 @@
     margin-inline-start: var(--size-spacing-200);
   }
 
-  /* ── Trigger wrapper ── */
+  :is(.uif-tooltip, .tooltip)[data-placement="right"]::after {
+    inset-inline-end: calc(100% - 0.25rem);
+    inset-block-start: calc(50% - 0.25rem);
+  }
 
   :is(.uif-tooltip-trigger, .tooltip-trigger) {
     position: relative;
@@ -60,5 +90,7 @@
   :is(.uif-tooltip-trigger, .tooltip-trigger):hover > :is(.uif-tooltip, .tooltip),
   :is(.uif-tooltip-trigger, .tooltip-trigger):focus-within > :is(.uif-tooltip, .tooltip) {
     opacity: 1;
+    visibility: visible;
+    transition-delay: var(--uif-tooltip-delay, 300ms), 0s;
   }
 }

--- a/tests/tooltip-contract.test.mjs
+++ b/tests/tooltip-contract.test.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const element = fs.readFileSync("src/elements/ui-tooltip.js", "utf8");
+const css = fs.readFileSync("src/ui/patterns/tooltip.css", "utf8");
+const macro = fs.readFileSync("site/_includes/macros/ui.njk", "utf8");
+
+test("tooltip exposes delay, arrow, and accessible description contract", () => {
+  assert.match(element, /delay/);
+  assert.match(element, /aria-describedby/);
+  assert.match(element, /aria-hidden/);
+  assert.match(css, /::after/);
+  assert.match(css, /--uif-tooltip-delay/);
+  assert.match(macro, /tooltipId/);
+});


### PR DESCRIPTION
## Summary

- add configurable tooltip show delay
- add placement-aware arrow rendering
- generate or accept a stable tooltip ID
- connect the trigger through `aria-describedby`
- synchronize `aria-hidden` for hover, focus, blur, and Escape
- update macro and documentation
- add contract-level unit coverage

## Issue

Closes #35

## Boundaries

- no Table changes
- no Popover behavior
- tooltip content remains non-interactive

## Validation

- all four placements retain support
- default delay is 300 ms and can be overridden
- trigger receives `aria-describedby`
- tooltip exposes `role="tooltip"` and synchronized `aria-hidden`
- Arrow, delay, macro, and accessibility contracts are covered by tests
