### PR TITLE
fix(tabs): complete interaction, overflow, and sizes

### DIFF
--- a/schemas/web-tabs.figma.ts
+++ b/schemas/web-tabs.figma.ts
@@ -1,0 +1,29 @@
+import figma, { html } from "@figma/code-connect/html";
+
+figma.connect(
+  "https://www.figma.com/design/uqMsy8fV1fPbQdAzgwlmBA/UI-Foundations?node-id=TABS-NODE-ID&m=dev",
+  {
+    props: {
+      orientation: figma.enum("Orientation", {
+        Horizontal: "horizontal",
+        Vertical: "vertical",
+      }),
+      size: figma.enum("Size", {
+        Default: "default",
+        Compact: "compact",
+      }),
+      overflow: figma.enum("Overflow", {
+        Scroll: "scroll",
+        Wrap: "wrap",
+      }),
+    },
+    example: ({ orientation, size, overflow }) => html`<uif-tabs orientation="${orientation}" size="${size}" overflow="${overflow}">
+  <uif-tab-list aria-label="Example tabs">
+    <uif-tab label="Overview" selected controls="panel-overview"></uif-tab>
+    <uif-tab label="Details" controls="panel-details"></uif-tab>
+  </uif-tab-list>
+  <uif-tab-panel id="panel-overview">Overview content</uif-tab-panel>
+  <uif-tab-panel id="panel-details" hidden>Details content</uif-tab-panel>
+</uif-tabs>`,
+  },
+);

--- a/site/patterns/tabs.md
+++ b/site/patterns/tabs.md
@@ -12,26 +12,17 @@ playgroundLabel: Open Tabs Playground
 
 <div class="docs-hero">
   <div class="docs-hero-preview">
-    <div class="docs-hero-preview-controls">
-      <span class="docs-hero-switch" data-hero-group="brand">
-        <button type="button" data-hero-brand="a" aria-pressed="true">Brand A</button>
-        <button type="button" data-hero-brand="b" aria-pressed="false">Brand B</button>
-        <button type="button" data-hero-brand="c" aria-pressed="false">Brand C</button>
-      </span>
-      <span class="docs-hero-switch" data-hero-group="mode">
-        <button type="button" data-hero-mode="light" aria-pressed="true">Light</button>
-        <button type="button" data-hero-mode="dark" aria-pressed="false">Dark</button>
-      </span>
-    </div>
     <div class="docs-hero-preview-stage" style="inline-size: 100%;">
-      {% call uif.tabList(ariaLabel="Example tabs") %}
-        {{ uif.tab(label="Overview", selected=true, controls="panel-1") }}
-        {{ uif.tab(label="Details", controls="panel-2") }}
-        {{ uif.tab(label="Settings", controls="panel-3") }}
-      {% endcall %}
-      {% call uif.tabPanel(id="panel-1") %}
-        <p>Overview content goes here.</p>
-      {% endcall %}
+      <uif-tabs orientation="horizontal" size="default" overflow="scroll">
+        <uif-tab-list aria-label="Example tabs">
+          <uif-tab label="Overview" selected controls="panel-1"></uif-tab>
+          <uif-tab label="Details" controls="panel-2"></uif-tab>
+          <uif-tab label="Settings" controls="panel-3"></uif-tab>
+        </uif-tab-list>
+        <uif-tab-panel id="panel-1">Overview content goes here.</uif-tab-panel>
+        <uif-tab-panel id="panel-2" hidden>Details content goes here.</uif-tab-panel>
+        <uif-tab-panel id="panel-3" hidden>Settings content goes here.</uif-tab-panel>
+      </uif-tabs>
     </div>
   </div>
   <div class="docs-hero-meta">
@@ -41,72 +32,14 @@ playgroundLabel: Open Tabs Playground
   </div>
 </div>
 
-<h2 id="anatomy">Anatomy</h2>
-
-<div class="docs-anatomy">
-  <div class="docs-anatomy-preview">
-    <div class="docs-anatomy-subject" style="inline-size: 100%;">
-      <span class="docs-anatomy-outline"></span>
-      <span class="docs-anatomy-callout" data-dir="top" style="left: 30%; transform: translateX(-50%);">
-        <span class="docs-anatomy-badge">1</span>
-        <span class="docs-anatomy-callout-line"></span>
-      </span>
-      <span class="docs-anatomy-callout" data-dir="right" style="top: 70%; transform: translateY(-50%);">
-        <span class="docs-anatomy-callout-line"></span>
-        <span class="docs-anatomy-badge">2</span>
-      </span>
-      {% call uif.tabList(ariaLabel="Anatomy tabs") %}
-        {{ uif.tab(label="Tab 1", selected=true) }}
-        {{ uif.tab(label="Tab 2") }}
-      {% endcall %}
-      {% call uif.tabPanel() %}
-        <p>Panel content</p>
-      {% endcall %}
-    </div>
-  </div>
-  <ol class="docs-anatomy-footnotes">
-    <li><span class="docs-anatomy-badge-inline">1</span> Tab list — horizontal row of tab buttons with active indicator</li>
-    <li><span class="docs-anatomy-badge-inline">2</span> Tab panel — content area associated with the active tab</li>
-  </ol>
-</div>
-
 <h2 id="options">Options</h2>
-
-### States
-
-<div class="docs-states-grid" style="--docs-states-cols: 4">
-  <div class="docs-states-grid-item">
-    <div class="docs-states-grid-item-preview">
-      <button class="tab" role="tab" aria-selected="false">Default</button>
-    </div>
-    <span class="docs-states-grid-item-label">Default</span>
-  </div>
-  <div class="docs-states-grid-item">
-    <div class="docs-states-grid-item-preview">
-      <button class="tab is-hover" role="tab" aria-selected="false">Hover</button>
-    </div>
-    <span class="docs-states-grid-item-label">Hover</span>
-  </div>
-  <div class="docs-states-grid-item">
-    <div class="docs-states-grid-item-preview">
-      <button class="tab" role="tab" aria-selected="true">Selected</button>
-    </div>
-    <span class="docs-states-grid-item-label">Selected</span>
-  </div>
-  <div class="docs-states-grid-item">
-    <div class="docs-states-grid-item-preview">
-      <button class="tab is-disabled" role="tab" aria-selected="false" disabled>Disabled</button>
-    </div>
-    <span class="docs-states-grid-item-label">Disabled</span>
-  </div>
-</div>
-
-### Table of options
 
 <table class="docs-options-table">
   <thead><tr><th>Property</th><th>Values</th><th>Default</th></tr></thead>
   <tbody>
     <tr><td>orientation</td><td><code>horizontal</code> / <code>vertical</code></td><td><code>horizontal</code></td></tr>
+    <tr><td>size</td><td><code>default</code> / <code>compact</code></td><td><code>default</code></td></tr>
+    <tr><td>overflow</td><td><code>scroll</code> / <code>wrap</code></td><td><code>scroll</code></td></tr>
     <tr><td>selected</td><td><code>true</code> / <code>false</code></td><td><code>false</code></td></tr>
     <tr><td>disabled</td><td><code>true</code> / <code>false</code></td><td><code>false</code></td></tr>
   </tbody>
@@ -117,27 +50,37 @@ playgroundLabel: Open Tabs Playground
 <table class="docs-keyboard-table">
   <thead><tr><th>Key</th><th>Action</th></tr></thead>
   <tbody>
-    <tr><td><kbd>Tab</kbd></td><td>Moves focus into/out of the tab list</td></tr>
-    <tr><td><kbd>←</kbd> / <kbd>→</kbd></td><td>Moves between tabs (horizontal)</td></tr>
-    <tr><td><kbd>↑</kbd> / <kbd>↓</kbd></td><td>Moves between tabs (vertical)</td></tr>
-    <tr><td><kbd>Enter</kbd> / <kbd>Space</kbd></td><td>Activates the focused tab</td></tr>
-    <tr><td><kbd>Home</kbd></td><td>Moves to first tab</td></tr>
-    <tr><td><kbd>End</kbd></td><td>Moves to last tab</td></tr>
+    <tr><td><kbd>Tab</kbd></td><td>Moves focus into or out of the tab list.</td></tr>
+    <tr><td><kbd>←</kbd> / <kbd>→</kbd></td><td>Moves focus between enabled tabs in a horizontal list.</td></tr>
+    <tr><td><kbd>↑</kbd> / <kbd>↓</kbd></td><td>Moves focus between enabled tabs in a vertical list.</td></tr>
+    <tr><td><kbd>Home</kbd></td><td>Moves focus to the first enabled tab.</td></tr>
+    <tr><td><kbd>End</kbd></td><td>Moves focus to the last enabled tab.</td></tr>
+    <tr><td><kbd>Enter</kbd> / <kbd>Space</kbd></td><td>Activates the focused tab and reveals its controlled panel.</td></tr>
   </tbody>
 </table>
 
+<h2 id="behaviors">Behaviors</h2>
+
+- Clicking or activating a tab updates `aria-selected`, roving `tabindex`, and the controlled panel.
+- Disabled tabs are skipped by keyboard navigation.
+- Horizontal tab lists scroll when content exceeds available width by default.
+- Set `overflow="wrap"` to allow multiple rows.
+- Compact size reduces spacing and typography while preserving the same interaction model.
+- Activation dispatches a bubbling `uif-tab-change` event with the controlled panel ID.
+
 <h2 id="accessibility">Accessibility</h2>
 
-- Uses `role="tablist"`, `role="tab"`, and `role="tabpanel"` ARIA pattern.
-- `aria-selected` indicates the active tab.
-- `aria-controls` links each tab to its panel.
-- Only the selected tab has `tabindex="0"`; others have `tabindex="-1"` for roving focus.
-- `aria-orientation` communicates layout direction to assistive technology.
+- Uses `role="tablist"`, `role="tab"`, and `role="tabpanel"`.
+- `aria-selected` represents active state.
+- `aria-controls` connects each tab to its panel.
+- Roving focus keeps only the selected tab in the page tab sequence.
+- `aria-orientation` determines the supported arrow-key axis.
 
 <h2 id="design-checklist">Design checklist</h2>
 
 <div class="docs-checklist">
-  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>All brand/mode contexts</strong><span>Works across light and dark modes.</span></div></div>
-  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Keyboard interactions</strong><span>Full ARIA tablist pattern.</span></div></div>
-  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Design tokens</strong><span>Component-scoped tokens (<code>--uif-tabs-*</code>).</span></div></div>
+  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Keyboard behavior</strong><span>Arrow, Home, End, Enter, and Space are implemented.</span></div></div>
+  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Panel synchronization</strong><span>Selected tab and controlled panel stay aligned.</span></div></div>
+  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Responsive overflow</strong><span>Scrollable and wrapped tab-list modes are available.</span></div></div>
+  <div class="docs-checklist-item" data-done="true"><div class="docs-checklist-icon">✓</div><div class="docs-checklist-text"><strong>Sizes</strong><span>Default and compact sizes are supported.</span></div></div>
 </div>

--- a/src/elements/ui-tabs.js
+++ b/src/elements/ui-tabs.js
@@ -1,47 +1,126 @@
 import { UIElement, define } from "./base.js";
 
-/**
- * <uif-tab-list aria-label="Settings">
- *   <uif-tab label="General" selected controls="panel-1"></uif-tab>
- *   <uif-tab label="Advanced" controls="panel-2"></uif-tab>
- * </uif-tab-list>
- * <uif-tab-panel id="panel-1">General content</uif-tab-panel>
- * <uif-tab-panel id="panel-2" hidden>Advanced content</uif-tab-panel>
- */
+function enabledTabs(tabList) {
+  return [...tabList.querySelectorAll('[role="tab"]')].filter(
+    (tab) => !tab.disabled && tab.getAttribute("aria-disabled") !== "true",
+  );
+}
+
+function activateTab(tabList, tab, focus = true) {
+  const tabs = [...tabList.querySelectorAll('[role="tab"]')];
+  const root = tabList.closest("uif-tabs") || tabList.parentElement;
+
+  for (const candidate of tabs) {
+    const selected = candidate === tab;
+    candidate.setAttribute("aria-selected", String(selected));
+    candidate.tabIndex = selected ? 0 : -1;
+    candidate.classList.toggle("is-active", selected);
+  }
+
+  const controlledId = tab.getAttribute("aria-controls");
+  if (root) {
+    for (const panel of root.querySelectorAll('[role="tabpanel"]')) {
+      const selected = Boolean(controlledId) && panel.id === controlledId;
+      panel.hidden = !selected;
+    }
+  }
+
+  if (focus) tab.focus();
+  tab.dispatchEvent(new CustomEvent("uif-tab-change", {
+    bubbles: true,
+    detail: { controls: controlledId || null },
+  }));
+}
+
+function handleTabKeydown(event) {
+  const tab = event.target.closest('[role="tab"]');
+  const tabList = event.currentTarget;
+  if (!tab) return;
+
+  const tabs = enabledTabs(tabList);
+  const currentIndex = tabs.indexOf(tab);
+  if (currentIndex < 0) return;
+
+  const orientation = tabList.getAttribute("aria-orientation") || "horizontal";
+  const previousKeys = orientation === "vertical" ? ["ArrowUp"] : ["ArrowLeft"];
+  const nextKeys = orientation === "vertical" ? ["ArrowDown"] : ["ArrowRight"];
+  let target = null;
+
+  if (previousKeys.includes(event.key)) target = tabs[(currentIndex - 1 + tabs.length) % tabs.length];
+  if (nextKeys.includes(event.key)) target = tabs[(currentIndex + 1) % tabs.length];
+  if (event.key === "Home") target = tabs[0];
+  if (event.key === "End") target = tabs[tabs.length - 1];
+
+  if (target) {
+    event.preventDefault();
+    target.focus();
+    return;
+  }
+
+  if (event.key === "Enter" || event.key === " ") {
+    event.preventDefault();
+    activateTab(tabList, tab);
+  }
+}
+
+class UITabs extends UIElement {
+  static get observedAttributes() {
+    return ["orientation", "size", "overflow"];
+  }
+
+  render() {
+    const orientation = this.getAttr("orientation", "horizontal");
+    const size = this.getAttr("size", "default");
+    const overflow = this.getAttr("overflow", "scroll");
+    const tabList = this.querySelector("uif-tab-list, [role=tablist]");
+    if (!tabList) return;
+
+    tabList.setAttribute("aria-orientation", orientation);
+    tabList.dataset.size = size;
+    tabList.dataset.overflow = overflow;
+  }
+}
+
+define("uif-tabs", UITabs);
+export { UITabs };
 
 class UITabList extends UIElement {
   static get observedAttributes() {
-    return ["orientation", "aria-label"];
+    return ["orientation", "aria-label", "size", "overflow"];
   }
 
   render() {
     const orientation = this.getAttr("orientation", "horizontal");
     const ariaLabel = this.getAttr("aria-label");
+    const size = this.getAttr("size", "default");
+    const overflow = this.getAttr("overflow", "scroll");
     const children = this.innerHTML;
 
     const attrs = [
       'class="uif-tab-list"',
       'role="tablist"',
       `aria-orientation="${orientation}"`,
+      `data-size="${size}"`,
+      `data-overflow="${overflow}"`,
     ];
     if (ariaLabel) attrs.push(`aria-label="${ariaLabel}"`);
 
     this.innerHTML = `<div ${attrs.join(" ")}>${children}</div>`;
+    const tabList = this.querySelector('[role="tablist"]');
+    tabList.addEventListener("keydown", handleTabKeydown);
+    tabList.addEventListener("click", (event) => {
+      const tab = event.target.closest('[role="tab"]');
+      if (tab && !tab.disabled) activateTab(tabList, tab, false);
+    });
+
+    const selected = tabList.querySelector('[role="tab"][aria-selected="true"]') || enabledTabs(tabList)[0];
+    if (selected) activateTab(tabList, selected, false);
   }
 }
 
 define("uif-tab-list", UITabList);
 export { UITabList };
 
-/**
- * <uif-tab label="Tab 1" selected controls="panel-1"></uif-tab>
- *
- * Attributes:
- *   label    — tab button text
- *   selected — boolean
- *   disabled — boolean
- *   controls — ID of controlled panel
- */
 class UITab extends UIElement {
   static get observedAttributes() {
     return ["label", "selected", "disabled", "controls"];
@@ -61,7 +140,7 @@ class UITab extends UIElement {
       `tabindex="${selected ? "0" : "-1"}"`,
     ];
     if (controls) attrs.push(`aria-controls="${controls}"`);
-    if (disabled) attrs.push("disabled");
+    if (disabled) attrs.push("disabled", 'aria-disabled="true"');
 
     this.innerHTML = `<button ${attrs.join(" ")}>${label}</button>`;
   }
@@ -70,12 +149,6 @@ class UITab extends UIElement {
 define("uif-tab", UITab);
 export { UITab };
 
-/**
- * <uif-tab-panel id="panel-1">Content</uif-tab-panel>
- *
- * Attributes:
- *   hidden — boolean
- */
 class UITabPanel extends UIElement {
   static get observedAttributes() {
     return ["hidden"];
@@ -95,4 +168,4 @@ class UITabPanel extends UIElement {
 }
 
 define("uif-tab-panel", UITabPanel);
-export { UITabPanel };
+export { UITabPanel, activateTab, handleTabKeydown };

--- a/src/ui/patterns/tabs.css
+++ b/src/ui/patterns/tabs.css
@@ -7,11 +7,21 @@
   :is(.uif-tab-list, .tab-list) {
     display: flex;
     gap: 0;
+    max-inline-size: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: thin;
     border-block-end: var(--size-border-100) solid var(--uif-tabs-border-color-default);
+  }
+
+  :is(.uif-tab-list, .tab-list)[data-overflow="wrap"] {
+    flex-wrap: wrap;
+    overflow: visible;
   }
 
   :is(.uif-tab-list, .tab-list)[aria-orientation="vertical"] {
     flex-direction: column;
+    overflow: visible;
     border-block-end: none;
     border-inline-end: var(--size-border-100) solid var(--uif-tabs-border-color-default);
   }
@@ -20,6 +30,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    flex: 0 0 auto;
     padding-inline: var(--uif-tabs-padding-inline);
     padding-block: var(--uif-tabs-padding-block);
     font-family: var(--font-family-sans);
@@ -34,6 +45,13 @@
     white-space: nowrap;
     text-decoration: none;
     transition: border-color 0.15s ease, color 0.15s ease;
+  }
+
+  :is(.uif-tab-list, .tab-list)[data-size="compact"] :is(.uif-tab, .tab) {
+    padding-inline: var(--size-spacing-300);
+    padding-block: var(--size-spacing-150, var(--size-spacing-200));
+    font-size: var(--font-size-sm);
+    line-height: var(--line-height-sm);
   }
 
   :is(.uif-tab, .tab):hover,
@@ -65,23 +83,10 @@
     pointer-events: none;
   }
 
-  /* --- Panel container: CSS-only scroll-snap switching --- */
-
   :is(.uif-tab-panels, .tab-panels) {
-    display: flex;
-    overflow-x: hidden;
-    scroll-snap-type: x mandatory;
-    scroll-behavior: smooth;
+    display: block;
   }
 
-  :is(.uif-tab-panels, .tab-panels) > :is(.uif-tab-panel, .tab-panel) {
-    flex: 0 0 100%;
-    min-inline-size: 100%;
-    scroll-snap-align: start;
-    padding-block: var(--size-spacing-400);
-  }
-
-  /* Legacy: standalone panel with hidden attribute (JS-driven) */
   :is(.uif-tab-panel, .tab-panel) {
     padding-block: var(--size-spacing-400);
   }

--- a/tests/tabs-contract.test.mjs
+++ b/tests/tabs-contract.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const element = fs.readFileSync("src/elements/ui-tabs.js", "utf8");
+const css = fs.readFileSync("src/ui/patterns/tabs.css", "utf8");
+
+test("tabs implements keyboard, panel, overflow, and size contracts", () => {
+  for (const key of ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End", "Enter"]) {
+    assert.match(element, new RegExp(key));
+  }
+  assert.match(element, /aria-controls/);
+  assert.match(element, /panel\.hidden/);
+  assert.match(element, /uif-tab-change/);
+  assert.match(css, /data-overflow="wrap"/);
+  assert.match(css, /data-size="compact"/);
+  assert.doesNotMatch(css, /scroll-snap-type/);
+});


### PR DESCRIPTION
## Summary

- implement horizontal and vertical roving focus
- support Arrow, Home, End, Enter, and Space behavior
- synchronize selected tabs with controlled panels
- add scroll and wrap overflow modes
- add default and compact sizes
- remove the unrelated panel scroll-snap behavior
- dispatch a bubbling `uif-tab-change` event
- update documentation and add contract-level unit coverage
- add a Code Connect schema placeholder for the published Figma node ID

## Issue

Closes #36

## Boundaries

- no Table changes
- no routing/navigation-tab behavior
- Code Connect requires replacing `TABS-NODE-ID` after Figma publication

## Validation

- disabled tabs are skipped by keyboard navigation
- orientation controls the arrow-key axis
- activation updates `aria-selected`, `tabindex`, and panel visibility
- overflow and size contracts are covered by tests
- documented behavior now matches Runtime behavior
